### PR TITLE
Add constructors to enable easy deserialization

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveEdgeIdentifier.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveEdgeIdentifier.java
@@ -9,11 +9,15 @@ public class AtlasPrimitiveEdgeIdentifier implements Serializable
 {
     private static final long serialVersionUID = 6082277761179021192L;
 
-    private final long identifier;
+    private long identifier;
 
     public static AtlasPrimitiveEdgeIdentifier from(final AtlasPrimitiveEdge atlasPrimitiveEdge)
     {
         return new AtlasPrimitiveEdgeIdentifier(atlasPrimitiveEdge.getIdentifier());
+    }
+
+    public AtlasPrimitiveEdgeIdentifier()
+    {
     }
 
     public AtlasPrimitiveEdgeIdentifier(final long identifier)
@@ -37,6 +41,11 @@ public class AtlasPrimitiveEdgeIdentifier implements Serializable
     public int hashCode()
     {
         return Long.hashCode(this.identifier);
+    }
+
+    public void setIdentifier(final long identifier)
+    {
+        this.identifier = identifier;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveRouteIdentifier.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/store/AtlasPrimitiveRouteIdentifier.java
@@ -19,7 +19,7 @@ public class AtlasPrimitiveRouteIdentifier
 {
     private static final long serialVersionUID = 2321636844479248974L;
 
-    private final List<AtlasPrimitiveEdgeIdentifier> primitiveRouteIdentifier;
+    private List<AtlasPrimitiveEdgeIdentifier> primitiveRouteIdentifier;
 
     public static AtlasPrimitiveRouteIdentifier from(final AtlasPrimitiveRoute atlasPrimitiveRoute)
     {
@@ -27,6 +27,10 @@ public class AtlasPrimitiveRouteIdentifier
         atlasPrimitiveRoute.forEach(
                 edge -> atlasPrimitiveEdgeIds.add(AtlasPrimitiveEdgeIdentifier.from(edge)));
         return new AtlasPrimitiveRouteIdentifier(atlasPrimitiveEdgeIds);
+    }
+
+    public AtlasPrimitiveRouteIdentifier()
+    {
     }
 
     public AtlasPrimitiveRouteIdentifier(final AtlasPrimitiveEdgeIdentifier... primitiveEdgeIds)
@@ -148,6 +152,12 @@ public class AtlasPrimitiveRouteIdentifier
                     ? subRouteIdentifierIterator.next() : null;
         }
         return overlapCount;
+    }
+
+    public void setPrimitiveRouteIdentifier(
+            final List<AtlasPrimitiveEdgeIdentifier> primitiveRouteIdentifier)
+    {
+        this.primitiveRouteIdentifier = primitiveRouteIdentifier;
     }
 
     public int size()


### PR DESCRIPTION
This change adds a default constructor to `AtlasPrimitiveIdentifier` classes that enable easy deserialization.