### PR TITLE
Adding boundary tag to nodes on ways that span boundaries

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveArea.java
@@ -33,4 +33,11 @@ public class AtlasPrimitiveArea extends AtlasPrimitiveEntity
     {
         return this.polygon;
     }
+
+    @Override
+    public String toString()
+    {
+        return "AtlasPrimitiveArea [polygon=" + this.polygon + ", getIdentifier()="
+                + getIdentifier() + ", getTags()=" + getTags() + "]";
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveLineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveLineItem.java
@@ -33,4 +33,11 @@ public class AtlasPrimitiveLineItem extends AtlasPrimitiveEntity
     {
         return this.polyLine;
     }
+
+    @Override
+    public String toString()
+    {
+        return "AtlasPrimitiveLineItem [polyLine=" + this.polyLine + ", getIdentifier()="
+                + getIdentifier() + ", getTags()=" + getTags() + "]";
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveLocationItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveLocationItem.java
@@ -41,4 +41,11 @@ public class AtlasPrimitiveLocationItem extends AtlasPrimitiveEntity
     {
         return this.location;
     }
+
+    @Override
+    public String toString()
+    {
+        return "AtlasPrimitiveLocationItem [location=" + this.location + ", getIdentifier()="
+                + getIdentifier() + ", getTags()=" + getTags() + "]";
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfProcessor.java
@@ -25,6 +25,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
+import org.openstreetmap.atlas.geography.atlas.pbf.converters.TagMapToTagCollectionConverter;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.CountrySlicingProcessor;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.WaySectionProcessor;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.PaddingIdentifierFactory;
@@ -39,7 +40,9 @@ import org.openstreetmap.atlas.tags.LastEditUserIdentifierTag;
 import org.openstreetmap.atlas.tags.LastEditUserNameTag;
 import org.openstreetmap.atlas.tags.LastEditVersionTag;
 import org.openstreetmap.atlas.tags.RouteTag;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.Bound;
 import org.openstreetmap.osmosis.core.domain.v0_6.Entity;
@@ -72,8 +75,8 @@ public class OsmPbfProcessor implements Sink
     private static final Logger logger = LoggerFactory.getLogger(OsmPbfProcessor.class);
 
     private static final JtsMultiPolygonToMultiPolygonConverter JTS_MULTI_POLYGON_TO_MULTI_POLYGON_CONVERTER = new JtsMultiPolygonToMultiPolygonConverter();
-
     private static final int MAXIMUM_NETWORK_EXTENSION = 100;
+    private static final TagMapToTagCollectionConverter TAG_MAP_TO_TAG_COLLECTION_CONVERTER = new TagMapToTagCollectionConverter();
 
     private final PackedAtlasBuilder builder;
     private final AtlasLoadingOption loadingOption;
@@ -86,6 +89,7 @@ public class OsmPbfProcessor implements Sink
     private boolean firstPass;
     private boolean secondPass;
     private final Set<Long> nodesOutsideOfCountry = new HashSet<>();
+    private final Set<Long> nodeIdentifiersAtNetworkBoundary = new HashSet<>();
 
     public OsmPbfProcessor(final PackedAtlasBuilder builder, final AtlasLoadingOption loadingOption,
             final MultiPolygon multiPolygon)
@@ -668,7 +672,8 @@ public class OsmPbfProcessor implements Sink
 
     /**
      * This function's job is to make sure that ways that are connected to the road network but
-     * outside of country boundaries (bridges, ferry routes, etc). The steps are the following:
+     * outside of country boundaries (bridges, ferry routes, etc) are still included. The steps are
+     * the following:
      * <p>
      * <ul>
      * <li>While loop: as long as there has been less than MAXIMUM_NETWORK_EXTENSION iterations, and
@@ -694,11 +699,39 @@ public class OsmPbfProcessor implements Sink
                 {
                     if (!this.store.containsWay(way.getId()))
                     {
+                        final List<WayNode> wayNodes = way.getWayNodes();
                         for (final WayNode wayNode : way.getWayNodes())
                         {
                             final long identifier = wayNode.getNodeId();
                             if (this.store.containsNodeAtEndOfEdges(identifier))
                             {
+                                final Long startNodeIdentifier = wayNodes.get(0).getNodeId();
+                                final Long endNodeIdentifier = wayNodes.get(wayNodes.size() - 1)
+                                        .getNodeId();
+                                if (startNodeIdentifier != identifier)
+                                {
+                                    // The start node is a new node outside of the network
+                                    this.nodeIdentifiersAtNetworkBoundary.add(startNodeIdentifier);
+                                }
+                                else
+                                {
+                                    // The start node has been used to connect a new way outside the
+                                    // network. It is not a boundary node anymore.
+                                    this.nodeIdentifiersAtNetworkBoundary
+                                            .remove(new Long(startNodeIdentifier));
+                                }
+                                if (endNodeIdentifier != identifier)
+                                {
+                                    // The end node is a new node outside of the network
+                                    this.nodeIdentifiersAtNetworkBoundary.add(endNodeIdentifier);
+                                }
+                                else
+                                {
+                                    // The end node has been used to connect a new way outside the
+                                    // network. It is not a boundary node anymore.
+                                    this.nodeIdentifiersAtNetworkBoundary
+                                            .remove(new Long(endNodeIdentifier));
+                                }
                                 this.store.addWay(way);
                                 logger.trace("Adding connected road with identifier {}",
                                         identifier);
@@ -772,6 +805,7 @@ public class OsmPbfProcessor implements Sink
             // Record outside location for later edge and line process
             if (this.nodesOutsideOfPolygon.contains(node.getId()))
             {
+                tagOutsideBoundaryNodes(node);
                 this.store.addNode(node);
             }
         }
@@ -868,4 +902,19 @@ public class OsmPbfProcessor implements Sink
         }
     }
 
+    private void tagOutsideBoundaryNodes(final Node node)
+    {
+        if (this.nodeIdentifiersAtNetworkBoundary.contains(node.getId()))
+        {
+            final Map<String, String> boundaryNodeTags = Maps.hashMap(SyntheticBoundaryNodeTag.KEY,
+                    SyntheticBoundaryNodeTag.EXISTING.name().toLowerCase());
+            final Collection<Tag> tags = new ArrayList<>();
+            tags.addAll(node.getTags());
+
+            // Still add the boundary node tags
+            tags.addAll(TAG_MAP_TO_TAG_COLLECTION_CONVERTER.convert(boundaryNodeTags));
+            node.getTags().clear();
+            node.getTags().addAll(tags);
+        }
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfProcessor.java
@@ -700,7 +700,7 @@ public class OsmPbfProcessor implements Sink
                     if (!this.store.containsWay(way.getId()))
                     {
                         final List<WayNode> wayNodes = way.getWayNodes();
-                        for (final WayNode wayNode : way.getWayNodes())
+                        for (final WayNode wayNode : wayNodes)
                         {
                             final long identifier = wayNode.getNodeId();
                             if (this.store.containsNodeAtEndOfEdges(identifier))

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/store/PbfMemoryStore.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/store/PbfMemoryStore.java
@@ -47,6 +47,7 @@ import org.openstreetmap.osmosis.core.domain.v0_6.Node;
 import org.openstreetmap.osmosis.core.domain.v0_6.OsmUser;
 import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
 import org.openstreetmap.osmosis.core.domain.v0_6.RelationMember;
+import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
 import org.openstreetmap.osmosis.core.domain.v0_6.Way;
 import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
 import org.openstreetmap.osmosis.core.task.v0_6.Sink;
@@ -502,9 +503,25 @@ public class PbfMemoryStore implements SinkRunnableSource
 
     public boolean isAtlasPoint(final Node node)
     {
-        // Each node will have a last edit time tag
-        return node.getTags().size() > AtlasTag.TAGS_FROM_OSM.size()
-                || containsNodeInRelations(node.getId());
+        if (containsNodeInRelations(node.getId()))
+        {
+            return true;
+        }
+        // Tags from OSM are the tags that all the nodes will have
+        if (node.getTags().size() > AtlasTag.TAGS_FROM_OSM.size())
+        {
+            int counter = 0;
+            for (final Tag tag : node.getTags())
+            {
+                // Tags from Atlas are the tags that only some nodes will have
+                if (AtlasTag.TAGS_FROM_ATLAS.contains(tag.getKey()))
+                {
+                    counter++;
+                }
+            }
+            return node.getTags().size() > AtlasTag.TAGS_FROM_OSM.size() + counter;
+        }
+        return false;
     }
 
     public boolean isOneNodeWay(final Way way)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/store/PbfMemoryStore.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/store/PbfMemoryStore.java
@@ -507,6 +507,11 @@ public class PbfMemoryStore implements SinkRunnableSource
         {
             return true;
         }
+        // All the OSM features will have tags that are added by the Atlas generation: last edit
+        // time, last user (from PBF) as well as some synthetic boundary tags for the nodes that are
+        // created at the provided boundary. Because an OSM Node becomes a Point only when it has
+        // tags, the logic here needs to make sure not to count the synthetic tags to make that
+        // decision.
         // Tags from OSM are the tags that all the nodes will have
         if (node.getTags().size() > AtlasTag.TAGS_FROM_OSM.size())
         {

--- a/src/main/java/org/openstreetmap/atlas/tags/AtlasTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/AtlasTag.java
@@ -17,7 +17,8 @@ public final class AtlasTag
                     LastEditUserNameTag.KEY, LastEditVersionTag.KEY, LastEditChangesetTag.KEY)));
 
     public static final Set<String> TAGS_FROM_ATLAS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(ISOCountryTag.KEY)));
+            .unmodifiableSet(new HashSet<>(Arrays.asList(ISOCountryTag.KEY,
+                    SyntheticBoundaryNodeTag.KEY, SyntheticNearestNeighborCountryCodeTag.KEY)));
 
     private AtlasTag()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
@@ -18,7 +18,9 @@ import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveLineI
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveLocationItem;
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveObjectStore;
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveRelation;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.tags.HighwayTag;
@@ -38,7 +40,8 @@ public class OsmPbfLoaderTest
 
     private MultiPolygon countryShape1;
     private MultiPolygon countryShape2;
-    private CountryBoundaryMap countryBoundaries;
+    private CountryBoundaryMap countryBoundariesAll;
+    private CountryBoundaryMap countryBoundaries1;
     private AtlasPrimitiveObjectStore store;
 
     @Before
@@ -50,15 +53,21 @@ public class OsmPbfLoaderTest
         this.countryShape2 = MultiPolygon.forPolygon(polygon2);
         final Map<String, MultiPolygon> boundaries = new HashMap<>();
         boundaries.put(COUNTRY_1_NAME, this.countryShape1);
+        this.countryBoundaries1 = new CountryBoundaryMap(boundaries);
         boundaries.put(COUNTRY_2_NAME, this.countryShape2);
-        this.countryBoundaries = new CountryBoundaryMap(boundaries);
+        this.countryBoundariesAll = new CountryBoundaryMap(boundaries);
         this.store = new AtlasPrimitiveObjectStore();
         this.store.addNode(
                 new AtlasPrimitiveLocationItem(1, Location.CROSSING_85_280, Maps.stringMap()));
+        this.store.addNode(
+                new AtlasPrimitiveLocationItem(17, Location.CROSSING_85_17, Maps.stringMap()));
         this.store.addNode(new AtlasPrimitiveLocationItem(2, Location.TEST_7, Maps.stringMap()));
         this.store.addEdge(new AtlasPrimitiveLineItem(3,
                 new PolyLine(Location.CROSSING_85_280, Location.forString("37.328076,-122.031869"),
                         Location.TEST_7),
+                Maps.stringMap(HighwayTag.KEY, HighwayTag.MOTORWAY.name().toLowerCase())));
+        this.store.addEdge(new AtlasPrimitiveLineItem(7,
+                new PolyLine(Location.CROSSING_85_280, Location.CROSSING_85_17),
                 Maps.stringMap(HighwayTag.KEY, HighwayTag.MOTORWAY.name().toLowerCase())));
         final PolyLine line4 = new Segment(Location.TEST_6, Location.TEST_7);
         this.store.addLine(new AtlasPrimitiveLineItem(4, line4, Maps.stringMap()));
@@ -78,7 +87,7 @@ public class OsmPbfLoaderTest
     {
         final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
         final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis, MultiPolygon.MAXIMUM,
-                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries)
+                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundariesAll)
                         .setAdditionalCountryCodes(COUNTRY_1_NAME));
         final Atlas atlas = osmPbfLoader.read();
         logger.info("{}", atlas);
@@ -86,7 +95,7 @@ public class OsmPbfLoaderTest
         Assert.assertEquals(1, atlas.numberOfRelations());
         final Relation relation = atlas.relations().iterator().next();
         Assert.assertEquals(1, relation.members().size());
-        Assert.assertEquals(1, atlas.numberOfEdges());
+        Assert.assertEquals(2, atlas.numberOfEdges());
     }
 
     @Test
@@ -98,5 +107,22 @@ public class OsmPbfLoaderTest
         final Atlas atlas = osmPbfLoader.read();
         logger.info("{}", atlas);
         Assert.assertEquals(3, atlas.numberOfLines());
+    }
+
+    @Test
+    public void testOutsideWayBoundaryNodes()
+    {
+        final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
+        final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
+                this.countryBoundaries1.countryBoundary(COUNTRY_1_NAME).iterator().next()
+                        .getBoundary(),
+                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
+                        .setAdditionalCountryCodes(COUNTRY_1_NAME));
+        final Atlas atlas = osmPbfLoader.read();
+        logger.info("{}", atlas);
+        final Edge edge = atlas.edgesIntersecting(Location.CROSSING_85_17.bounds()).iterator()
+                .next();
+        final Node node = edge.end();
+        System.out.println(node.getTags());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
@@ -24,6 +24,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,9 @@ public class OsmPbfLoaderTest
         this.store.addNode(
                 new AtlasPrimitiveLocationItem(17, Location.CROSSING_85_17, Maps.stringMap()));
         this.store.addNode(new AtlasPrimitiveLocationItem(2, Location.TEST_7, Maps.stringMap()));
+        this.store.addNode(new AtlasPrimitiveLocationItem(2,
+                new Segment(Location.TEST_6, Location.TEST_7).middle(),
+                Maps.stringMap("tag_key", "tag_value")));
         this.store.addEdge(new AtlasPrimitiveLineItem(3,
                 new PolyLine(Location.CROSSING_85_280, Location.forString("37.328076,-122.031869"),
                         Location.TEST_7),
@@ -123,6 +127,7 @@ public class OsmPbfLoaderTest
         final Edge edge = atlas.edgesIntersecting(Location.CROSSING_85_17.bounds()).iterator()
                 .next();
         final Node node = edge.end();
-        System.out.println(node.getTags());
+        Assert.assertNotNull(node.tag(SyntheticBoundaryNodeTag.KEY));
+        Assert.assertEquals(1, atlas.numberOfPoints());
     }
 }


### PR DESCRIPTION
When a way is not assigned any country code (it is not within a country boundary) but it is still connected to ways that are inside the boundary (long bridges, ferry routes for example), the end nodes of those ways were not assigned any `synthetic_boundary_node` tag. This PR adds the tag to those nodes.
It also refactors the function that decides when an OSM node becomes an Atlas `Point`. That allows to take the new tags into account, and to avoid building more `Point`s than necessary.