### PR TITLE
DynamicAtlas expansion according to a predicate

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -751,6 +751,7 @@ public class DynamicAtlas extends BareAtlas
     {
         final RelationMemberList knownMembers = relation.members();
         boolean result = true;
+        boolean loop = false;
         for (final RelationMember member : knownMembers)
         {
             final AtlasEntity entity = member.getEntity();
@@ -783,6 +784,7 @@ public class DynamicAtlas extends BareAtlas
                     logger.error(
                             "Skipping! Unable to expand on relation which has a loop: {}. Parent tree: {}",
                             relation, parentRelationIdentifierTree);
+                    loop = true;
                     result = true;
                 }
                 else
@@ -801,6 +803,47 @@ public class DynamicAtlas extends BareAtlas
             {
                 throw new CoreException("Unknown Relation Member Type: {}",
                         entity.getClass().getName());
+            }
+        }
+        if (this.policy.isAgressivelyExploreRelations() && !loop)
+        {
+            // Get all the neighboring shards
+            final Set<Shard> onlyNeighboringShards = new HashSet<>();
+            this.loadedShards.keySet().forEach(
+                    shard -> this.sharding.neighbors(shard).forEach(onlyNeighboringShards::add));
+            onlyNeighboringShards.removeAll(this.loadedShards.keySet());
+            // For each of those shards, load the Atlas individually and find the relation and its
+            // members if it is there too.
+            final Set<Shard> neighboringShardsContainingRelation = new HashSet<>();
+            onlyNeighboringShards
+                    .forEach(shard -> this.policy.getAtlasFetcher().apply(shard).ifPresent(atlas ->
+                    {
+                        final Relation newRelation = atlas.relation(relation.getIdentifier());
+                        if (newRelation != null)
+                        {
+                            final RelationMemberList newMembers = newRelation.members();
+                            for (final RelationMember newMember : newMembers)
+                            {
+                                if (!knownMembers.contains(newMember))
+                                {
+                                    neighboringShardsContainingRelation.add(shard);
+                                    if (logger.isDebugEnabled())
+                                    {
+                                        logger.debug("{}: Triggering new shard load for {}{}",
+                                                this.getName(),
+                                                "Atlas " + relation.getType() + " containing ",
+                                                newMember);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }));
+            // Add the neighboring shards as new shards to be loaded.
+            if (!neighboringShardsContainingRelation.isEmpty())
+            {
+                result = false;
+                addNewShards(neighboringShardsContainingRelation);
             }
         }
         return result;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -539,7 +539,9 @@ public class DynamicAtlas extends BareAtlas
     private <V extends AtlasEntity> boolean entitiesCovered(final Iterable<V> entities,
             final Predicate<V> entityCoveredPredicate)
     {
-        return Iterables.stream(entities).allMatch(entityCoveredPredicate);
+        return Iterables.stream(entities)
+                .filter(entity -> this.policy.getAtlasEntitiesToConsiderForExpansion().test(entity))
+                .allMatch(entityCoveredPredicate);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -805,7 +805,7 @@ public class DynamicAtlas extends BareAtlas
                         entity.getClass().getName());
             }
         }
-        if (this.policy.isAgressivelyExploreRelations() && !loop)
+        if (this.policy.isAggressivelyExploreRelations() && !loop)
         {
             // Get all the neighboring shards
             final Set<Shard> onlyNeighboringShards = new HashSet<>();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -11,6 +11,7 @@ import java.util.function.Predicate;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.dynamic.DynamicAtlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
@@ -35,6 +36,7 @@ public class DynamicAtlasPolicy
     {
     };
     private Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion = entity -> true;
+    private boolean agressivelyExploreRelations = false;
 
     public DynamicAtlasPolicy(final Function<Shard, Optional<Atlas>> atlasFetcher,
             final Sharding sharding, final MultiPolygon shapeCoveringInitialShards,
@@ -77,6 +79,11 @@ public class DynamicAtlasPolicy
         this.sharding = sharding;
     }
 
+    public Predicate<AtlasEntity> getAtlasEntitiesToConsiderForExpansion()
+    {
+        return this.atlasEntitiesToConsiderForExpansion;
+    }
+
     public Function<Shard, Optional<Atlas>> getAtlasFetcher()
     {
         // Here, make sure to not load outside the bounds.
@@ -96,11 +103,6 @@ public class DynamicAtlasPolicy
             }
             return Optional.empty();
         };
-    }
-
-    public Predicate<AtlasEntity> getAtlasEntitiesToConsiderForExpansion()
-    {
-        return this.atlasEntitiesToConsiderForExpansion;
     }
 
     public Set<Shard> getInitialShards()
@@ -130,6 +132,11 @@ public class DynamicAtlasPolicy
         return this.shardSetChecker;
     }
 
