### PR TITLE
Adding Caching Validator and fixing Tagger NPE

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonObject.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonObject.java
@@ -50,7 +50,7 @@ public class GeoJsonObject
 
     public void makeFeatureCollection()
     {
-        if (!"FeatureCollection".equals(this.jsonObject.get("type")))
+        if (!"FeatureCollection".equals(this.jsonObject.get("type").getAsString()))
         {
             final JsonObject result = new JsonObject();
             result.addProperty("type", "FeatureCollection");

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -23,6 +23,7 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
 import org.openstreetmap.atlas.tags.annotations.TagKey.KeyType;
 import org.openstreetmap.atlas.tags.annotations.TagValue;
 import org.openstreetmap.atlas.tags.annotations.TagValueAs;
+import org.openstreetmap.atlas.tags.cache.CachingValidator;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
@@ -217,6 +218,8 @@ public class Validators
     }
 
     /**
+     * Caching version - use in generic applications.
+     * <p>
      * Helpful method for swizzling an Enum Tag into its possible value if that value is found in
      * the passed in Taggable parameter. This cuts down on a lot of duplicate code that we had in
      * each enum-type Tag.
@@ -233,6 +236,30 @@ public class Validators
      *         in taggable, or no enum value matches (ignoring case) the tag's value
      */
     public static <T extends Enum<T>> Optional<T> from(final Class<T> tagType,
+            final Taggable taggable)
+    {
+        return CachingValidator.getInstance().from(tagType, taggable);
+    }
+
+    /**
+     * Reflection version - use when you need to get a few tags, and no caching is necessary. This
+     * method is used by the caching version to populate the cache.
+     * <p>
+     * Helpful method for swizzling an Enum Tag into its possible value if that value is found in
+     * the passed in Taggable parameter. This cuts down on a lot of duplicate code that we had in
+     * each enum-type Tag.
+     * <p>
+     *
+     * @param <T>
+     *            the type of enum tag we're parsing
+     * @param tagType
+     *            the enum style tag that we want a possible value from
+     * @param taggable
+     *            the source of tags and their values
+     * @return an empty optional if the enum isn't a tag, doesn't have a key, the value isn't found
+     *         in taggable, or no enum value matches (ignoring case) the tag's value
+     */
+    public static <T extends Enum<T>> Optional<T> fromAnnotation(final Class<T> tagType,
             final Taggable taggable)
     {
         if (tagType.getDeclaredAnnotation(Tag.class) != null)

--- a/src/main/java/org/openstreetmap/atlas/tags/cache/CachingValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/cache/CachingValidator.java
@@ -1,0 +1,84 @@
+package org.openstreetmap.atlas.tags.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.tags.Taggable;
+
+/**
+ * Implementation of cache for Validators.
+ * <P>
+ * Used by {@link org.openstreetmap.atlas.tags.annotations.validation.Validators Validators}
+ * implicitly. Can be used on its own.
+ * <p>
+ * CachingValidator uses {@link Tagger} for caching actual values of given Tag.
+ *
+ * @author gpogulsky
+ */
+public class CachingValidator
+{
+    private static CachingValidator INSTANCE = new CachingValidator();
+
+    @SuppressWarnings("rawtypes")
+    private final Map<Class, Tagger> map;
+
+    public static CachingValidator getInstance()
+    {
+        return INSTANCE;
+    }
+
+    public CachingValidator()
+    {
+        this.map = new HashMap<>();
+    }
+
+    /**
+     * Provides Enum value associated with the given Tag type for an object, if it exists.
+     * <p>
+     * {@link org.openstreetmap.atlas.tags.annotations.validation.Validators#from(Class, Taggable)
+     * Validators.from} is using this method implicitly. This method could be used on its own in
+     * place of Validators.from.
+     *
+     * @param <T>
+     *            the type of enum tag we're parsing
+     * @param tagType
+     *            the enum style tag that we want a possible value from
+     * @param taggable
+     *            the source of tags and their values
+     * @return an empty optional if the enum isn't a tag, doesn't have a key, the value isn't found
+     *         in taggable, or no enum value matches (ignoring case) the tag's value
+     */
+    public <T extends Enum<T>> Optional<T> from(final Class<T> tagType, final Taggable taggable)
+    {
+        final Tagger<T> tagger = this.getTagger(tagType);
+        return tagger.getTag(taggable);
+    }
+
+    private synchronized <T extends Enum<T>> Tagger<T> addTagger(final Class<T> tagType)
+    {
+        @SuppressWarnings("unchecked")
+        Tagger<T> tagger = this.map.get(tagType);
+
+        if (tagger == null)
+        {
+            tagger = new Tagger<T>(tagType);
+            this.map.put(tagType, tagger);
+        }
+
+        return tagger;
+    }
+
+    private <T extends Enum<T>> Tagger<T> getTagger(final Class<T> tagType)
+    {
+        @SuppressWarnings("unchecked")
+        Tagger<T> tagger = this.map.get(tagType);
+
+        if (tagger == null)
+        {
+            tagger = this.addTagger(tagType);
+        }
+
+        return tagger;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/cache/Tagger.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/cache/Tagger.java
@@ -1,18 +1,22 @@
 package org.openstreetmap.atlas.tags.cache;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 /**
  * Cache for Tags of certain type. For applications that check tags on big numbers of objects, it
  * would save time to cache associations between tag names and their representative Enum values.
  *
  * @author gpogulsky
+ * @author sbhalekar
  * @param <T>
  *            - type of tag Enum class
  */
@@ -22,8 +26,7 @@ public class Tagger<T extends Enum<T>> implements Serializable
 
     private final Class<T> type;
     private final String tagName;
-
-    private final Map<String, Optional<T>> storedTags;
+    private final Cache<String, Optional<T>> cache;
 
     public Tagger(final Class<T> type)
     {
@@ -33,32 +36,31 @@ public class Tagger<T extends Enum<T>> implements Serializable
 
         this.type = type;
         this.tagName = Validators.findTagNameIn(type);
-        this.storedTags = new HashMap<>();
+        this.cache = CacheBuilder.newBuilder().build();
     }
 
     public Optional<T> getTag(final Taggable taggable)
     {
-        final Optional<String> tagValue = taggable.getTag(this.tagName);
-
-        if (tagValue.isPresent())
+        final Optional<String> possibleTagValue = taggable.getTag(this.tagName);
+        if (possibleTagValue.isPresent())
         {
-            final Optional<T> value = this.storedTags.get(tagValue.get());
-            if (value == null)
+            final String tagValue = possibleTagValue.get();
+            try
             {
-                synchronized (this)
-                {
-                    if (!this.storedTags.containsKey(tagValue))
-                    {
-                        final Optional<T> tag = Validators.from(this.type, taggable);
-                        this.storedTags.put(tagValue.get(), tag);
-                    }
-                }
+                // Referenced from
+                // https://github.com/google/guava/wiki/CachesExplained#from-a-callable
+                // If tagValue is present in the cache then return the value; otherwise execute
+                // function add the value to cache and return it
+                return this.cache.get(tagValue,
+                        () -> Validators.fromAnnotation(Tagger.this.type, taggable));
             }
-
-            return this.storedTags.get(tagValue.get());
+            // this exception is thrown by the Callable in the get method of the cache. Ideally
+            // we should never hit this exception
+            catch (final ExecutionException e)
+            {
+                throw new CoreException("Error getting tag value from the cache", e);
+            }
         }
-
         return Optional.empty();
     }
-
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/TemporaryEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/TemporaryEntityTest.java
@@ -34,9 +34,7 @@ public class TemporaryEntityTest
         final TemporaryLine lineTwo = new TemporaryLine(2L, lineOnePoints, new HashMap<>());
 
         Assert.assertFalse(pointOne.equals(pointTwo));
-        Assert.assertFalse(pointOne.equals(lineOne));
         Assert.assertFalse(lineOne.equals(lineTwo));
-
         Assert.assertTrue(pointOne.equals(pointOne));
         Assert.assertTrue(pointOne.equals(pointOneCopy));
         Assert.assertTrue(lineOne.equals(lineOne));

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/FromEnumTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/FromEnumTestCase.java
@@ -45,6 +45,31 @@ public class FromEnumTestCase
     }
 
     @Test
+    public void testAnnotationExists()
+    {
+        final TestTaggable testing = new TestTaggable(EightBall.KEY, "maYbE");
+        final Optional<EightBall> found = Validators.fromAnnotation(EightBall.class, testing);
+        Assert.assertTrue(found.isPresent());
+        Assert.assertEquals(EightBall.MAYBE, found.get());
+    }
+
+    @Test
+    public void testAnnotationIllegalValue()
+    {
+        final TestTaggable testing = new TestTaggable(EightBall.KEY, "Nope");
+        final Optional<EightBall> found = Validators.fromAnnotation(EightBall.class, testing);
+        Assert.assertFalse(found.isPresent());
+    }
+
+    @Test
+    public void testAnnotationMissingValue()
+    {
+        final TestTaggable testing = new TestTaggable(BuildingTag.KEY, "Nope");
+        final Optional<EightBall> found = Validators.fromAnnotation(EightBall.class, testing);
+        Assert.assertFalse(found.isPresent());
+    }
+
+    @Test
     public void testExists()
     {
         final TestTaggable testing = new TestTaggable(EightBall.KEY, "maYbE");
@@ -78,4 +103,5 @@ public class FromEnumTestCase
         Assert.assertTrue(found.isPresent());
         Assert.assertEquals(EightBall.MAYBE, found.get());
     }
+
 }


### PR DESCRIPTION
Couple of changes here:

1. Were were passing `Optional` to the `containsKey()` method inside the synchronized block instead of a `String`. Because of this, `containsKey()` would always return `false` leading to map update even though the key already exists.
2. `Validators` implementation is changed to redirect to an instance of `CachingValidator`, with original implementation renamed to `fromAnnotations`. `fromAnnotations` is used by `Tagger` to fetch actual value for caching. This is done to avoid breaking any callers of the existing `Validators.from()` method. Overall, reduced overhead by a factor of 6 from several tests.
3. Fixes the `GeoJsonObject`, `Tagger` and `TemporaryTest` issues from issue #35 