### PR TITLE
Check vehicle transportation access tags in PbfOneWay's forTag method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/MotorcarTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/MotorcarTag.java
@@ -1,0 +1,32 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM motorcar tag
+ *
+ * @author mkalender
+ */
+@Tag(taginfo = "http://taginfo.openstreetmap.org/keys/motorcar#values", osm = "http://wiki.openstreetmap.org/wiki/Key:motorcar")
+public enum MotorcarTag
+{
+    YES,
+    NO,
+    PRIVATE,
+    AGRICULTURAL,
+    PERMISSIVE,
+    DESTINATION,
+    DESIGNATED,
+    DELIVERY,
+    FORESTRY,
+    OFFICIAL,
+    CUSTOMERS,
+    EMERGENCY,
+    BUS,
+    SERVICE,
+    UNKNOWN;
+
+    @TagKey
+    public static final String KEY = "motorcar";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/VehicleTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/VehicleTag.java
@@ -1,0 +1,32 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM vehicle tag
+ *
+ * @author mkalender
+ */
+@Tag(taginfo = "http://taginfo.openstreetmap.org/keys/vehicle#values", osm = "http://wiki.openstreetmap.org/wiki/Key:vehicle")
+public enum VehicleTag
+{
+    YES,
+    NO,
+    PRIVATE,
+    AGRICULTURAL,
+    PERMISSIVE,
+    DESTINATION,
+    DESIGNATED,
+    DELIVERY,
+    FORESTRY,
+    OFFICIAL,
+    CUSTOMERS,
+    EMERGENCY,
+    BUS,
+    SERVICE,
+    UNKNOWN;
+
+    @TagKey
+    public static final String KEY = "vehicle";
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/PbfOneWayTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/PbfOneWayTest.java
@@ -6,8 +6,11 @@ import org.openstreetmap.atlas.geography.atlas.pbf.store.PbfOneWay;
 import org.openstreetmap.atlas.tags.AccessTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.JunctionTag;
+import org.openstreetmap.atlas.tags.MotorVehicleTag;
+import org.openstreetmap.atlas.tags.MotorcarTag;
 import org.openstreetmap.atlas.tags.OneWayTag;
 import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.VehicleTag;
 
 /**
  * Testing {@link PbfOneWay} functionality.
@@ -21,9 +24,53 @@ public class PbfOneWayTest
     {
         final Taggable primary = Taggable.with(HighwayTag.KEY,
                 HighwayTag.PRIMARY.name().toLowerCase());
-        final Taggable closedNeighborhood = Taggable.with(HighwayTag.KEY,
+        final Taggable primaryAccessNo = Taggable.with(HighwayTag.KEY,
                 HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
                 AccessTag.NO.name().toLowerCase());
+        final Taggable primaryAccessNoForVehicles = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), MotorVehicleTag.KEY,
+                MotorVehicleTag.NO.name().toLowerCase(), MotorcarTag.KEY,
+                MotorcarTag.NO.name().toLowerCase(), VehicleTag.KEY,
+                VehicleTag.NO.name().toLowerCase());
+        final Taggable primaryAccessNoMotorVehicleYes = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), MotorVehicleTag.KEY,
+                MotorVehicleTag.YES.name().toLowerCase());
+        final Taggable primaryAccessNoMotorCarYes = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), MotorcarTag.KEY,
+                MotorcarTag.YES.name().toLowerCase());
+        final Taggable primaryAccessNoVehicleYes = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), VehicleTag.KEY,
+                VehicleTag.YES.name().toLowerCase());
+        final Taggable primaryAccessNoMotorVehicleYesOneWayTrue = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), MotorVehicleTag.KEY,
+                MotorVehicleTag.YES.name().toLowerCase(), OneWayTag.KEY,
+                OneWayTag.TRUE.name().toLowerCase());
+        final Taggable primaryAccessNoMotorCarYesOneWayTrue = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), MotorcarTag.KEY,
+                MotorcarTag.YES.name().toLowerCase(), OneWayTag.KEY,
+                OneWayTag.TRUE.name().toLowerCase());
+        final Taggable primaryAccessNoVehicleYesOneWayTrue = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.NO.name().toLowerCase(), VehicleTag.KEY,
+                VehicleTag.YES.name().toLowerCase(), OneWayTag.KEY,
+                OneWayTag.TRUE.name().toLowerCase());
+        final Taggable primaryMotorVehicleNo = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), MotorVehicleTag.KEY,
+                MotorVehicleTag.NO.name().toLowerCase());
+        final Taggable primaryAccessYesVehicleNo = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.YES.name().toLowerCase(), MotorVehicleTag.KEY,
+                MotorVehicleTag.NO.name().toLowerCase());
+        final Taggable primaryAccessDeliveryMotorcarNo = Taggable.with(HighwayTag.KEY,
+                HighwayTag.PRIMARY.name().toLowerCase(), AccessTag.KEY,
+                AccessTag.DELIVERY.name().toLowerCase(), MotorcarTag.KEY,
+                MotorcarTag.NO.name().toLowerCase());
         final Taggable motorway = Taggable.with(HighwayTag.KEY,
                 HighwayTag.MOTORWAY.name().toLowerCase());
         final Taggable twoWayMotorway = Taggable.with(HighwayTag.KEY,
@@ -64,15 +111,26 @@ public class PbfOneWayTest
         Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(explicitlyTwoWay));
         Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(explicitlyTwoWayUsingZero));
         Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(explicitlyTwoWayUsingFalse));
+        Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(primaryAccessNoMotorVehicleYes));
+        Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(primaryAccessNoMotorCarYes));
+        Assert.assertEquals(PbfOneWay.NO, PbfOneWay.forTag(primaryAccessNoVehicleYes));
 
         Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(motorway));
         Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(roundabout));
         Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(explicitlyOneWay));
         Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(explicitlyOneWayUsingTrue));
         Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(explicitlyOneWayUsingOne));
+        Assert.assertEquals(PbfOneWay.YES,
+                PbfOneWay.forTag(primaryAccessNoMotorVehicleYesOneWayTrue));
+        Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(primaryAccessNoMotorCarYesOneWayTrue));
+        Assert.assertEquals(PbfOneWay.YES, PbfOneWay.forTag(primaryAccessNoVehicleYesOneWayTrue));
 
-        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(closedNeighborhood));
+        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(primaryAccessNo));
+        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(primaryAccessNoForVehicles));
         Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(oneWayReversible));
+        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(primaryMotorVehicleNo));
+        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(primaryAccessYesVehicleNo));
+        Assert.assertEquals(PbfOneWay.CLOSED, PbfOneWay.forTag(primaryAccessDeliveryMotorcarNo));
 
         Assert.assertEquals(PbfOneWay.REVERSED, PbfOneWay.forTag(oneWayReversed));
         Assert.assertEquals(PbfOneWay.REVERSED, PbfOneWay.forTag(oneWayReversedUsingNegativeOne));


### PR DESCRIPTION
This PR updates `PbfOneWay`'s `forTag` method to consider vehicle transportation access tags (**motor_vehicle**, **vehicle**, **motorcar**) for evaluation.

During Atlas generation a way is assumed to be `CLOSED` for all transportation modes if **access=no** is present. However, some users combine **access=no** with transportation modes like **foot**, **horse**, more importantly **motor_vehicle**, **motorcar** and **vehicle**. `forTag` method directly returns `CLOSED` if **access=no**, which results in conversion of an OSM way to Atlas line, not an edge. Here is an example OSM way that was converted to a line: http://www.openstreetmap.org/way/440253638#map=16/15.3111/-61.3699&layers=N

I fetched an Atlas and looked for an edge with OSM identifier 440253638, it wasn't there. However, same Atlas had a line for OSM way 440253638. Here is the console output for the item:
> [Line: id=440253638000000, polyLine=LINESTRING (-61.3812215 15.3025888, -61.3810315 15.3027072, -61.3809322 15.302758, -61.3808693 15.3027875, -61.3808212 15.3028075, -61.3807599 15.3028353, -61.3806513 15.3028624, -61.3805538 15.302876, -61.3797885 15.3029584, -61.3793492 15.3030107, -61.3792464 15.3030147, -61.3781583 15.3031033, -61.3779847 15.3031211, -61.3769618 15.3032052, -61.3767924 15.303224, -61.3757657 15.3033131, -61.37564 15.3033302, -61.3755661 15.3033427, -61.3754507 15.3033924, -61.3753188 15.3035185, -61.3751307 15.3037185, -61.3750543 15.303778, -61.3750006 15.3038337, -61.3748075 15.3039747, -61.3746697 15.3040775, -61.3744296 15.3042952, -61.374327 15.3043877, -61.374259 15.304452, -61.3741875 15.3045307, -61.3741169 15.3045852, -61.3740031 15.304682, -61.3738576 15.3047577, -61.3736068 15.304845, -61.3732084 15.3049069, -61.3730129 15.3049061, -61.3725687 15.3049101, -61.3723169 15.3049162, -61.3721984 15.3049276, -61.3720917 15.3049446, -61.3719452 15.3049896, -61.3718456 15.3050308, -61.371729 15.305076, -61.371668 15.305087, -61.371599 15.305091, -61.371526 15.305089, -61.371374 15.305084, -61.371298 15.305091, -61.371222 15.305099, -61.371147 15.305115, -61.371007 15.305182, -61.3709331 15.3052115, -61.3708635 15.3052433, -61.3707671 15.3052734, -61.3706118 15.3053032, -61.3703829 15.3053262, -61.3702751 15.305355, -61.3701772 15.3053903, -61.3699693 15.3054474, -61.3693804 15.3057324, -61.369161 15.3058556, -61.368986 15.3059521, -61.3688035 15.3060863, -61.3684715 15.3063737, -61.3682549 15.3065707, -61.3681006 15.3066492, -61.3679299 15.3067187, -61.3675809 15.3068234, -61.3670215 15.3070006, -61.3666627 15.3071179, -61.3663179 15.3072279, -61.3661485 15.3072798, -61.3658631 15.307377, -61.3656969 15.3074821, -61.3655905 15.3075989, -61.3654452 15.3078321, -61.3653229 15.3080218, -61.3651677 15.3081862, -61.3649331 15.3084074, -61.3645636 15.3087405, -61.3641999 15.3090442, -61.3638741 15.3094794, -61.363618 15.3097577, -61.3634979 15.3099258, -61.3633462 15.3102335, -61.363333 15.3103001, -61.3631955 15.3104643, -61.3630688 15.3105921, -61.3628892 15.3107638, -61.3627485 15.310839, -61.3625271 15.3109112, -61.3623422 15.3109901, -61.3622685 15.3110491, -61.3622038 15.3111255, -61.3620489 15.3113673, -61.3618494 15.3116486, -61.3616569 15.3118175, -61.3613805 15.3119892, -61.3611396 15.3121096, -61.360914 15.3122271, -61.3606393 15.3124423, -61.3604915 15.3126239, -61.3603935 15.3128419, -61.3602196 15.3132456, -61.3598159 15.3141033, -61.3597608 15.3142313, -61.3597558 15.3143891, -61.3597644 15.3146414, -61.3597486 15.3148247, -61.3596949 15.3150243, -61.3595519 15.3152511, -61.3593347 15.3155892, -61.3593061 15.3156922, -61.35925 15.3158555, -61.359185 15.3160826, -61.3591522 15.3163056, -61.3591143 15.3164857, -61.3590556 15.3167979, -61.3589386 15.3171463, -61.3589254 15.317316, -61.358981 15.3174859, -61.3590287 15.3176613, -61.3589922 15.3178849, -61.3589278 15.3180561, -61.3588665 15.318334, -61.3588383 15.3184077, -61.3588021 15.3184853, -61.358731 15.318559, -61.3585955 15.3186922, -61.3585432 15.3187893, -61.358495 15.3189238, -61.3584306 15.3192096, -61.3583099 15.3199883, -61.3582977 15.3205514), [Tags: [last_edit_changeset => 53811863], [access => no], [bicycle => yes], [maxspeed => 30 mph], [source => GPS/Bing], [oneway => no], [horse => yes], [last_edit_user_name => Paulish], [motor_vehicle => yes], [last_edit_time => 1510769625000], [last_edit_user_id => 4022664], [name => Valley Road], [highway => tertiary], [last_edit_version => 5], [foot => yes]]]

On the other hand, some users tag OSM ways with `motor_vehicle=no`, `vehicle=no` or `motorcar=no` to specify that road is closed for vehicles. For those cases, OSM ways should be converted to lines, not edges.

Here is an edge from Atlas for OSM way [442427323](http://www.openstreetmap.org/way/442427323#map=15/15.3614/-61.3403), which should rather be a line:
> [Edge: id=442427323000000, startNode=3662013554000000, endNode=1675559633000000, polyLine=LINESTRING (-61.3441521 15.3776763, -61.3441292 15.3776542, -61.3441186 15.3775757, -61.3440478 15.3775143, -61.3439062 15.3774563, -61.3428197 15.3765451, -61.3420841 15.3758829, -61.3416404 15.3756155, -61.3407839 15.3750748, -61.3412522 15.3743084, -61.3413878 15.3739578, -61.3414987 15.3735954, -61.341702 15.3727517, -61.3426079 15.3717297, -61.3428605 15.3700304, -61.3436985 15.3693708, -61.3446537 15.3687588, -61.3448447 15.3681528, -61.345313 15.3669525, -61.3450542 15.3646055, -61.3452637 15.3632864, -61.3464961 15.3621931, -61.3470322 15.3611295, -61.3477963 15.3609334, -61.3479689 15.3600897, -61.3468104 15.359745, -61.3454979 15.3589013, -61.3447584 15.3585269, -61.343791 15.3575999, -61.3415233 15.3567265, -61.3408517 15.3566254, -61.3400752 15.3563581, -61.3393173 15.3559599, -61.3384608 15.3557163, -61.3371729 15.3547715, -61.3359589 15.3533989, -61.3348929 15.3527512, -61.3346711 15.352353, -61.3337529 15.3517707, -61.3331737 15.3512716, -61.3334448 15.3495305, -61.3335249 15.3488352, -61.3338823 15.3476349, -61.3349549 15.3476865, -61.3349792 15.3476705, -61.3349718 15.3476449, -61.3347197 15.3475345), [Tags: [last_edit_changeset => 44408649], [access => yes], [bicycle => no], [surface => mud_and_roots], [horse => no], [trail_visibility => good], [last_edit_user_name => MintCondition], [motor_vehicle => no], [last_edit_time => 1481750388000], [last_edit_user_id => 3091009], [name => Waitukubuli trail segment 4], [width => 1], [sac_scale => demanding_mountain_hiking], [highway => path], [last_edit_version => 3], [foot => yes]]]

To fix the issue **motor_vehicle=yes**, **motorcar=yes**, **vehicle=yes** tags are checked if **access=no** is present. Also existence of `motor_vehicle=no`, `vehicle=no` or `motorcar=no` tags are checked. If one of these tags is attached to an OSM way, it will not be converted to an edge. `isNotAccessibleToVehicles` method is created to encapsulate the logic.

Unit test is updated accordingly.