+    public boolean isAgressivelyExploreRelations()
+    {
+        return this.agressivelyExploreRelations;
+    }
+
     public boolean isDeferLoading()
     {
         return this.deferLoading;
@@ -140,6 +147,29 @@ public class DynamicAtlasPolicy
         return this.extendIndefinitely;
     }
 
+    /**
+     * This switch tells the {@link DynamicAtlas} to preemptively and temporarily load the
+     * neighboring shards to see if they contain the relation in the current shard and if the member
+     * list is different. In which case it expands to the neighboring shards that are including
+     * those members.
+     *
+     * @param agressivelyExploreRelations
+     *            True to agressively explore relations
+     * @return The modified policy
+     */
+    public DynamicAtlasPolicy withAgressivelyExploreRelations(
+            final boolean agressivelyExploreRelations)
+    {
+        this.agressivelyExploreRelations = agressivelyExploreRelations;
+        return this;
+    }
+
+    /**
+     * @param atlasEntitiesToConsiderForExpansion
+     *            A predicate that defines what entities will be considered when deciding to expand
+     *            or not to a neighboring shard.
+     * @return The modified policy
+     */
     public DynamicAtlasPolicy withAtlasEntitiesToConsiderForExpansion(
             final Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -36,7 +36,7 @@ public class DynamicAtlasPolicy
     {
     };
     private Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion = entity -> true;
-    private boolean agressivelyExploreRelations = false;
+    private boolean aggressivelyExploreRelations = false;
 
     public DynamicAtlasPolicy(final Function<Shard, Optional<Atlas>> atlasFetcher,
             final Sharding sharding, final MultiPolygon shapeCoveringInitialShards,
@@ -132,9 +132,9 @@ public class DynamicAtlasPolicy
         return this.shardSetChecker;
     }
 
-    public boolean isAgressivelyExploreRelations()
+    public boolean isAggressivelyExploreRelations()
     {
-        return this.agressivelyExploreRelations;
+        return this.aggressivelyExploreRelations;
     }
 
     public boolean isDeferLoading()
@@ -153,14 +153,14 @@ public class DynamicAtlasPolicy
      * list is different. In which case it expands to the neighboring shards that are including
      * those members.
      *
-     * @param agressivelyExploreRelations
-     *            True to agressively explore relations
+     * @param aggressivelyExploreRelations
+     *            True to aggressively explore relations
      * @return The modified policy
      */
-    public DynamicAtlasPolicy withAgressivelyExploreRelations(
-            final boolean agressivelyExploreRelations)
+    public DynamicAtlasPolicy withAggressivelyExploreRelations(
+            final boolean aggressivelyExploreRelations)
     {
-        this.agressivelyExploreRelations = agressivelyExploreRelations;
+        this.aggressivelyExploreRelations = aggressivelyExploreRelations;
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -197,7 +197,7 @@ public class DynamicAtlasPolicy
      * boundaries.
      *
      * @param extendIndefinitely
-     *            True to extend indefinitely
+     *            True to extend indefinitely.
      * @return The modified policy
      */
     public DynamicAtlasPolicy withExtendIndefinitely(final boolean extendIndefinitely)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -6,10 +6,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.utilities.maps.MultiMap;
@@ -32,6 +34,7 @@ public class DynamicAtlasPolicy
     private Consumer<Set<Shard>> shardSetChecker = set ->
     {
     };
+    private Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion = entity -> true;
 
     public DynamicAtlasPolicy(final Function<Shard, Optional<Atlas>> atlasFetcher,
             final Sharding sharding, final MultiPolygon shapeCoveringInitialShards,
@@ -95,6 +98,11 @@ public class DynamicAtlasPolicy
         };
     }
 
+    public Predicate<AtlasEntity> getAtlasEntitiesToConsiderForExpansion()
+    {
+        return this.atlasEntitiesToConsiderForExpansion;
+    }
+
     public Set<Shard> getInitialShards()
     {
         return this.initialShards;
@@ -130,6 +138,13 @@ public class DynamicAtlasPolicy
     public boolean isExtendIndefinitely()
     {
         return this.extendIndefinitely;
+    }
+
+    public DynamicAtlasPolicy withAtlasEntitiesToConsiderForExpansion(
+            final Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion)
+    {
+        this.atlasEntitiesToConsiderForExpansion = atlasEntitiesToConsiderForExpansion;
+        return this;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.sharding;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -338,6 +339,30 @@ public class SlippyTile implements Shard
     {
         return "[SlippyTile: zoom = " + this.zoom + ", x = " + this.xAxis + ", y = " + this.yAxis
                 + "]";
+    }
+
+    /**
+     * Add the siblings and parent.
+     *
+     * @param candidates
+     *            The candidate tiles
+     * @param visitedTiles
+     *            The tiles already visited
+     * @param targetTile
+     *            The target tile
+     */
+    protected void getNeighborsForAllZoomLevels(final Queue<SlippyTile> candidates,
+            final Set<String> visitedTiles, final SlippyTile targetTile)
+    {
+        final SlippyTile parent = targetTile.parent();
+        for (final SlippyTile child : parent.split())
+        {
+            if (!visitedTiles.contains(child.getName()) && !child.equals(targetTile))
+            {
+                candidates.add(child);
+            }
+        }
+        candidates.add(parent);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAgressiveRelationsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAgressiveRelationsTest.java
@@ -1,0 +1,69 @@
+package org.openstreetmap.atlas.geography.atlas.dynamic;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
+
+/**
+ * @author matthieun
+ */
+public class DynamicAtlasAgressiveRelationsTest
+{
+    @Rule
+    public DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
+
+    private Map<Shard, Atlas> store;
+    private final Supplier<DynamicAtlasPolicy> policySupplier = () -> new DynamicAtlasPolicy(
+            shard ->
+            {
+                if (this.store.containsKey(shard))
+                {
+                    return Optional.of(this.store.get(shard));
+                }
+                else
+                {
+                    return Optional.empty();
+                }
+            }, new SlippyTileSharding(12), new SlippyTile(1350, 1870, 12), Rectangle.MAXIMUM);
+
+    @Before
+    public void prepare()
+    {
+        this.store = new HashMap<>();
+        this.store.put(new SlippyTile(1350, 1870, 12), this.rule.getAtlasz12x1350y1870());
+        this.store.put(new SlippyTile(1350, 1869, 12), this.rule.getAtlasz12x1350y1869());
+        this.store.put(new SlippyTile(1349, 1869, 12), this.rule.getAtlasz12x1349y1869());
+        this.store.put(new SlippyTile(1349, 1870, 12), this.rule.getAtlasz12x1349y1870());
+    }
+
+    @Test
+    public void testRelationsAgressively()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(
+                this.policySupplier.get().withAgressivelyExploreRelations(true));
+
+        // Prompts load of 12-1350-1869
+        Assert.assertNotNull(dynamicAtlas.relation(1));
+        Assert.assertEquals(6, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1349-1870
+        Assert.assertNotNull(dynamicAtlas.relation(2));
+        Assert.assertEquals(8, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1349-1869
+        Assert.assertNotNull(dynamicAtlas.relation(3));
+        Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAgressiveRelationsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAgressiveRelationsTest.java
@@ -49,10 +49,10 @@ public class DynamicAtlasAgressiveRelationsTest
     }
 
     @Test
-    public void testRelationsAgressively()
+    public void testRelationsAggressively()
     {
         final DynamicAtlas dynamicAtlas = new DynamicAtlas(
-                this.policySupplier.get().withAgressivelyExploreRelations(true));
+                this.policySupplier.get().withAggressivelyExploreRelations(true));
 
         // Prompts load of 12-1350-1869
         Assert.assertNotNull(dynamicAtlas.relation(1));

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
@@ -75,7 +75,7 @@ public class DynamicAtlasFilteredEntitiesTest
         final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
                 .withAtlasEntitiesToConsiderForExpansion(
                         entity -> "relation".equals(entity.getTag("type").orElse("")))
-                .withAgressivelyExploreRelations(true));
+                .withAggressivelyExploreRelations(true));
         runLoadNoEdgesTest(dynamicAtlas);
     }
 
@@ -84,7 +84,7 @@ public class DynamicAtlasFilteredEntitiesTest
     {
         final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
                 .withAtlasEntitiesToConsiderForExpansion(entity -> entity instanceof Relation)
-                .withAgressivelyExploreRelations(true));
+                .withAggressivelyExploreRelations(true));
         runLoadNoEdgesTest(dynamicAtlas);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
@@ -1,0 +1,113 @@
+package org.openstreetmap.atlas.geography.atlas.dynamic;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+
+/**
+ * @author matthieun
+ */
+public class DynamicAtlasFilteredEntitiesTest
+{
+    @Rule
+    public DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
+
+    private Map<Shard, Atlas> store;
+    private final Supplier<DynamicAtlasPolicy> policySupplier = () -> new DynamicAtlasPolicy(
+            shard ->
+            {
+                if (this.store.containsKey(shard))
+                {
+                    return Optional.of(this.store.get(shard));
+                }
+                else
+                {
+                    return Optional.empty();
+                }
+            }, new SlippyTileSharding(12), new SlippyTile(1350, 1870, 12), Rectangle.MAXIMUM);
+
+    @Before
+    public void prepare()
+    {
+        this.store = new HashMap<>();
+        this.store.put(new SlippyTile(1350, 1870, 12), this.rule.getAtlasz12x1350y1870());
+        this.store.put(new SlippyTile(1350, 1869, 12), this.rule.getAtlasz12x1350y1869());
+        this.store.put(new SlippyTile(1349, 1869, 12), this.rule.getAtlasz12x1349y1869());
+        this.store.put(new SlippyTile(1349, 1870, 12), this.rule.getAtlasz12x1349y1870());
+    }
+
+    @Test
+    public void testLoadEdgesOnlyByTag()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
+                .withAtlasEntitiesToConsiderForExpansion(entity -> Validators.isOfType(entity,
+                        HighwayTag.class, HighwayTag.SECONDARY)));
+        runLoadEdgesOnlyTest(dynamicAtlas);
+    }
+
+    @Test
+    public void testLoadEdgesOnlyByType()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
+                .withAtlasEntitiesToConsiderForExpansion(entity -> entity instanceof Edge));
+        runLoadEdgesOnlyTest(dynamicAtlas);
+    }
+
+    private void runLoadEdgesOnlyTest(final DynamicAtlas dynamicAtlas)
+    {
+        // Already loaded: 12-1350-1870
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        // Test an area that does not exist
+        Assert.assertNull(dynamicAtlas.area(5));
+        Assert.assertNotNull(dynamicAtlas.area(1));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        // Usually prompts load of 12-1350-1869, but not here
+        Assert.assertNotNull(dynamicAtlas.area(2));
+        // Still 4
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Now onto edges, the behavior should be the same as without the predicate
+        // Already loaded: 12-1350-1870
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNull(dynamicAtlas.edge(6000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(1000000));
+        Assert.assertTrue(dynamicAtlas.edge(1000000).hasReverseEdge());
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1350-1869
+        Assert.assertNotNull(dynamicAtlas.edge(2000000));
+        Assert.assertEquals(6, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(3000000));
+        Assert.assertEquals(6, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1349-1869
+        Assert.assertNotNull(dynamicAtlas.edge(4000000));
+        Assert.assertEquals(8, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(5000000));
+        Assert.assertEquals(8, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1349-1870
+        Assert.assertNotNull(dynamicAtlas.edge(6000000));
+        Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(7000000));
+        Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(8000000));
+        Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasFilteredEntitiesTest.java
@@ -13,6 +13,7 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -68,6 +69,25 @@ public class DynamicAtlasFilteredEntitiesTest
         runLoadEdgesOnlyTest(dynamicAtlas);
     }
 
+    @Test
+    public void testLoadNoEdgesByTag()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
+                .withAtlasEntitiesToConsiderForExpansion(
+                        entity -> "relation".equals(entity.getTag("type").orElse("")))
+                .withAgressivelyExploreRelations(true));
+        runLoadNoEdgesTest(dynamicAtlas);
+    }
+
+    @Test
+    public void testLoadNoEdgesByType()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier.get()
+                .withAtlasEntitiesToConsiderForExpansion(entity -> entity instanceof Relation)
+                .withAgressivelyExploreRelations(true));
+        runLoadNoEdgesTest(dynamicAtlas);
+    }
+
     private void runLoadEdgesOnlyTest(final DynamicAtlas dynamicAtlas)
     {
         // Already loaded: 12-1350-1870
@@ -109,5 +129,52 @@ public class DynamicAtlasFilteredEntitiesTest
         Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
         Assert.assertNotNull(dynamicAtlas.edge(8000000));
         Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+    }
