### PR TITLE
Fix DynamicTileSharding NPE for partial of the world sharding tree and fix NPE when data is large

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -410,7 +410,7 @@ public class DynamicTileSharding extends Command implements Sharding
         }
         this.root.build(tile ->
         {
-            int count = 0;
+            long count = 0;
             for (final SlippyTile miniTile : tile.split(finalZoom))
             {
                 count += counts.get(miniTile);

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -413,7 +413,7 @@ public class DynamicTileSharding extends Command implements Sharding
             long count = 0;
             for (final SlippyTile miniTile : tile.split(finalZoom))
             {
-                count += counts.get(miniTile);
+                count += counts.getOrDefault(miniTile, 0);
             }
             if (count <= MINIMUM_TO_SPLIT)
             {


### PR DESCRIPTION
Two commits:
1, Fix NPE when processing partial of the world tiles
2, Change to long to avoid integer overflow