### PR TITLE
Leverage relations in lowest order function for AtlasCloner

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
@@ -1,18 +1,10 @@
 package org.openstreetmap.atlas.geography.atlas.packed;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
-import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Atlas Cloner. Mostly useful to get a {@link MultiAtlas} and clone it into one single
@@ -22,9 +14,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PackedAtlasCloner
 {
-    private static final Logger logger = LoggerFactory.getLogger(PackedAtlasCloner.class);
-    private static final int MAXIMUM_RELATION_LOOPS = 500;
-
     private String shardName = null;
 
     public PackedAtlasCloner()
@@ -63,62 +52,10 @@ public class PackedAtlasCloner
                 line -> builder.addLine(line.getIdentifier(), line.asPolyLine(), line.getTags()));
         atlas.points().forEach(point -> builder.addPoint(point.getIdentifier(), point.getLocation(),
                 point.getTags()));
-        // Add all the relations that do not have members that are relations.
-        Set<Long> stagedRelationIdentifiers = new HashSet<>();
-        for (final Relation relation : atlas.relations())
-        {
-            boolean skip = false;
-            for (final RelationMember member : relation.members())
-            {
-                if (member.getEntity() instanceof Relation)
-                {
-                    stagedRelationIdentifiers.add(relation.getIdentifier());
-                    skip = true;
-                    break;
-                }
-            }
-            if (!skip)
-            {
-                addRelation(builder, relation);
-            }
-        }
-        // Add all the other relations
-        int iterations = 0;
-        while (++iterations < MAXIMUM_RELATION_LOOPS && !stagedRelationIdentifiers.isEmpty())
-        {
-            logger.trace("Copying relations level {} deep.", iterations);
-            final Set<Long> stagedRelationIdentifiersCopy = new HashSet<>();
-            for (final Long relationIdentifier : stagedRelationIdentifiers)
-            {
-                final Relation relation = atlas.relation(relationIdentifier);
-                boolean skip = false;
-                for (final RelationMember member : relation.members())
-                {
-                    final AtlasEntity entity = member.getEntity();
-                    if (entity instanceof Relation
-                            && builder.peek().relation(entity.getIdentifier()) == null)
-                    {
-                        skip = true;
-                        break;
-                    }
-                }
-                if (!skip)
-                {
-                    addRelation(builder, relation);
-                }
-                else
-                {
-                    stagedRelationIdentifiersCopy.add(relationIdentifier);
-                }
-            }
-            stagedRelationIdentifiers = stagedRelationIdentifiersCopy;
-        }
-        if (iterations >= MAXIMUM_RELATION_LOOPS)
-        {
-            throw new CoreException(
-                    "There might be a loop in relations! It took more than {} loops to copy the relation of {}.",
-                    MAXIMUM_RELATION_LOOPS, atlas.getName());
-        }
+        // It's crucial to add relations in lowest order to highest order, to avoid adding a
+        // relation which may contain an un-added sub-relation.
+        atlas.relationsLowerOrderFirst().forEach(relation -> addRelation(builder, relation));
+
         return (PackedAtlas) builder.get();
     }
 


### PR DESCRIPTION
Simple change to leverage common `Atlas` functionality to return `Relation`s in the lowest order to highest order. This replaces existing code that did the same thing.