### PR TITLE
OSM turn[:lanes[:forward|:backward]] tags

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/README.md
+++ b/src/main/java/org/openstreetmap/atlas/tags/README.md
@@ -4,7 +4,7 @@ This package helps with OSM tag parsing and validation.
 
 ## Enum or Interface
 
-Each recognized tag has a java instance named after itself. When the tag values are set in the OSM wiki, and well defined, we use enums (for example, [HighwayTag](HighwayTag.java)). When the values are more loosely defined, like using ranges, we use interfaces and validation annotations (for example, [LaneTag](LaneTag.java)).
+Each recognized tag has a java instance named after itself. When the tag values are set in the OSM wiki, and well defined, we use enums (for example, [HighwayTag](HighwayTag.java)). When the values are more loosely defined, like using ranges, we use interfaces and validation annotations (for example, [LanesTag](LanesTag.java)).
 
 ## Annotations and Validation
 

--- a/src/main/java/org/openstreetmap/atlas/tags/TurnLanesBackwardTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TurnLanesBackwardTag.java
@@ -1,0 +1,70 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM turn:lanes:backward tag indicating the lane types for a two-way
+ *
+ * @author brian_l_davis
+ */
+@Tag(value = Validation.NON_EMPTY_STRING, taginfo = "http://taginfo.openstreetmap.org/keys/turn%3Alanes%3Abackward#values", osm = "https://wiki.openstreetmap.org/wiki/Key:turn")
+public interface TurnLanesBackwardTag extends TurnLanesTag
+{
+    @TagKey
+    String KEY = "turn:lanes:backward";
+
+    /**
+     * The list of turn types specified in the turn:lanes:backward tag
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return The list of turn types when tagged
+     */
+    static Optional<List<Set<TurnType>>> getBackwardTurnLanes(final Taggable taggable)
+    {
+        return taggable.getTag(KEY)
+                .map(tagValue -> Arrays.stream(tagValue.split(TURN_LANE_DELIMITER))
+                        .map(lane -> Arrays.stream(lane.split(TURN_TYPE_DELIMITER))
+                                .map(TurnType::safeValueOf).filter(Objects::nonNull)
+                                .collect(Collectors.toSet()))
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has the {@link TurnType} in the {@code turn:lanes:backward}
+     * tags.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @param turnType
+     *            A turn type to test for
+     * @return {@code true} if tagged with the turn type, otherwise {@code false}
+     */
+    static boolean hasBackwardTurnLane(final Taggable taggable, final TurnType turnType)
+    {
+        return getBackwardTurnLanes(taggable)
+                .map(lanes -> lanes.stream().anyMatch(turnLane -> turnLane.contains(turnType)))
+                .orElse(false);
+    }
+
+    /**
+     * Checks if the {@link Taggable} has a {@code turn:lanes:backward} tag value.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return {@code true} if tagged, otherwise {@code false}
+     */
+    static boolean hasBackwardTurnLane(final Taggable taggable)
+    {
+        return taggable.getTag(KEY).isPresent();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/TurnLanesForwardTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TurnLanesForwardTag.java
@@ -1,0 +1,70 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM turn:lanes:forward tag indicating the lane types for a two-way
+ *
+ * @author brian_l_davis
+ */
+@Tag(value = Validation.NON_EMPTY_STRING, taginfo = "http://taginfo.openstreetmap.org/keys/turn%3Alanes%3Aforward#values", osm = "https://wiki.openstreetmap.org/wiki/Key:turn")
+public interface TurnLanesForwardTag extends TurnLanesTag
+{
+    @TagKey
+    String KEY = "turn:lanes:forward";
+
+    /**
+     * The list of turn types specified in the turn:lanes:forward tag
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return The list of turn types when tagged
+     */
+    static Optional<List<Set<TurnType>>> getForwardTurnLanes(final Taggable taggable)
+    {
+        return taggable.getTag(KEY)
+                .map(tagValue -> Arrays.stream(tagValue.split(TURN_LANE_DELIMITER))
+                        .map(lane -> Arrays.stream(lane.split(TURN_TYPE_DELIMITER))
+                                .map(TurnType::safeValueOf).filter(Objects::nonNull)
+                                .collect(Collectors.toSet()))
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has the {@link TurnType} in the {@code turn:lanes:forward}
+     * tags.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @param turnType
+     *            A turn type to test for
+     * @return {@code true} if tagged with the turn type, otherwise {@code false}
+     */
+    static boolean hasForwardTurnLane(final Taggable taggable, final TurnType turnType)
+    {
+        return getForwardTurnLanes(taggable)
+                .map(lanes -> lanes.stream().anyMatch(turnLane -> turnLane.contains(turnType)))
+                .orElse(false);
+    }
+
+    /**
+     * Checks if the {@link Taggable} has a {@code turn:lanes:forward} tag value.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return {@code true} if tagged, otherwise {@code false}
+     */
+    static boolean hasForwardTurnLane(final Taggable taggable)
+    {
+        return taggable.getTag(KEY).isPresent();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/TurnLanesTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TurnLanesTag.java
@@ -1,0 +1,77 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.OptionalIterable;
+
+/**
+ * OSM turn:lanes tag indicating the lane types for a one-way road
+ *
+ * @author brian_l_davis
+ */
+@Tag(value = Validation.NON_EMPTY_STRING, taginfo = "http://taginfo.openstreetmap.org/keys/turn%3Alanes#values", osm = "https://wiki.openstreetmap.org/wiki/Key:turn")
+public interface TurnLanesTag extends TurnTag
+{
+    @TagKey
+    String KEY = "turn:lanes";
+
+    /**
+     * The list of turn types specified in the turn:lanes tag
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return The list of turn types when tagged
+     */
+    static Optional<List<Set<TurnType>>> getTurnLanes(final Taggable taggable)
+    {
+        return taggable.getTag(KEY)
+                .map(tagValue -> Arrays.stream(tagValue.split(TURN_LANE_DELIMITER))
+                        .map(lane -> Arrays.stream(lane.split(TURN_TYPE_DELIMITER))
+                                .map(TurnType::safeValueOf).filter(Objects::nonNull)
+                                .collect(Collectors.toSet()))
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has the {@link TurnType} in any of the
+     * {@code turn:lanes[:forward|:backward]} tags.
+     * 
+     * @param taggable
+     *            The taggable object being test
+     * @param turnType
+     *            A turn type to test for
+     * @return {@code true} if tagged with the turn type, otherwise {@code false}
+     */
+    @SuppressWarnings("unchecked")
+    static boolean hasTurnLane(final Taggable taggable, final TurnType turnType)
+    {
+        final OptionalIterable<List<Set<TurnType>>> turnLanes = new OptionalIterable<>(Iterables
+                .iterable(getTurnLanes(taggable), TurnLanesForwardTag.getForwardTurnLanes(taggable),
+                        TurnLanesBackwardTag.getBackwardTurnLanes(taggable)));
+        return Iterables.asList(turnLanes).stream().anyMatch(
+                lanes -> lanes.stream().anyMatch(turnLane -> turnLane.contains(turnType)));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has a {@code turn[:lanes[:forward|:backward]]} tag value.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return {@code true} if tagged, otherwise {@code false}
+     */
+    static boolean hasTurnLane(final Taggable taggable)
+    {
+        return taggable.getTag(TurnLanesTag.KEY).isPresent()
+                || taggable.getTag(TurnLanesForwardTag.KEY).isPresent()
+                || taggable.getTag(TurnLanesBackwardTag.KEY).isPresent();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
@@ -1,0 +1,118 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.OptionalIterable;
+
+/**
+ * Base OSM turn tag indicating a turn direction
+ *
+ * @author brian_l_davis
+ */
+@Tag(value = Validation.NON_EMPTY_STRING, taginfo = "http://taginfo.openstreetmap.org/keys/turn#values", osm = "https://wiki.openstreetmap.org/wiki/Key:turn")
+public interface TurnTag
+{
+    @TagKey
+    String KEY = "turn";
+
+    String TURN_LANE_DELIMITER = "\\|";
+    String TURN_TYPE_DELIMITER = ";";
+
+    /**
+     * The list of turn types specified in the turn tag
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return The list of turn types when tagged
+     */
+    static Optional<List<Set<TurnType>>> getTurns(final Taggable taggable)
+    {
+        return taggable.getTag(KEY)
+                .map(tagValue -> Arrays.stream(tagValue.split(TURN_LANE_DELIMITER))
+                        .map(lane -> Arrays.stream(lane.split(TURN_TYPE_DELIMITER))
+                                .map(TurnType::safeValueOf).filter(Objects::nonNull)
+                                .collect(Collectors.toSet()))
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has the {@link TurnType} in any of the
+     * {@code turn[:lanes[:forward|:backward]]} tags.
+     * 
+     * @param taggable
+     *            The taggable object being test
+     * @param turnType
+     *            A turn type to test for
+     * @return {@code true} if tagged with the turn type, otherwise {@code false}
+     */
+    @SuppressWarnings("unchecked")
+    static boolean hasTurn(final Taggable taggable, final TurnType turnType)
+    {
+        final OptionalIterable<List<Set<TurnType>>> turnLanes = new OptionalIterable<>(
+                Iterables.iterable(getTurns(taggable), TurnLanesTag.getTurnLanes(taggable),
+                        TurnLanesForwardTag.getForwardTurnLanes(taggable),
+                        TurnLanesBackwardTag.getBackwardTurnLanes(taggable)));
+        return Iterables.asList(turnLanes).stream().anyMatch(
+                lanes -> lanes.stream().anyMatch(turnLane -> turnLane.contains(turnType)));
+    }
+
+    /**
+     * Checks if the {@link Taggable} has a {@code turn[:lanes[:forward|:backward]]} tag value.
+     *
+     * @param taggable
+     *            The taggable object being test
+     * @return {@code true} if tagged, otherwise {@code false}
+     */
+    static boolean hasTurn(final Taggable taggable)
+    {
+        return taggable.getTag(TurnTag.KEY).isPresent()
+                || taggable.getTag(TurnLanesTag.KEY).isPresent()
+                || taggable.getTag(TurnLanesForwardTag.KEY).isPresent()
+                || taggable.getTag(TurnLanesBackwardTag.KEY).isPresent();
+    }
+
+    /**
+     * @author brian_l_davis
+     */
+    enum TurnType
+    {
+        LEFT,
+        SHARP_LEFT,
+        SLIGHT_LEFT,
+        THROUGH,
+        RIGHT,
+        SHARP_RIGHT,
+        SLIGHT_RIGHT,
+        REVERSE,
+        MERGE_TO_LEFT,
+        MERGE_TO_RIGHT,
+        NONE;
+
+        static final EnumSet<TurnType> leftTurn = EnumSet.of(LEFT, SHARP_LEFT, SLIGHT_LEFT,
+                MERGE_TO_LEFT);
+        static final EnumSet<TurnType> rightTurn = EnumSet.of(RIGHT, SHARP_RIGHT, SLIGHT_RIGHT,
+                MERGE_TO_RIGHT);
+
+        static TurnType safeValueOf(final String value)
+        {
+            try
+            {
+                return valueOf(value.toUpperCase());
+            }
+            catch (final IllegalArgumentException ignored)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/TurnLaneBackwardTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TurnLaneBackwardTagTestCase.java
@@ -1,0 +1,61 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+/**
+ * Test for {@link org.openstreetmap.atlas.tags.TurnLanesBackwardTag}
+ *
+ * @author brian_l_davis
+ */
+public class TurnLaneBackwardTagTestCase
+{
+    @Test
+    public void testBackwardTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesBackwardTag.getBackwardTurnLanes(taggable).isPresent());
+        Assert.assertTrue(
+                TurnLanesBackwardTag.hasBackwardTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMalformedTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "sdf|sldkf;jsdl|sldkfj");
+        Assert.assertTrue(TurnLanesBackwardTag.hasBackwardTurnLane(taggable));
+        Assert.assertFalse(TurnLanesBackwardTag.hasBackwardTurnLane(taggable,
+                TurnLanesBackwardTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMultipleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left;through|right");
+        Assert.assertTrue(TurnLanesBackwardTag.hasBackwardTurnLane(taggable,
+                TurnLanesBackwardTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesBackwardTag.hasBackwardTurnLane(taggable));
+    }
+
+    @Test
+    public void testSingleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesBackwardTag.hasBackwardTurnLane(taggable,
+                TurnLanesBackwardTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesBackwardTag.hasBackwardTurnLane(taggable));
+    }
+
+    @Test
+    public void testUntagged()
+    {
+        final TestTaggable taggable = new TestTaggable(HighwayTag.KEY, "no");
+        Assert.assertFalse(TurnLanesBackwardTag.getBackwardTurnLanes(taggable).isPresent());
+        Assert.assertFalse(TurnLanesBackwardTag.hasBackwardTurnLane(taggable));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/TurnLaneForwardTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TurnLaneForwardTagTestCase.java
@@ -1,0 +1,61 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+/**
+ * Test for {@link org.openstreetmap.atlas.tags.TurnLanesForwardTag}
+ *
+ * @author brian_l_davis
+ */
+public class TurnLaneForwardTagTestCase
+{
+    @Test
+    public void testForwardTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesForwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesForwardTag.getForwardTurnLanes(taggable).isPresent());
+        Assert.assertTrue(
+                TurnLanesForwardTag.hasForwardTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMalformedTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesForwardTag.KEY,
+                "sdf|sldkf;jsdl|sldkfj");
+        Assert.assertTrue(TurnLanesForwardTag.hasForwardTurnLane(taggable));
+        Assert.assertFalse(TurnLanesForwardTag.hasForwardTurnLane(taggable,
+                TurnLanesForwardTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMultipleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesForwardTag.KEY,
+                "left;through|right");
+        Assert.assertTrue(TurnLanesForwardTag.hasForwardTurnLane(taggable,
+                TurnLanesForwardTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesForwardTag.hasForwardTurnLane(taggable));
+    }
+
+    @Test
+    public void testSingleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesForwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesForwardTag.hasForwardTurnLane(taggable,
+                TurnLanesForwardTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesForwardTag.hasForwardTurnLane(taggable));
+    }
+
+    @Test
+    public void testUntagged()
+    {
+        final TestTaggable taggable = new TestTaggable(HighwayTag.KEY, "no");
+        Assert.assertFalse(TurnLanesForwardTag.getForwardTurnLanes(taggable).isPresent());
+        Assert.assertFalse(TurnLanesForwardTag.hasForwardTurnLane(taggable));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/TurnLaneTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TurnLaneTagTestCase.java
@@ -1,0 +1,83 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+/**
+ * Test for {@link org.openstreetmap.atlas.tags.TurnLanesTag}
+ *
+ * @author brian_l_davis
+ */
+public class TurnLaneTagTestCase
+{
+    @Test
+    public void testBackwardTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesBackwardTag.getBackwardTurnLanes(taggable).isPresent());
+        Assert.assertTrue(
+                TurnLanesBackwardTag.hasBackwardTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testForwardTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesForwardTag.KEY,
+                "left|through|right");
+        Assert.assertTrue(TurnLanesForwardTag.getForwardTurnLanes(taggable).isPresent());
+        Assert.assertTrue(
+                TurnLanesForwardTag.hasForwardTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable));
+    }
+
+    @Test
+    public void testMalformedTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesTag.KEY, "sdf|sldkf;jsdl|sldkfj");
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable));
+        Assert.assertFalse(TurnLanesTag.hasTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMatchSpecificTurnLaneTags()
+    {
+        final TestTaggable forwardTurnLaneTagged = new TestTaggable(TurnLanesForwardTag.KEY,
+                "right");
+        final TestTaggable backwardTurnLaneTagged = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left");
+
+        Assert.assertTrue(TurnTag.hasTurn(forwardTurnLaneTagged));
+        Assert.assertTrue(TurnTag.hasTurn(forwardTurnLaneTagged, TurnTag.TurnType.RIGHT));
+
+        Assert.assertTrue(TurnTag.hasTurn(backwardTurnLaneTagged));
+        Assert.assertTrue(TurnTag.hasTurn(backwardTurnLaneTagged, TurnTag.TurnType.LEFT));
+    }
+
+    @Test
+    public void testMultipleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesTag.KEY, "left;through|right");
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable));
+    }
+
+    @Test
+    public void testSingleTypeTurnLane()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnLanesTag.KEY, "left|through|right");
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable, TurnLanesTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnLanesTag.hasTurnLane(taggable));
+    }
+
+    @Test
+    public void testUntagged()
+    {
+        final TestTaggable taggable = new TestTaggable(HighwayTag.KEY, "no");
+        Assert.assertFalse(TurnLanesTag.getTurnLanes(taggable).isPresent());
+        Assert.assertFalse(TurnLanesTag.hasTurnLane(taggable));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/TurnTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TurnTagTestCase.java
@@ -1,0 +1,64 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+/**
+ * Test for {@link org.openstreetmap.atlas.tags.TurnTag}
+ *
+ * @author brian_l_davis
+ */
+public class TurnTagTestCase
+{
+    @Test
+    public void testMalformedTurn()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnTag.KEY, "sdf|sldkf;jsdl|sldkfj");
+        Assert.assertTrue(TurnTag.hasTurn(taggable));
+        Assert.assertFalse(TurnTag.hasTurn(taggable, TurnTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMatchSpecificTurnTags()
+    {
+        final TestTaggable forwardTurnLaneTagged = new TestTaggable(TurnLanesForwardTag.KEY,
+                "right");
+        final TestTaggable backwardTurnLaneTagged = new TestTaggable(TurnLanesBackwardTag.KEY,
+                "left");
+        final TestTaggable turnLanedTagged = new TestTaggable(TurnLanesBackwardTag.KEY, "through");
+
+        Assert.assertTrue(TurnTag.hasTurn(forwardTurnLaneTagged));
+        Assert.assertTrue(TurnTag.hasTurn(forwardTurnLaneTagged, TurnTag.TurnType.RIGHT));
+
+        Assert.assertTrue(TurnTag.hasTurn(backwardTurnLaneTagged));
+        Assert.assertTrue(TurnTag.hasTurn(backwardTurnLaneTagged, TurnTag.TurnType.LEFT));
+
+        Assert.assertTrue(TurnTag.hasTurn(turnLanedTagged));
+        Assert.assertTrue(TurnTag.hasTurn(turnLanedTagged, TurnTag.TurnType.THROUGH));
+    }
+
+    @Test
+    public void testMultipleTypeTurn()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnTag.KEY, "left;through|right");
+        Assert.assertTrue(TurnTag.hasTurn(taggable, TurnTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnTag.hasTurn(taggable));
+    }
+
+    @Test
+    public void testSingleTypeTurn()
+    {
+        final TestTaggable taggable = new TestTaggable(TurnTag.KEY, "left|through|right");
+        Assert.assertTrue(TurnTag.hasTurn(taggable, TurnTag.TurnType.THROUGH));
+        Assert.assertTrue(TurnTag.hasTurn(taggable));
+    }
+
+    @Test
+    public void testUntagged()
+    {
+        final TestTaggable taggable = new TestTaggable(HighwayTag.KEY, "no");
+        Assert.assertFalse(TurnTag.getTurns(taggable).isPresent());
+        Assert.assertFalse(TurnTag.hasTurn(taggable));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/FromEnumTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/FromEnumTestCase.java
@@ -5,9 +5,9 @@ import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.tags.BuildingTag;
-import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
  * Test case for verifying reflections-based enum value parsing
@@ -44,37 +44,10 @@ public class FromEnumTestCase
         public static final String KEY = "magic-eight-ball";
     }
 
-    /**
-     * Simple taggable implementation for testing
-     *
-     * @author cstaylor
-     */
-    private static final class TestingTaggable implements Taggable
-    {
-        private final String key;
-        private final String value;
-
-        TestingTaggable(final String key, final String value)
-        {
-            this.key = key;
-            this.value = value;
-        }
-
-        @Override
-        public Optional<String> getTag(final String key)
-        {
-            if (key.equals(this.key))
-            {
-                return Optional.of(this.value);
-            }
-            return Optional.empty();
-        }
-    }
-
     @Test
     public void testExists()
     {
-        final TestingTaggable testing = new TestingTaggable(EightBall.KEY, "maYbE");
+        final TestTaggable testing = new TestTaggable(EightBall.KEY, "maYbE");
         final Optional<EightBall> found = Validators.from(EightBall.class, testing);
         Assert.assertTrue(found.isPresent());
         Assert.assertEquals(EightBall.MAYBE, found.get());
@@ -83,7 +56,7 @@ public class FromEnumTestCase
     @Test
     public void testIllegalValue()
     {
-        final TestingTaggable testing = new TestingTaggable(EightBall.KEY, "Nope");
+        final TestTaggable testing = new TestTaggable(EightBall.KEY, "Nope");
         final Optional<EightBall> found = Validators.from(EightBall.class, testing);
         Assert.assertFalse(found.isPresent());
     }
@@ -91,7 +64,7 @@ public class FromEnumTestCase
     @Test
     public void testMissingValue()
     {
-        final TestingTaggable testing = new TestingTaggable(BuildingTag.KEY, "Nope");
+        final TestTaggable testing = new TestTaggable(BuildingTag.KEY, "Nope");
         final Optional<EightBall> found = Validators.from(EightBall.class, testing);
         Assert.assertFalse(found.isPresent());
     }
@@ -99,7 +72,7 @@ public class FromEnumTestCase
     @Test
     public void testWith()
     {
-        final TestingTaggable testing = new TestingTaggable(DisusedEightBall.KEY, "maYbE");
+        final TestTaggable testing = new TestTaggable(DisusedEightBall.KEY, "maYbE");
         final Optional<EightBall> found = Validators.from(DisusedEightBall.class, EightBall.class,
                 testing);
         Assert.assertTrue(found.isPresent());


### PR DESCRIPTION
This PR adds classes that model the various turn tags available in OSM, wiki: [key:turn](https://wiki.openstreetmap.org/wiki/Key:turn). 

More general tags like `TurnTag` contain methods that obscure more specific tag sources. This makes it easy to interrogate a `Taggable` edge when we're not interested in the specific lanes or direct. This is done through the `hasTurn` accessor methods.  This property is not symmetrical, so detail isn't lost when querying for more specific tags.

(pseudo code)
```
// general query
Taggable tagged = new Taggable("turn:lanes:backward=through|through;right")
TurnTag.hasTurn(tagged, THROUGH) == true

// specific query
Taggable tagged = new Taggable("turn:lanes:backward=through|through;right")
TurnLanesForwardTag.hasForwardTurnLane(tagged, THROUGH) == false
```