### PR TITLE
Country slicing: force-slice ferries and piers

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/CountrySlicingProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/CountrySlicingProcessor.java
@@ -345,6 +345,14 @@ public class CountrySlicingProcessor
         return results;
     }
 
+    /**
+     * In case of Ferries and Piers that can extend out in the water and connect to other countries,
+     * here is the option to force country slicing, even if there is no immediate country nearby.
+     *
+     * @param way
+     *            The way to test for
+     * @return True if eligible for mandatory slicing.
+     */
     private boolean canSkipSlicingIfSingleCountry(final Way way)
     {
         return !Validators.isOfType(Taggable.with(way.getTags()), RouteTag.class, RouteTag.FERRY)

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -902,7 +902,7 @@ public class CountryBoundaryMap implements Serializable
         List<Polygon> polygons = query(target.getEnvelopeInternal());
 
         // Performance improvement, if only one polygon returned no need to do any further
-        // evaluation.
+        // evaluation, except if slicing is mandatory.
         if (isSameCountry(polygons) && canSkipIfSingleCountry)
         {
             final String countryCode = getGeometryProperty(polygons.get(0), ISOCountryTag.KEY);
@@ -983,7 +983,8 @@ public class CountryBoundaryMap implements Serializable
             }
         }
 
-        // Performance: short circuit, if all intersected polygons in same country, skip cutting
+        // Performance: short circuit, if all intersected polygons in same country, skip cutting,
+        // except if slicing is mandatory.
         if (isSameCountry(intersected) && canSkipIfSingleCountry)
         {
             final String countryCode = getGeometryProperty(intersected.get(0), ISOCountryTag.KEY);

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -879,6 +879,9 @@ public class CountryBoundaryMap implements Serializable
      *            id of object being sliced.
      * @param geometry
      *            The object to be sliced.
+     * @param canSkipIfSingleCountry
+     *            When set to true, this flag tells the function that if a feature is only touching
+     *            a single country boundary, then slicing can be skipped.
      * @return a list of geometry objects. If target doesn't cross any border then it contains only
      *         one item with country code assigned. If target cross border then slice it by the
      *         border line and assign country code for each piece. If a feature is not contained by
@@ -886,8 +889,8 @@ public class CountryBoundaryMap implements Serializable
      * @throws TopologyException
      *             When the slicing could not be made.
      */
-    public List<Geometry> slice(final long identifier, final Geometry geometry)
-            throws TopologyException
+    public List<Geometry> slice(final long identifier, final Geometry geometry,
+            final boolean canSkipIfSingleCountry) throws TopologyException
     {
         if (Objects.isNull(geometry))
         {
@@ -900,7 +903,7 @@ public class CountryBoundaryMap implements Serializable
 
         // Performance improvement, if only one polygon returned no need to do any further
         // evaluation.
-        if (isSameCountry(polygons))
+        if (isSameCountry(polygons) && canSkipIfSingleCountry)
         {
             final String countryCode = getGeometryProperty(polygons.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
@@ -981,7 +984,7 @@ public class CountryBoundaryMap implements Serializable
         }
 
         // Performance: short circuit, if all intersected polygons in same country, skip cutting
-        if (isSameCountry(intersected))
+        if (isSameCountry(intersected) && canSkipIfSingleCountry)
         {
             final String countryCode = getGeometryProperty(intersected.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);

--- a/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
@@ -87,7 +87,7 @@ public class CountryBoundaryMapTest
                         .getResourceAsStream("AIA_MAF_osm_boundaries_with_grid_index.txt.gz"))
                                 .withDecompressor(Decompressor.GZIP));
 
-        final List<Geometry> firstSlice = mapWithGridIndex.slice(1000000L, geometry);
+        final List<Geometry> firstSlice = mapWithGridIndex.slice(1000000L, geometry, true);
 
         logger.info(firstSlice.toString());
         logger.info("It took {} to slice using serialized pre-built grid index",
@@ -103,7 +103,7 @@ public class CountryBoundaryMapTest
         // Construct the grid index on the fly
         mapFromOsmTextFile.createGridIndex(mapFromOsmTextFile.getLoadedCountries());
 
-        final List<Geometry> secondSlice = mapFromOsmTextFile.slice(1000000L, geometry);
+        final List<Geometry> secondSlice = mapFromOsmTextFile.slice(1000000L, geometry, true);
 
         logger.info(secondSlice.toString());
         logger.info("It took {} to slice using constructed grid index", start2.elapsedSince());
@@ -176,7 +176,7 @@ public class CountryBoundaryMapTest
 
         final Geometry geometry = reader.read(
                 "POLYGON (( -71.7424191 18.7499411097, -71.730485136 18.749848501, -71.730081575 18.749979671, -71.730142154 18.749575218, -71.730486015 18.7498444, -71.7424191 18.7499411097 ))");
-        final List<Geometry> pieces = map.slice(1000000L, geometry);
+        final List<Geometry> pieces = map.slice(1000000L, geometry, true);
         logger.info(pieces.toString());
         Assert.assertEquals(2, pieces.size());
     }


### PR DESCRIPTION
Ferries need to be country sliced properly, even when jumping from one country to no country (international waters). Current behavior is to not slice any feature that is crossing such a boundary. Also, in some cases, when the country boundary is admin_level 3 and hugs the coastline, we also want the piers connected to ferry lines to be sliced, even though they go from a country to no country.

That PR brings multiple things:
 - Ferries are always country-sliced, even when going from country to no country
 - Piers are always country-sliced, even when going from country to no country
 - All other features going from country to no country are not sliced, as before.