### PR TITLE
Fix DynamicTileSharding NPE for partial of the world sharding tree and fix NPE when data is large 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -410,7 +410,7 @@ public class DynamicTileSharding extends Command implements Sharding
         }
         this.root.build(tile ->
         {
-            int count = 0;
+            long count = 0;
             for (final SlippyTile miniTile : tile.split(finalZoom))
             {
                 count += counts.getOrDefault(miniTile, 0);

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -413,7 +413,7 @@ public class DynamicTileSharding extends Command implements Sharding
             int count = 0;
             for (final SlippyTile miniTile : tile.split(finalZoom))
             {
-                count += counts.get(miniTile);
+                count += counts.getOrDefault(miniTile, 0);
             }
             if (count <= MINIMUM_TO_SPLIT)
             {


### PR DESCRIPTION
Two changes to fix NPE:
1, When there are no input data for some tiles, the sharding tree is able to build assuming there is no data in that tile.
2, When the input data it too large, use long instead of int to hold counts.