### PR TITLE
Remove forced slicing due to decreased performance

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -879,9 +879,6 @@ public class CountryBoundaryMap implements Serializable
      *            id of object being sliced.
      * @param geometry
      *            The object to be sliced.
-     * @param canSkipIfSingleCountry
-     *            When set to true, this flag tells the function that if a feature is only touching
-     *            a single country boundary, then slicing can be skipped.
      * @return a list of geometry objects. If target doesn't cross any border then it contains only
      *         one item with country code assigned. If target cross border then slice it by the
      *         border line and assign country code for each piece. If a feature is not contained by
@@ -889,8 +886,8 @@ public class CountryBoundaryMap implements Serializable
      * @throws TopologyException
      *             When the slicing could not be made.
      */
-    public List<Geometry> slice(final long identifier, final Geometry geometry,
-            final boolean canSkipIfSingleCountry) throws TopologyException
+    public List<Geometry> slice(final long identifier, final Geometry geometry)
+            throws TopologyException
     {
         if (Objects.isNull(geometry))
         {
@@ -902,8 +899,8 @@ public class CountryBoundaryMap implements Serializable
         List<Polygon> polygons = query(target.getEnvelopeInternal());
 
         // Performance improvement, if only one polygon returned no need to do any further
-        // evaluation, except if slicing is mandatory.
-        if (isSameCountry(polygons) && canSkipIfSingleCountry)
+        // evaluation.
+        if (isSameCountry(polygons))
         {
             final String countryCode = getGeometryProperty(polygons.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
@@ -983,9 +980,8 @@ public class CountryBoundaryMap implements Serializable
             }
         }
 
-        // Performance: short circuit, if all intersected polygons in same country, skip cutting,
-        // except if slicing is mandatory.
-        if (isSameCountry(intersected) && canSkipIfSingleCountry)
+        // Performance: short circuit, if all intersected polygons in same country, skip cutting.
+        if (isSameCountry(intersected))
         {
             final String countryCode = getGeometryProperty(intersected.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/CountrySlicingProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/CountrySlicingProcessorTest.java
@@ -15,8 +15,6 @@ import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
-import org.openstreetmap.atlas.tags.ManMadeTag;
-import org.openstreetmap.atlas.tags.RouteTag;
 import org.openstreetmap.atlas.tags.SyntheticNearestNeighborCountryCodeTag;
 import org.openstreetmap.osmosis.core.domain.v0_6.CommonEntityData;
 import org.openstreetmap.osmosis.core.domain.v0_6.Node;
@@ -98,21 +96,6 @@ public class CountrySlicingProcessorTest
     }
 
     @Test
-    public void testDoNotForceSlicingForNonFerryNorPier()
-    {
-        this.store = new PbfMemoryStore(AtlasLoadingOption.createOptionWithNoSlicing());
-
-        // Way starts in CIV and ends in the water
-        addWay("4.658914,-7.069965 4.039977,-6.673084");
-
-        final MultiPolygon bound = boundaryMap.countryBoundary("CIV").get(0).getBoundary();
-        final CountrySlicingProcessor processor = new CountrySlicingProcessor(this.store,
-                boundaryMap, bound, null);
-        processor.run();
-        Assert.assertEquals("should be 1 piece after slicing", 1, this.store.wayCount());
-    }
-
-    @Test
     public void testFilterBasedOnBound()
     {
         this.store = new PbfMemoryStore(AtlasLoadingOption.createOptionWithNoSlicing());
@@ -130,38 +113,6 @@ public class CountrySlicingProcessorTest
         processor = new CountrySlicingProcessor(this.store, boundaryMap, bound, countryCodeSet);
         processor.run();
         Assert.assertEquals("should be 1 piece after filtering", 1, this.store.wayCount());
-    }
-
-    @Test
-    public void testForceSlicingForFerries()
-    {
-        this.store = new PbfMemoryStore(AtlasLoadingOption.createOptionWithNoSlicing());
-
-        // Way starts in CIV and ends in the water
-        final Way way = addWay("4.658914,-7.069965 4.039977,-6.673084");
-        way.getTags().add(new Tag(RouteTag.KEY, RouteTag.FERRY.name().toLowerCase()));
-
-        final MultiPolygon bound = boundaryMap.countryBoundary("CIV").get(0).getBoundary();
-        final CountrySlicingProcessor processor = new CountrySlicingProcessor(this.store,
-                boundaryMap, bound, null);
-        processor.run();
-        Assert.assertEquals("should be 2 piece after slicing", 2, this.store.wayCount());
-    }
-
-    @Test
-    public void testForceSlicingForPiers()
-    {
-        this.store = new PbfMemoryStore(AtlasLoadingOption.createOptionWithNoSlicing());
-
-        // Way starts in CIV and ends in the water
-        final Way way = addWay("4.658914,-7.069965 4.039977,-6.673084");
-        way.getTags().add(new Tag(ManMadeTag.KEY, ManMadeTag.PIER.name().toLowerCase()));
-
-        final MultiPolygon bound = boundaryMap.countryBoundary("CIV").get(0).getBoundary();
-        final CountrySlicingProcessor processor = new CountrySlicingProcessor(this.store,
-                boundaryMap, bound, null);
-        processor.run();
-        Assert.assertEquals("should be 2 piece after slicing", 2, this.store.wayCount());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
@@ -87,7 +87,7 @@ public class CountryBoundaryMapTest
                         .getResourceAsStream("AIA_MAF_osm_boundaries_with_grid_index.txt.gz"))
                                 .withDecompressor(Decompressor.GZIP));
 
-        final List<Geometry> firstSlice = mapWithGridIndex.slice(1000000L, geometry, true);
+        final List<Geometry> firstSlice = mapWithGridIndex.slice(1000000L, geometry);
 
         logger.info(firstSlice.toString());
         logger.info("It took {} to slice using serialized pre-built grid index",
@@ -103,7 +103,7 @@ public class CountryBoundaryMapTest
         // Construct the grid index on the fly
         mapFromOsmTextFile.createGridIndex(mapFromOsmTextFile.getLoadedCountries());
 
-        final List<Geometry> secondSlice = mapFromOsmTextFile.slice(1000000L, geometry, true);
+        final List<Geometry> secondSlice = mapFromOsmTextFile.slice(1000000L, geometry);
 
         logger.info(secondSlice.toString());
         logger.info("It took {} to slice using constructed grid index", start2.elapsedSince());
@@ -176,7 +176,7 @@ public class CountryBoundaryMapTest
 
         final Geometry geometry = reader.read(
                 "POLYGON (( -71.7424191 18.7499411097, -71.730485136 18.749848501, -71.730081575 18.749979671, -71.730142154 18.749575218, -71.730486015 18.7498444, -71.7424191 18.7499411097 ))");
-        final List<Geometry> pieces = map.slice(1000000L, geometry, true);
+        final List<Geometry> pieces = map.slice(1000000L, geometry);
         logger.info(pieces.toString());
         Assert.assertEquals(2, pieces.size());
     }


### PR DESCRIPTION
This is rolling back #32 as the performance is negatively impacted due to too many slicing operations.