### PR TITLE
Handling Long.MIN_VALUE case for osm and country identifier calculation

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactory.java
@@ -13,15 +13,15 @@ public class ReverseIdentifierFactory
 
     public long getCountryOsmIdentifier(final long countryCodeAndWaySectionedIdentifier)
     {
-        return Math.abs(countryCodeAndWaySectionedIdentifier)
-                / AbstractIdentifierFactory.IDENTIFIER_SCALE;
+        return Math.abs(
+                countryCodeAndWaySectionedIdentifier / AbstractIdentifierFactory.IDENTIFIER_SCALE);
     }
 
     public long getOsmIdentifier(final long countryCodeAndWaySectionedIdentifier)
     {
-        return Math.abs(countryCodeAndWaySectionedIdentifier)
-                / (AbstractIdentifierFactory.IDENTIFIER_SCALE
-                        * AbstractIdentifierFactory.IDENTIFIER_SCALE);
+        return Math.abs(
+                countryCodeAndWaySectionedIdentifier / (AbstractIdentifierFactory.IDENTIFIER_SCALE
+                        * AbstractIdentifierFactory.IDENTIFIER_SCALE));
     }
 
     public long getStartIdentifier(final long countryOsmIdentifier)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactoryTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactoryTest.java
@@ -1,0 +1,31 @@
+package org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * {@link ReverseIdentifierFactory} test.
+ *
+ * @author mgostintsev
+ */
+public class ReverseIdentifierFactoryTest
+{
+    private static final ReverseIdentifierFactory IDENTIFIER_FACTORY = new ReverseIdentifierFactory();
+
+    @Test
+    public void testMinimumCountryOsmIdentifier()
+    {
+        final long atlasIdentifier = Long.MIN_VALUE;
+        final long countryOsmIdentifier = IDENTIFIER_FACTORY
+                .getCountryOsmIdentifier(atlasIdentifier);
+        Assert.assertTrue(countryOsmIdentifier > 0);
+    }
+
+    @Test
+    public void testMinimumOsmIdentifier()
+    {
+        final long atlasIdentifier = Long.MIN_VALUE;
+        final long osmIdentifier = IDENTIFIER_FACTORY.getOsmIdentifier(atlasIdentifier);
+        Assert.assertTrue(osmIdentifier > 0);
+    }
+}


### PR DESCRIPTION
Per Math.abs() [documentation](https://docs.oracle.com/javase/7/docs/api/java/lang/Math.html): "Note that if the argument is equal to the value of Long.MIN_VALUE, the most negative representable long value, the result is that same value, which is negative." We want to handle this case gracefully, so performing the computation first and then taking the absolute value. Adding tests for this functionality.