### PR TITLE
Adding Earth-Centered-Earth-Fixed Converter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Altitude.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Altitude.java
@@ -1,0 +1,87 @@
+package org.openstreetmap.atlas.geography;
+
+import java.io.Serializable;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.tags.ElevationTag;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * This is the height or elevation (usually defined in meters) above the Earth ellipsoid. The Earth
+ * ellipsoid is a mathematical surface defined by a semi-major axis and a semi-minor axis. The most
+ * common values for these two parameters are defined by the World Geodetic Standard 1984 (WGS-84).
+ * The WGS-84 ellipsoid is intended to correspond to mean sea level. An {@link Altitude} of zero
+ * corresponds roughly to sea level, with positive values increasing away from the Earth’s center.
+ * Altitude values range from the center of the Earth (see {@link Distance#AVERAGE_EARTH_RADIUS}) to
+ * positive infinity. For more detail, see
+ * <a href= "http://danceswithcode.net/engineeringnotes/geodetic_to_ecef/geodetic_to_ecef.html">
+ * here</a>.
+ * <p>
+ * Please also note that this is NOT the same elevation (height above sea level) as referenced by
+ * the {@link ElevationTag} in OSM.
+ *
+ * @author mgostintsev
+ */
+public final class Altitude implements Serializable
+{
+    private static final long serialVersionUID = -9064525655677062110L;
+
+    public static final Altitude MEAN_SEA_LEVEL = Altitude.meters(0);
+
+    private final Distance distance;
+
+    // The altitude will be negative in the range between the center of the earth and sea level:
+    // [-AVERAGE_EARTH_RADIUS to 0). Even though the underlying altitude is negative, the
+    // representation will be positive to make use of the Distance functionality.
+    private boolean isNegative = false;
+
+    public static Altitude meters(final double meters)
+    {
+        return new Altitude(meters);
+    }
+
+    private Altitude(final double meters)
+    {
+        if (meters < 0)
+        {
+            if (-meters > Distance.AVERAGE_EARTH_RADIUS.asMeters())
+            {
+                throw new CoreException("Cannot have an altitude below the center of the Earth.");
+            }
+            this.isNegative = true;
+            this.distance = Distance.meters(-meters);
+        }
+        else
+        {
+            this.distance = Distance.meters(meters);
+        }
+    }
+
+    public double asMeters()
+    {
+        return this.isNegative ? -this.distance.asMeters() : this.distance.asMeters();
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (other instanceof Altitude)
+        {
+            final Altitude that = (Altitude) other;
+            return this.asMeters() == that.asMeters();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Double.hashCode(this.asMeters());
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.valueOf(this.asMeters());
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -9,6 +9,8 @@ import java.util.Random;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Snapper.SnappedLocation;
 import org.openstreetmap.atlas.geography.converters.WktLocationConverter;
+import org.openstreetmap.atlas.geography.coordinates.EarthCenteredEarthFixedCoordinate;
+import org.openstreetmap.atlas.geography.coordinates.GeodeticCoordinate;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonObject;
 import org.openstreetmap.atlas.utilities.collections.StringList;
@@ -531,6 +533,22 @@ public class Location implements Located, Iterable<Location>, Serializable
     public String toCompactString()
     {
         return this.getLatitude() + "," + this.getLongitude();
+    }
+
+    /**
+     * @return the {@link EarthCenteredEarthFixedCoordinate} for this {@link Location}.
+     */
+    public EarthCenteredEarthFixedCoordinate toEarthCenteredEarthFixedCoordinate()
+    {
+        return new EarthCenteredEarthFixedCoordinate(this);
+    }
+
+    /**
+     * @return the {@link GeodeticCoordinate} for this {@link Location}.
+     */
+    public GeodeticCoordinate toGeodeticCoordinate()
+    {
+        return new GeodeticCoordinate(this);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/constants/WorldGeodeticStandardConstants.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/constants/WorldGeodeticStandardConstants.java
@@ -1,0 +1,48 @@
+package org.openstreetmap.atlas.geography.constants;
+
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * World Geodetic Standard 1984 ellipsoid constants.
+ *
+ * @author mgostintsev
+ */
+public final class WorldGeodeticStandardConstants
+{
+    /**
+     * Equatorial radius, typically denoted as 'a' in standard convention.
+     */
+    public static final Distance SEMI_MAJOR_AXIS = Distance.meters(6378137.0);
+
+    /**
+     * {@link #SEMI_MAJOR_AXIS} squared, for convenience.
+     */
+    public static final double SEMI_MAJOR_AXIS_SQUARED = Math.pow(SEMI_MAJOR_AXIS.asMeters(), 2);
+
+    /**
+     * Flattening is the measure of compression of a sphere to form a spheroid. Typically denoted as
+     * 'f' in standard convention.
+     */
+    public static final double FLATTENING = 298.257223563;
+
+    /**
+     * {@link #FLATTENING} inverse, for convenience.
+     */
+    public static final double INVERSE_FLATTENING = 1 / FLATTENING;
+
+    /**
+     * The measure of how much a conic section deviates from being circular. Typically denoted as
+     * 'e' in standard convention. Eccentricity does not have units. Ex: the eccentricity of a
+     * circle is 0 and that of a line is infinite.
+     */
+    public static final double ECCENTRICITY = Math.sqrt(1 - Math.pow(1 - INVERSE_FLATTENING, 2));
+
+    /**
+     * {@link #ECCENTRICITY} squared, for convenience.
+     */
+    public static final double ECCENTRICITY_SQUARED = Math.pow(ECCENTRICITY, 2);
+
+    private WorldGeodeticStandardConstants()
+    {
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverter.java
@@ -1,0 +1,78 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import org.openstreetmap.atlas.geography.Altitude;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Longitude;
+import org.openstreetmap.atlas.geography.constants.WorldGeodeticStandardConstants;
+import org.openstreetmap.atlas.geography.coordinates.EarthCenteredEarthFixedCoordinate;
+import org.openstreetmap.atlas.geography.coordinates.GeodeticCoordinate;
+import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
+
+/**
+ * Conversion from a {@link GeodeticCoordinate} to an {@link EarthCenteredEarthFixedCoordinate}. For
+ * reference, images and formulas used are found
+ * <a href= "https://microem.ru/files/2012/08/GPS.G1-X-00006.pdf"> here</a>.
+ *
+ * @author mgostintsev
+ */
+public class GeodeticEarthCenteredEarthFixedConverter
+        implements TwoWayConverter<GeodeticCoordinate, EarthCenteredEarthFixedCoordinate>
+{
+    @Override
+    public GeodeticCoordinate backwardConvert(final EarthCenteredEarthFixedCoordinate coordinate)
+    {
+        final double semiMinor = Math.sqrt(WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS_SQUARED
+                * (1 - WorldGeodeticStandardConstants.ECCENTRICITY_SQUARED));
+        final double semiMinorSquared = Math.pow(semiMinor, 2);
+
+        final double secondEccentricity = Math
+                .sqrt((WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS_SQUARED - semiMinorSquared)
+                        / semiMinorSquared);
+        final double auxiliaryP = Math
+                .sqrt(Math.pow(coordinate.getX(), 2) + Math.pow(coordinate.getY(), 2));
+        final double theta = Math.atan2(
+                coordinate.getZ() * WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS.asMeters(),
+                auxiliaryP * semiMinor);
+
+        final double longitude = Math.atan2(coordinate.getY(), coordinate.getX());
+        final double latitude = Math.atan2(
+                coordinate.getZ() + Math.pow(secondEccentricity, 2) * semiMinor
+                        * Math.pow(Math.sin(theta), 3),
+                auxiliaryP - WorldGeodeticStandardConstants.ECCENTRICITY_SQUARED
+                        * WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS.asMeters()
+                        * Math.pow(Math.cos(theta), 3));
+
+        final double radiusOfCurviture = WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS.asMeters()
+                / Math.sqrt(1 - WorldGeodeticStandardConstants.ECCENTRICITY_SQUARED
+                        * Math.pow(Math.sin(latitude), 2));
+
+        final double altitude = auxiliaryP / Math.cos(latitude) - radiusOfCurviture;
+
+        return new GeodeticCoordinate(Latitude.radians(latitude), Longitude.radians(longitude),
+                Altitude.meters(altitude));
+    }
+
+    @Override
+    public EarthCenteredEarthFixedCoordinate convert(final GeodeticCoordinate coordinate)
+    {
+        final double radiusOfCurviture = WorldGeodeticStandardConstants.SEMI_MAJOR_AXIS.asMeters()
+                / Math.sqrt(1 - WorldGeodeticStandardConstants.ECCENTRICITY_SQUARED
+                        * Math.pow(Math.sin(coordinate.getLatitude().asPositiveRadians()), 2));
+
+        final double height = coordinate.getAltitude().asMeters();
+
+        final double xValue = (radiusOfCurviture + height)
+                * Math.cos(coordinate.getLatitude().asPositiveRadians())
+                * Math.cos(coordinate.getLongitude().asPositiveRadians());
+
+        final double yValue = (radiusOfCurviture + height)
+                * Math.cos(coordinate.getLatitude().asPositiveRadians())
+                * Math.sin(coordinate.getLongitude().asPositiveRadians());
+
+        final double zValue = ((1 - WorldGeodeticStandardConstants.ECCENTRICITY_SQUARED)
+                * radiusOfCurviture + height)
+                * Math.sin(coordinate.getLatitude().asPositiveRadians());
+
+        return new EarthCenteredEarthFixedCoordinate(xValue, yValue, zValue);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/coordinates/EarthCenteredEarthFixedCoordinate.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/coordinates/EarthCenteredEarthFixedCoordinate.java
@@ -1,0 +1,108 @@
+package org.openstreetmap.atlas.geography.coordinates;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.converters.GeodeticEarthCenteredEarthFixedConverter;
+
+/**
+ * Earth-Fixed, Earth-Centered (ECEF) coordinate system representation. This is a right-handed
+ * Cartesian coordinate system (think X, Y and Z) with the origin at the Earth's center. Note: Units
+ * are generally expressed in meters.
+ *
+ * @author mgostintsev
+ */
+public class EarthCenteredEarthFixedCoordinate implements Serializable
+{
+    private static final long serialVersionUID = -3091871010423428109L;
+
+    private static final GeodeticEarthCenteredEarthFixedConverter COORDINATE_CONVERTER = new GeodeticEarthCenteredEarthFixedConverter();
+
+    private final double xValue;
+    private final double yValue;
+    private final double zValue;
+
+    /**
+     * Constructs an {@link EarthCenteredEarthFixedCoordinate} at (0,0,0).
+     */
+    public EarthCenteredEarthFixedCoordinate()
+    {
+        this.xValue = 0;
+        this.yValue = 0;
+        this.zValue = 0;
+    }
+
+    /**
+     * Constructs an {@link EarthCenteredEarthFixedCoordinate} at given (x,y,z).
+     *
+     * @param xValue
+     *            x-value
+     * @param yValue
+     *            y-value
+     * @param zValue
+     *            z-value
+     */
+    public EarthCenteredEarthFixedCoordinate(final double xValue, final double yValue,
+            final double zValue)
+    {
+        this.xValue = xValue;
+        this.yValue = yValue;
+        this.zValue = zValue;
+    }
+
+    /**
+     * Constructs an {@link EarthCenteredEarthFixedCoordinate} at given {@link Location}.
+     *
+     * @param location
+     *            The {@link Location} of the coordinate
+     */
+    public EarthCenteredEarthFixedCoordinate(final Location location)
+    {
+        final EarthCenteredEarthFixedCoordinate coordinate = COORDINATE_CONVERTER
+                .apply(location.toGeodeticCoordinate());
+        this.xValue = coordinate.getX();
+        this.yValue = coordinate.getY();
+        this.zValue = coordinate.getZ();
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (other instanceof EarthCenteredEarthFixedCoordinate)
+        {
+            final EarthCenteredEarthFixedCoordinate that = (EarthCenteredEarthFixedCoordinate) other;
+            return this.getX() == that.getX() && this.getY() == that.getY()
+                    && this.getZ() == that.getZ();
+        }
+        return false;
+    }
+
+    public double getX()
+    {
+        return this.xValue;
+    }
+
+    public double getY()
+    {
+        return this.yValue;
+    }
+
+    public double getZ()
+    {
+        return this.zValue;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(this.getX()).append(this.getY()).append(this.getZ())
+                .hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")";
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/coordinates/GeodeticCoordinate.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/coordinates/GeodeticCoordinate.java
@@ -1,0 +1,98 @@
+package org.openstreetmap.atlas.geography.coordinates;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.openstreetmap.atlas.geography.Altitude;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Longitude;
+
+/**
+ * Geodetic coordinate system representation, consisting of a {@link Latitude}, {@link Longitude}
+ * and {@link Altitude} - commonly referred to as LLA. Note: Units are generally expressed in polar
+ * coordinates and meters (for {@link Altitude}}.
+ *
+ * @author mgostintsev
+ */
+public class GeodeticCoordinate implements Serializable
+{
+    private static final long serialVersionUID = 4614378421580938085L;
+
+    private final Latitude latitude;
+    private final Longitude longitude;
+    private final Altitude altitude;
+
+    /**
+     * Default constructor.
+     *
+     * @param latitude
+     *            latitude
+     * @param longitude
+     *            longitude
+     * @param altitude
+     *            altitude
+     */
+    public GeodeticCoordinate(final Latitude latitude, final Longitude longitude,
+            final Altitude altitude)
+    {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.altitude = altitude;
+    }
+
+    /**
+     * Creates a {@link GeodeticCoordinate} at the given {@link Location}, at mean sea level.
+     *
+     * @param location
+     *            The {@link Location} of the coordinate.
+     */
+    public GeodeticCoordinate(final Location location)
+    {
+        this.latitude = location.getLatitude();
+        this.longitude = location.getLongitude();
+        this.altitude = Altitude.MEAN_SEA_LEVEL;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (other instanceof GeodeticCoordinate)
+        {
+            final GeodeticCoordinate that = (GeodeticCoordinate) other;
+            return this.getLatitude().equals(that.getLatitude())
+                    && this.getLongitude().equals(that.getLongitude())
+                    && this.getAltitude().equals(that.getAltitude());
+        }
+        return false;
+    }
+
+    public Altitude getAltitude()
+    {
+        return this.altitude;
+    }
+
+    public Latitude getLatitude()
+    {
+        return this.latitude;
+    }
+
+    public Longitude getLongitude()
+    {
+        return this.longitude;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(this.getLatitude()).append(this.getLongitude())
+                .append(this.getAltitude()).hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(" + this.getLatitude() + ", " + this.getLongitude() + ", " + this.getAltitude()
+                + ")";
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/ElevationTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ElevationTag.java
@@ -1,0 +1,17 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM elevation tag. This tag is used to express height above sea level of a point in meters.
+ *
+ * @author mgostintsev
+ */
+@Tag(value = Validation.DOUBLE, taginfo = "https://taginfo.openstreetmap.org/keys/ele#values", osm = "http://wiki.openstreetmap.org/wiki/Key:ele")
+public interface ElevationTag
+{
+    @TagKey
+    String KEY = "ele";
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/AltitudeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/AltitudeTest.java
@@ -1,0 +1,31 @@
+package org.openstreetmap.atlas.geography;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * Tests {@link Altitude} functionality.
+ *
+ * @author mgostintsev
+ */
+public class AltitudeTest
+{
+    @Test
+    public void testAltitudeEquals()
+    {
+        final Altitude positiveAltitude = Altitude.meters(40);
+        final Altitude duplicatePositiveAltitude = Altitude.meters(40);
+        final Altitude negativeAltitude = Altitude.meters(-40);
+
+        Assert.assertNotEquals(positiveAltitude, negativeAltitude);
+        Assert.assertEquals(positiveAltitude, duplicatePositiveAltitude);
+    }
+
+    @Test(expected = CoreException.class)
+    public void testInvalidAltitude()
+    {
+        @SuppressWarnings("unused")
+        final Altitude impossible = Altitude.meters(-7371000);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverterTest.java
@@ -1,0 +1,72 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Altitude;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Longitude;
+import org.openstreetmap.atlas.geography.coordinates.EarthCenteredEarthFixedCoordinate;
+import org.openstreetmap.atlas.geography.coordinates.GeodeticCoordinate;
+
+/**
+ * {@link GeodeticEarthCenteredEarthFixedConverter} test.
+ *
+ * @author mgostintsev
+ */
+public class GeodeticEarthCenteredEarthFixedConverterTest
+{
+    private static final GeodeticEarthCenteredEarthFixedConverter CONVERTER = new GeodeticEarthCenteredEarthFixedConverter();
+
+    @Test
+    public void testConversionToEarthCenteredEarthFixed()
+    {
+        final EarthCenteredEarthFixedCoordinate earthCenteredCoordinates = new EarthCenteredEarthFixedCoordinate(
+                -576793.17, -5376363.47, 3372298.51);
+        final GeodeticCoordinate geodeticCoordinates = CONVERTER
+                .backwardConvert(earthCenteredCoordinates);
+
+        Assert.assertEquals(32.12345, geodeticCoordinates.getLatitude().asDegrees(), 1e-3);
+        Assert.assertEquals(-96.12345, geodeticCoordinates.getLongitude().asDegrees(), 1e-3);
+        Assert.assertEquals(500.0, geodeticCoordinates.getAltitude().asMeters(), 1e-2);
+    }
+
+    @Test
+    public void testConversionToGeodetic()
+    {
+        final GeodeticCoordinate geodeticCoordinates = new GeodeticCoordinate(
+                Latitude.degrees(32.12345), Longitude.degrees(-96.12345), Altitude.meters(500.0));
+        final EarthCenteredEarthFixedCoordinate earthCenteredCoordinates = CONVERTER
+                .convert(geodeticCoordinates);
+
+        Assert.assertEquals(-576793.17, earthCenteredCoordinates.getX(), 1e-2);
+        Assert.assertEquals(-5376363.47, earthCenteredCoordinates.getY(), 1e-2);
+        Assert.assertEquals(3372298.51, earthCenteredCoordinates.getZ(), 1e-2);
+    }
+
+    @Test
+    public void testFullConversionCycle()
+    {
+        final double latitude = -39.664914;
+        final double longitude = 176.881899;
+        final double altitude = 300.0;
+
+        final GeodeticCoordinate geodeticCoordinates = new GeodeticCoordinate(
+                Latitude.degrees(latitude), Longitude.degrees(longitude),
+                Altitude.meters(altitude));
+
+        final EarthCenteredEarthFixedCoordinate earthCenteredCoordinates = CONVERTER
+                .convert(geodeticCoordinates);
+
+        assertEquals(-4909490.91860, earthCenteredCoordinates.getX(), 1e-2);
+        assertEquals(267444.11617, earthCenteredCoordinates.getY(), 1e-2);
+        assertEquals(-4049606.55365, earthCenteredCoordinates.getZ(), 1e-2);
+
+        final GeodeticCoordinate backToGeodetic = CONVERTER
+                .backwardConvert(earthCenteredCoordinates);
+        assertEquals(latitude, backToGeodetic.getLatitude().asDegrees(), 1e-6);
+        assertEquals(longitude, backToGeodetic.getLongitude().asDegrees(), 1e-6);
+        assertEquals(altitude, backToGeodetic.getAltitude().asMeters(), 1e-6);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/coordinates/CoordinatesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/coordinates/CoordinatesTest.java
@@ -1,0 +1,47 @@
+package org.openstreetmap.atlas.geography.coordinates;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Altitude;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Longitude;
+
+/**
+ * Tests {@link EarthCenteredEarthFixedCoordinate} and {@link GeodeticCoordinate} functionality.
+ *
+ * @author mgostintsev
+ */
+public class CoordinatesTest
+{
+    @Test
+    public void testEarthCenteredEarthFixedCoordinateEquality()
+    {
+        final EarthCenteredEarthFixedCoordinate coordinate = new EarthCenteredEarthFixedCoordinate(
+                -576793.17, -5376363.47, 3372298.51);
+
+        final EarthCenteredEarthFixedCoordinate identicalCoordinate = new EarthCenteredEarthFixedCoordinate(
+                -576793.17, -5376363.47, 3372298.51);
+
+        final EarthCenteredEarthFixedCoordinate newCoordinate = new EarthCenteredEarthFixedCoordinate(
+                -576123.17, -5376992.47, 3372123.51);
+
+        Assert.assertEquals(coordinate, identicalCoordinate);
+        Assert.assertNotEquals(coordinate, newCoordinate);
+    }
+
+    @Test
+    public void testGeodeticCoordinateEquality()
+    {
+        final GeodeticCoordinate coordinate = new GeodeticCoordinate(Latitude.degrees(32.12345),
+                Longitude.degrees(-96.12345), Altitude.meters(500.0));
+
+        final GeodeticCoordinate identicalCoordinate = new GeodeticCoordinate(
+                Latitude.degrees(32.12345), Longitude.degrees(-96.12345), Altitude.meters(500.0));
+
+        final GeodeticCoordinate newCoordinate = new GeodeticCoordinate(Latitude.degrees(45.24252),
+                Longitude.degrees(-99.14141), Altitude.meters(700.0));
+
+        Assert.assertEquals(coordinate, identicalCoordinate);
+        Assert.assertNotEquals(coordinate, newCoordinate);
+    }
+}


### PR DESCRIPTION
Adding the definition of `Altitude`. `Altitude`, when paired with existing `Latitude` and `Longitude`, are used to define the `GeodeticCoordinate` and convert between it and the `EarthCenteredEarthFixedCoordinate` using the new `GeodeticEarthCenteredEarthFixedConverter`. I've also added corresponding tests to verify conversions and test coordinate equality. There's also a new, un-related, `ElevationTag`, which was discovered during traversal of the OSM wiki.