+
+    private void runLoadNoEdgesTest(final DynamicAtlas dynamicAtlas)
+    {
+        // Already loaded: 12-1350-1870
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        // Test an area that does not exist
+        Assert.assertNull(dynamicAtlas.area(5));
+        Assert.assertNotNull(dynamicAtlas.area(1));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        // Usually prompts load of 12-1350-1869, but not here
+        Assert.assertNotNull(dynamicAtlas.area(2));
+        // Still 4
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Already loaded: 12-1350-1870
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNull(dynamicAtlas.edge(6000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNotNull(dynamicAtlas.edge(1000000));
+        Assert.assertTrue(dynamicAtlas.edge(1000000).hasReverseEdge());
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Does NOT Prompt load of 12-1350-1869
+        Assert.assertNotNull(dynamicAtlas.edge(2000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNull(dynamicAtlas.edge(3000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Does NOT Prompt load of 12-1349-1869
+        Assert.assertNull(dynamicAtlas.edge(4000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNull(dynamicAtlas.edge(5000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Does NOT Prompt load of 12-1349-1870
+        Assert.assertNull(dynamicAtlas.edge(6000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        Assert.assertNull(dynamicAtlas.edge(7000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+        // Was already there from the initial shard
+        Assert.assertNotNull(dynamicAtlas.edge(8000000));
+        Assert.assertEquals(4, dynamicAtlas.numberOfEdges());
+
+        // Prompts load of 12-1350-1869
+        Assert.assertNotNull(dynamicAtlas.relation(1));
+        Assert.assertEquals(6, dynamicAtlas.numberOfEdges());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/SlippyTileTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/SlippyTileTest.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.geography.sharding;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -59,16 +58,7 @@ public class SlippyTileTest extends Command
     @Test
     public void testNeighbors()
     {
-        final Iterator<SlippyTile> iterator = SlippyTile.allTiles(2, Rectangle.TEST_RECTANGLE_2)
-                .iterator();
-        while (iterator.hasNext())
-        {
-            final SlippyTile next = iterator.next();
-            Assert.assertEquals(5, next.neighbors().size());
-        }
-
-        final SlippyTile tile = new SlippyTile(659, 1588, 12);
-        Assert.assertEquals(12, tile.neighbors().size());
+        Assert.assertEquals(8, new SlippyTile(659, 1588, 12).neighbors().size());
     }
 
     @Test


### PR DESCRIPTION
This change allows for expanding of a `DynamicAtlas` to be triggered only by the loading of some `AtlasEntity`(ies) that follow a specific `Predicate`. That brings in more flexibility to `DynamicAtlas` if a user is interested only in expanding along one feature type for example.

I added 2 new tests for the new behavior, using the same `DynamicAtlasTestRule `.

Also included: now `DynamicAtlas` can expand on `Relation`s "aggressively". Because Relations might have incomplete member lists in any given shard, this option looks at all the neighboring shards to find if any of those shards contain the same relation and new members. In that case, it does add the new shard to the expansion list.