### PR TITLE
Add a TestAtlas reader from a .osm xml file created by JOSM

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/AtlasLoadingOption.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/AtlasLoadingOption.java
@@ -103,6 +103,7 @@ public final class AtlasLoadingOption implements Serializable
         atlasLoadingOption.setOsmPbfWayFilter(filter);
         atlasLoadingOption.setOsmPbfNodeFilter(filter);
         atlasLoadingOption.setOsmPbfRelationFilter(filter);
+        atlasLoadingOption.setWaySectioning(true);
         return atlasLoadingOption;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
@@ -1,0 +1,46 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/**
+ * Parses an OSM file created by JOSM and makes it look like real OSM data
+ *
+ * @author matthieun
+ */
+public class OsmFileParser
+{
+    private final List<Tuple<String, String>> replacements;
+
+    public OsmFileParser()
+    {
+        this.replacements = new ArrayList<>();
+        this.replacements.add(new Tuple<>("id=\\'-", "id=\\'"));
+        this.replacements.add(new Tuple<>("ref=\\'-", "ref=\\'"));
+        this.replacements.add(new Tuple<>("action=\\'modify\\'",
+                "uid=\\'1\\' version=\\'1\\' changeset=\\'1\\' user=\\'myself\\'"
+                        + " timestamp=\\'2017-12-19T21:43:02Z\\' action=\\'modify\\'"));
+        this.replacements.add(new Tuple<>("generator=\\'JOSM\\'",
+                "generator=\\'JOSM\\' timestamp=\\'2017-12-19T21:43:02Z\\'"));
+    }
+
+    public void update(final Resource josmOsmFile, final WritableResource osmFile)
+    {
+        final StringList result = new StringList();
+        for (final String line : josmOsmFile.lines())
+        {
+            String replaced = line;
+            for (final Tuple<String, String> replacement : this.replacements)
+            {
+                replaced = replaced.replaceAll(replacement.getFirst(), replacement.getSecond());
+            }
+            result.add(replaced);
+        }
+        osmFile.writeAndClose(result.join(System.lineSeparator()));
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
@@ -26,6 +26,8 @@ public class OsmFileParser
         this.replacements.add(new Tuple<>("ref=\\'-", "ref=\\'"));
         this.replacements.add(new Tuple<>("action=\\'modify\\'",
                 "uid=\\'1\\' version=\\'1\\' changeset=\\'1\\' user=\\'myself\\'"
+                        // Here the timestamp is meaningless, just there so osmosis can read the XML
+                        // file.
                         + " timestamp=\\'2017-12-19T21:43:02Z\\' action=\\'modify\\'"));
         this.replacements.add(new Tuple<>("generator=\\'JOSM\\'",
                 "generator=\\'JOSM\\' timestamp=\\'2017-12-19T21:43:02Z\\'"));

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileParser.java
@@ -15,6 +15,8 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  */
 public class OsmFileParser
 {
+    // List of regexes being replaced. The first item in the tuple is the regex, and the second is
+    // the replacement.
     private final List<Tuple<String, String>> replacements;
 
     public OsmFileParser()

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileToPbf.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmFileToPbf.java
@@ -1,0 +1,24 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.osmosis.osmbinary.file.BlockOutputStream;
+import org.openstreetmap.osmosis.xml.common.CompressionMethod;
+
+import crosby.binary.osmosis.OsmosisSerializer;
+
+/**
+ * @author matthieun
+ */
+public class OsmFileToPbf
+{
+    public void update(final Resource osmFile, final WritableResource pbfFile)
+    {
+        final OsmosisXmlReaderFromResource osmReader = new OsmosisXmlReaderFromResource(osmFile,
+                true, CompressionMethod.None);
+        final OsmosisSerializer pbfWriter = new OsmosisSerializer(
+                new BlockOutputStream(pbfFile.write()));
+        osmReader.setSink(pbfWriter);
+        osmReader.run();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
@@ -31,7 +31,7 @@ import org.xml.sax.SAXParseException;
  */
 public class OsmosisXmlReaderFromResource implements RunnableSource
 {
-    private static Logger log = Logger.getLogger(XmlReader.class.getName());
+    private static Logger log = Logger.getLogger(OsmosisXmlReaderFromResource.class.getName());
 
     private Sink sink;
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
@@ -65,13 +65,10 @@ public class OsmosisXmlReaderFromResource implements RunnableSource
     public void run()
     {
         InputStream inputStream = null;
-
         try
         {
             final SAXParser parser;
-
             this.sink.initialize(Collections.<String, Object> emptyMap());
-
             // make "-" an alias for /dev/stdin
             if (this.resource.getName() != null && this.resource.getName().equals("-"))
             {
@@ -81,16 +78,11 @@ public class OsmosisXmlReaderFromResource implements RunnableSource
             {
                 inputStream = this.resource.read();
             }
-
             inputStream = new CompressionActivator(this.compressionMethod)
                     .createCompressionInputStream(inputStream);
-
             parser = createParser();
-
             parser.parse(inputStream, new OsmHandler(this.sink, this.enableDateParsing));
-
             this.sink.complete();
-
         }
         catch (final SAXParseException e)
         {
@@ -112,7 +104,6 @@ public class OsmosisXmlReaderFromResource implements RunnableSource
         finally
         {
             this.sink.release();
-
             if (inputStream != null)
             {
                 try
@@ -147,7 +138,6 @@ public class OsmosisXmlReaderFromResource implements RunnableSource
         try
         {
             return SAXParserFactory.newInstance().newSAXParser();
-
         }
         catch (final ParserConfigurationException e)
         {
@@ -158,5 +148,4 @@ public class OsmosisXmlReaderFromResource implements RunnableSource
             throw new OsmosisRuntimeException("Unable to create SAX Parser.", e);
         }
     }
-
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/OsmosisXmlReaderFromResource.java
@@ -1,0 +1,162 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.openstreetmap.osmosis.core.task.v0_6.RunnableSource;
+import org.openstreetmap.osmosis.core.task.v0_6.Sink;
+import org.openstreetmap.osmosis.xml.common.CompressionActivator;
+import org.openstreetmap.osmosis.xml.common.CompressionMethod;
+import org.openstreetmap.osmosis.xml.v0_6.XmlReader;
+import org.openstreetmap.osmosis.xml.v0_6.impl.OsmHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * From {@link XmlReader}. Almost everything here is copied from osmosis-xml version 0.44.1. The
+ * only change is to allow reading from a {@link Resource} instead from a {@link File}.
+ *
+ * @author Brett Henderson
+ * @author matthieun
+ */
+public class OsmosisXmlReaderFromResource implements RunnableSource
+{
+    private static Logger log = Logger.getLogger(XmlReader.class.getName());
+
+    private Sink sink;
+
+    private final Resource resource;
+    private final boolean enableDateParsing;
+    private final CompressionMethod compressionMethod;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param resource
+     *            The resource to read.
+     * @param enableDateParsing
+     *            If true, dates will be parsed from xml data, else the current date will be used
+     *            thus saving parsing time.
+     * @param compressionMethod
+     *            Specifies the compression method to employ.
+     */
+    public OsmosisXmlReaderFromResource(final Resource resource, final boolean enableDateParsing,
+            final CompressionMethod compressionMethod)
+    {
+        this.resource = resource;
+        this.enableDateParsing = enableDateParsing;
+        this.compressionMethod = compressionMethod;
+    }
+
+    /**
+     * Reads all data from the file and send it to the sink.
+     */
+    @Override
+    public void run()
+    {
+        InputStream inputStream = null;
+
+        try
+        {
+            final SAXParser parser;
+
+            this.sink.initialize(Collections.<String, Object> emptyMap());
+
+            // make "-" an alias for /dev/stdin
+            if (this.resource.getName() != null && this.resource.getName().equals("-"))
+            {
+                inputStream = System.in;
+            }
+            else
+            {
+                inputStream = this.resource.read();
+            }
+
+            inputStream = new CompressionActivator(this.compressionMethod)
+                    .createCompressionInputStream(inputStream);
+
+            parser = createParser();
+
+            parser.parse(inputStream, new OsmHandler(this.sink, this.enableDateParsing));
+
+            this.sink.complete();
+
+        }
+        catch (final SAXParseException e)
+        {
+            throw new OsmosisRuntimeException(
+                    "Unable to parse xml resource " + this.resource.getName() + ".  publicId=("
+                            + e.getPublicId() + "), systemId=(" + e.getSystemId() + "), lineNumber="
+                            + e.getLineNumber() + ", columnNumber=" + e.getColumnNumber() + ".",
+                    e);
+        }
+        catch (final SAXException e)
+        {
+            throw new OsmosisRuntimeException("Unable to parse XML.", e);
+        }
+        catch (final IOException e)
+        {
+            throw new OsmosisRuntimeException(
+                    "Unable to read XML file " + this.resource.getName() + ".", e);
+        }
+        finally
+        {
+            this.sink.release();
+
+            if (inputStream != null)
+            {
+                try
+                {
+                    inputStream.close();
+                }
+                catch (final IOException e)
+                {
+                    log.log(Level.SEVERE, "Unable to close input stream.", e);
+                }
+                inputStream = null;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSink(final Sink sink)
+    {
+        this.sink = sink;
+    }
+
+    /**
+     * Creates a new SAX parser.
+     *
+     * @return The newly created SAX parser.
+     */
+    private SAXParser createParser()
+    {
+        try
+        {
+            return SAXParserFactory.newInstance().newSAXParser();
+
+        }
+        catch (final ParserConfigurationException e)
+        {
+            throw new OsmosisRuntimeException("Unable to create SAX Parser.", e);
+        }
+        catch (final SAXException e)
+        {
+            throw new OsmosisRuntimeException("Unable to create SAX Parser.", e);
+        }
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
@@ -298,7 +298,15 @@ public @interface TestAtlas
 
     /**
      * Sometimes we want to load the Atlas directly from a file. Note that this setting takes
-     * precendence over directly defining values
+     * precedence over directly defining values
+     *
+     * @return the resource path to the osm file
+     */
+    String loadFromJosmOsmResource() default "";
+
+    /**
+     * Sometimes we want to load the Atlas directly from a file. Note that this setting takes
+     * precedence over directly defining values
      *
      * @return the resource path to the text file
      */

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -21,9 +21,13 @@ import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
+import org.openstreetmap.atlas.geography.atlas.pbf.OsmPbfLoader;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
+import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
 import org.openstreetmap.atlas.streaming.resource.ClassResource;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.tags.BuildingPartTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
@@ -102,7 +106,18 @@ public class TestAtlasHandler implements FieldHandler
             }
             catch (final Throwable e)
             {
-                throw new CoreException("Error creating field", e);
+                throw new CoreException("Error creating field {}", field, e);
+            }
+        }
+        else if (StringUtils.isNotEmpty(testAtlas.loadFromJosmOsmResource()))
+        {
+            try
+            {
+                loadFromJosmOsmResource(field, rule, context, testAtlas.loadFromJosmOsmResource());
+            }
+            catch (final Throwable e)
+            {
+                throw new CoreException("Error creating field {}", field, e);
             }
         }
         else
@@ -320,6 +335,33 @@ public class TestAtlasHandler implements FieldHandler
         }
     }
 
+    private void loadFromJosmOsmResource(final Field field, final CoreTestRule rule,
+            final CreationContext context, final String resourcePath)
+    {
+        final String packageName = rule.getClass().getPackage().getName().replaceAll("\\.", "/");
+        final String completeName = String.format("%s/%s", packageName, resourcePath);
+        final ClassResource resource = new ClassResource(completeName);
+        FileSuffix.suffixFor(completeName).ifPresent(suffix ->
+        {
+            if (suffix == FileSuffix.GZIP)
+            {
+                resource.setDecompressor(Decompressor.GZIP);
+            }
+        });
+        try
+        {
+            final StringResource osmFile = new StringResource();
+            new OsmFileParser().update(resource, osmFile);
+            final ByteArrayResource pbfFile = new ByteArrayResource();
+            new OsmFileToPbf().update(osmFile, pbfFile);
+            field.set(rule, new OsmPbfLoader(pbfFile, AtlasLoadingOption.withNoFilter()).read());
+        }
+        catch (IllegalArgumentException | IllegalAccessException e)
+        {
+            throw new CoreException("Error loading from text resource {}", resourcePath, e);
+        }
+    }
+
     private void loadFromTextResource(final Field field, final CoreTestRule rule,
             final CreationContext context, final String resourcePath)
     {
@@ -339,7 +381,7 @@ public class TestAtlasHandler implements FieldHandler
         }
         catch (IllegalArgumentException | IllegalAccessException e)
         {
-            throw new CoreException("Error locding from text resource", e);
+            throw new CoreException("Error loading from text resource {}", resourcePath, e);
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -358,7 +358,7 @@ public class TestAtlasHandler implements FieldHandler
         }
         catch (IllegalArgumentException | IllegalAccessException e)
         {
-            throw new CoreException("Error loading from text resource {}", resourcePath, e);
+            throw new CoreException("Error loading from JOSM osm resource {}", resourcePath, e);
         }
     }
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/OsmFileParserTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/OsmFileParserTest.java
@@ -1,0 +1,25 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+
+/**
+ * @author matthieun
+ */
+public class OsmFileParserTest
+{
+    @Test
+    public void testReplacement()
+    {
+        final Resource josmOsmFile = new InputStreamResource(
+                () -> OsmFileParserTest.class.getResourceAsStream("josmOsmFile.osm"));
+        final Resource osmFile = new InputStreamResource(
+                () -> OsmFileParserTest.class.getResourceAsStream("osmFile.osm"));
+        final StringResource result = new StringResource();
+        new OsmFileParser().update(josmOsmFile, result);
+        Assert.assertEquals(osmFile.all(), result.all());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTest.java
@@ -1,0 +1,32 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author matthieun
+ */
+public class TestAtlasTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(TestAtlasTest.class);
+
+    @Rule
+    public final TestAtlasTestRule rule = new TestAtlasTestRule();
+
+    @Test
+    public void loadFromJosmOsmResourceTest()
+    {
+        final Atlas atlas = this.rule.getAtlasFromJosmOsmResource();
+        logger.info("{}", atlas);
+        Assert.assertEquals(4, atlas.numberOfNodes());
+        Assert.assertEquals(4, atlas.numberOfEdges());
+        Assert.assertEquals(3, atlas.numberOfAreas());
+        Assert.assertEquals(1, atlas.numberOfLines());
+        Assert.assertEquals(1, atlas.numberOfPoints());
+        Assert.assertEquals(1, atlas.numberOfRelations());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/testing/TestAtlasTestRule.java
@@ -1,0 +1,17 @@
+package org.openstreetmap.atlas.utilities.testing;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+
+/**
+ * @author matthieun
+ */
+public class TestAtlasTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "josmOsmFile.osm")
+    private Atlas atlasFromJosmOsmResource;
+
+    public Atlas getAtlasFromJosmOsmResource()
+    {
+        return this.atlasFromJosmOsmResource;
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/utilities/testing/josmOsmFile.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/testing/josmOsmFile.osm
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-1409998' action='modify' lat='7.01378166705' lon='-10.54718467843' />
+  <node id='-1409999' action='modify' lat='7.01400307686' lon='-10.54665453727' />
+  <node id='-1410001' action='modify' lat='7.01357328126' lon='-10.54613226949' />
+  <node id='-1410003' action='modify' lat='7.01317734799' lon='-10.54639734007' />
+  <node id='-1410005' action='modify' lat='7.01283872058' lon='-10.54584357876' />
+  <node id='-1410007' action='modify' lat='7.01390669848' lon='-10.54582520753' />
+  <node id='-1410009' action='modify' lat='7.01386502134' lon='-10.54528719299' />
+  <node id='-1410011' action='modify' lat='7.01352899926' lon='-10.54497750656' />
+  <node id='-1410013' action='modify' lat='7.01375561883' lon='-10.54479379428' />
+  <node id='-1410038' action='modify' lat='7.0143390986' lon='-10.54653381206' />
+  <node id='-1410039' action='modify' lat='7.01445631542' lon='-10.54617426087' />
+  <node id='-1410040' action='modify' lat='7.0142161719' lon='-10.5460947868' />
+  <node id='-1410041' action='modify' lat='7.01409895502' lon='-10.54645433798' />
+  <node id='-1410044' action='modify' lat='7.01328016806' lon='-10.54558045762' />
+  <node id='-1410045' action='modify' lat='7.01327244286' lon='-10.54497940386' />
+  <node id='-1410047' action='modify' lat='7.01296382279' lon='-10.54498343051' />
+  <node id='-1410049' action='modify' lat='7.01297154799' lon='-10.54558448427' />
+  <node id='-1410053' action='modify' lat='7.01316627317' lon='-10.54543612693' />
+  <node id='-1410054' action='modify' lat='7.01316237444' lon='-10.54513562601' />
+  <node id='-1410056' action='modify' lat='7.01306208877' lon='-10.54513694681' />
+  <node id='-1410058' action='modify' lat='7.0130659875' lon='-10.54543744773' />
+  <node id='-1410070' action='modify' lat='7.01345866903' lon='-10.54661517035'>
+    <tag k='natural' v='tree' />
+  </node>
+  <node id='-1410095' action='modify' lat='7.0145452395' lon='-10.54658593494' />
+  <node id='-1410096' action='modify' lat='7.01453752104' lon='-10.54579789937' />
+  <node id='-1410098' action='modify' lat='7.01414130659' lon='-10.54548164825' />
+  <node id='-1410100' action='modify' lat='7.01401781111' lon='-10.54494505824' />
+  <way id='-1410000' action='modify'>
+    <nd ref='-1409998' />
+    <nd ref='-1409999' />
+    <nd ref='-1410001' />
+    <nd ref='-1410003' />
+    <nd ref='-1410005' />
+    <tag k='highway' v='motorway' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-1410008' action='modify'>
+    <nd ref='-1410001' />
+    <nd ref='-1410007' />
+    <nd ref='-1410009' />
+    <nd ref='-1410011' />
+    <nd ref='-1410013' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='-1410042' action='modify'>
+    <nd ref='-1410038' />
+    <nd ref='-1410039' />
+    <nd ref='-1410040' />
+    <nd ref='-1410041' />
+    <nd ref='-1410038' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='-1410046' action='modify'>
+    <nd ref='-1410044' />
+    <nd ref='-1410045' />
+    <nd ref='-1410047' />
+    <nd ref='-1410049' />
+    <nd ref='-1410044' />
+  </way>
+  <way id='-1410055' action='modify'>
+    <nd ref='-1410053' />
+    <nd ref='-1410054' />
+    <nd ref='-1410056' />
+    <nd ref='-1410058' />
+    <nd ref='-1410053' />
+  </way>
+  <way id='-1410097' action='modify'>
+    <nd ref='-1410095' />
+    <nd ref='-1410096' />
+    <nd ref='-1410098' />
+    <nd ref='-1410100' />
+    <tag k='waterway' v='canal' />
+  </way>
+  <relation id='-1410065' action='modify'>
+    <member type='way' ref='-1410046' role='outer' />
+    <member type='way' ref='-1410055' role='inner' />
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/testing/osmFile.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/testing/osmFile.osm
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM' timestamp='2017-12-19T21:43:02Z'>
+  <node id='1409998' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01378166705' lon='-10.54718467843' />
+  <node id='1409999' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01400307686' lon='-10.54665453727' />
+  <node id='1410001' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01357328126' lon='-10.54613226949' />
+  <node id='1410003' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01317734799' lon='-10.54639734007' />
+  <node id='1410005' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01283872058' lon='-10.54584357876' />
+  <node id='1410007' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01390669848' lon='-10.54582520753' />
+  <node id='1410009' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01386502134' lon='-10.54528719299' />
+  <node id='1410011' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01352899926' lon='-10.54497750656' />
+  <node id='1410013' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01375561883' lon='-10.54479379428' />
+  <node id='1410038' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.0143390986' lon='-10.54653381206' />
+  <node id='1410039' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01445631542' lon='-10.54617426087' />
+  <node id='1410040' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.0142161719' lon='-10.5460947868' />
+  <node id='1410041' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01409895502' lon='-10.54645433798' />
+  <node id='1410044' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01328016806' lon='-10.54558045762' />
+  <node id='1410045' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01327244286' lon='-10.54497940386' />
+  <node id='1410047' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01296382279' lon='-10.54498343051' />
+  <node id='1410049' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01297154799' lon='-10.54558448427' />
+  <node id='1410053' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01316627317' lon='-10.54543612693' />
+  <node id='1410054' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01316237444' lon='-10.54513562601' />
+  <node id='1410056' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01306208877' lon='-10.54513694681' />
+  <node id='1410058' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.0130659875' lon='-10.54543744773' />
+  <node id='1410070' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01345866903' lon='-10.54661517035'>
+    <tag k='natural' v='tree' />
+  </node>
+  <node id='1410095' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.0145452395' lon='-10.54658593494' />
+  <node id='1410096' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01453752104' lon='-10.54579789937' />
+  <node id='1410098' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01414130659' lon='-10.54548164825' />
+  <node id='1410100' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify' lat='7.01401781111' lon='-10.54494505824' />
+  <way id='1410000' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1409998' />
+    <nd ref='1409999' />
+    <nd ref='1410001' />
+    <nd ref='1410003' />
+    <nd ref='1410005' />
+    <tag k='highway' v='motorway' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='1410008' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1410001' />
+    <nd ref='1410007' />
+    <nd ref='1410009' />
+    <nd ref='1410011' />
+    <nd ref='1410013' />
+    <tag k='highway' v='primary' />
+  </way>
+  <way id='1410042' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1410038' />
+    <nd ref='1410039' />
+    <nd ref='1410040' />
+    <nd ref='1410041' />
+    <nd ref='1410038' />
+    <tag k='building' v='yes' />
+  </way>
+  <way id='1410046' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1410044' />
+    <nd ref='1410045' />
+    <nd ref='1410047' />
+    <nd ref='1410049' />
+    <nd ref='1410044' />
+  </way>
+  <way id='1410055' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1410053' />
+    <nd ref='1410054' />
+    <nd ref='1410056' />
+    <nd ref='1410058' />
+    <nd ref='1410053' />
+  </way>
+  <way id='1410097' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <nd ref='1410095' />
+    <nd ref='1410096' />
+    <nd ref='1410098' />
+    <nd ref='1410100' />
+    <tag k='waterway' v='canal' />
+  </way>
+  <relation id='1410065' uid='1' version='1' changeset='1' user='myself' timestamp='2017-12-19T21:43:02Z' action='modify'>
+    <member type='way' ref='1410046' role='outer' />
+    <member type='way' ref='1410055' role='inner' />
+    <tag k='building' v='yes' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+</osm>


### PR DESCRIPTION
Hats off to @jklamer for this nice idea!

This PR adds the option to create a `@TestAtlas` from a .osm file created by JOSM. Thanks to this option, it is now way faster to go from test concept to implementation:

1. Open JOSM
1. File > New Layer
1. Start drawing and adding tags
1. Save as .osm file
1. Put that file in the resources package for the specific unit test
1. In the `CoreTestRule` define a `@TestAtlas(loadFromJosmOsmResource = "myNewJosmFile.osm")` annotation.
1. The `@TestAtlas` creation will alter the .osm file so it looks like existing OSM data (and not a JOSM change set), then load it in memory using a PBF (using osmosis) and finally create a test atlas from that pbf.

Below are a few screenshots of the process:

- Drawing in Josm

<img width="1310" alt="screen shot 2017-12-21 at 1 29 03 pm" src="https://user-images.githubusercontent.com/1944860/34275615-f307868e-e652-11e7-8610-7df2ac9f1936.png">

- The file saved by JOSM

<img width="657" alt="screen shot 2017-12-21 at 1 26 08 pm" src="https://user-images.githubusercontent.com/1944860/34275527-93b0d564-e652-11e7-84d3-25025c8e8fb4.png">

- The altered .osm file

<img width="1223" alt="screen shot 2017-12-21 at 1 26 59 pm" src="https://user-images.githubusercontent.com/1944860/34275547-a73fe39a-e652-11e7-9228-fb572842dc11.png">
