### PR TITLE
Snap a Location to a MultiPolygon

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -519,6 +519,18 @@ public class Location implements Located, Iterable<Location>, Serializable
     }
 
     /**
+     * Snap this {@link Location} to a {@link MultiPolygon} using a {@link Snapper}
+     *
+     * @param shape
+     *            The shape to snap to
+     * @return The corresponding {@link SnappedLocation}
+     */
+    public SnappedLocation snapTo(final MultiPolygon shape)
+    {
+        return new Snapper().snap(this, shape);
+    }
+
+    /**
      * Snap this {@link Location} to a {@link PolyLine} using a {@link Snapper}
      *
      * @param shape

--- a/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
@@ -104,6 +104,10 @@ public class Snapper
             {
                 target = (PolyLine) shape;
             }
+            else if (shape instanceof Polygon)
+            {
+                target = (Polygon) shape;
+            }
             else
             {
                 target = new PolyLine(shape);
@@ -127,5 +131,27 @@ public class Snapper
             return new SnappedLocation(origin, target, new PolyLine(target));
         }
         return null;
+    }
+
+    public SnappedLocation snap(final Location origin, final MultiPolygon shape)
+    {
+        SnappedLocation best = null;
+        for (final Polygon outer : shape.outers())
+        {
+            final SnappedLocation candidate = snap(origin, outer);
+            if (best == null || candidate.getDistance().isLessThan(best.getDistance()))
+            {
+                best = candidate;
+            }
+        }
+        for (final Polygon inner : shape.inners())
+        {
+            final SnappedLocation candidate = snap(origin, inner);
+            if (best == null || candidate.getDistance().isLessThan(best.getDistance()))
+            {
+                best = candidate;
+            }
+        }
+        return best;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography;
 
+import org.openstreetmap.atlas.utilities.collections.MultiIterable;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 import com.google.common.collect.Iterables;
@@ -136,17 +137,9 @@ public class Snapper
     public SnappedLocation snap(final Location origin, final MultiPolygon shape)
     {
         SnappedLocation best = null;
-        for (final Polygon outer : shape.outers())
+        for (final Polygon member : new MultiIterable<>(shape.outers(), shape.inners()))
         {
-            final SnappedLocation candidate = snap(origin, outer);
-            if (best == null || candidate.getDistance().isLessThan(best.getDistance()))
-            {
-                best = candidate;
-            }
-        }
-        for (final Polygon inner : shape.inners())
-        {
-            final SnappedLocation candidate = snap(origin, inner);
+            final SnappedLocation candidate = snap(origin, member);
             if (best == null || candidate.getDistance().isLessThan(best.getDistance()))
             {
                 best = candidate;

--- a/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
@@ -9,6 +9,24 @@ import org.junit.Test;
 public class SnapperTest
 {
     @Test
+    public void testMultiPolygon()
+    {
+        final MultiPolygon shape = MultiPolygon.TEST_MULTI_POLYGON;
+        final Location origin1 = Location.forString("37.328709, -122.032873");
+        final Location origin2 = Location.forString("37.324014, -122.046642");
+        Assert.assertEquals(Location.forString("37.3283544,-122.0322605"), origin1.snapTo(shape));
+        Assert.assertEquals(Location.forString("37.3249067,-122.0459561"), origin2.snapTo(shape));
+    }
+
+    @Test
+    public void testPolygon()
+    {
+        final Polygon shape = new Polygon(Location.TEST_6, Location.TEST_1, Location.EIFFEL_TOWER);
+        final Location origin = Location.forString("37.325315, -122.008007");
+        Assert.assertEquals(Location.forString("37.3278247,-122.0082398"), origin.snapTo(shape));
+    }
+
+    @Test
     public void testPolyLine()
     {
         final PolyLine shape = new PolyLine(Location.TEST_6, Location.TEST_1,


### PR DESCRIPTION
This change adds a missing feature: snap a `Location` to a `MultiPolygon`.