### PR TITLE
Utility to match string names

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/matching/NameMatcher.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/matching/NameMatcher.java
@@ -1,0 +1,87 @@
+package org.openstreetmap.atlas.utilities.matching;
+
+import java.io.Serializable;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A {@code Predicate<String>} utility to find matching names
+ *
+ * @author brian_l_davis
+ */
+public class NameMatcher implements Serializable, Predicate<String>
+{
+    private static final long serialVersionUID = 5446378702031541204L;
+
+    private static final int DEFAULT_LEVENSHTEIN_DISTANCE_THRESHOLD = 1;
+
+    private final String sourceName;
+
+    // Uses Levenstein Distance to compare strings when true
+    private boolean fuzzyMatch = false;
+    // The minimum number of single-character differences allow to still match (see
+    // https://en.wikipedia.org/wiki/Levenshtein_distance)
+    private int lavenshteinDistanceThreshold = DEFAULT_LEVENSHTEIN_DISTANCE_THRESHOLD;
+    // Null values are considered a match when true
+    private boolean matchNull = false;
+    // Requires strings have the same characters and casing
+    private boolean exactMatch = false;
+
+    public NameMatcher(final String sourceName)
+    {
+        this.sourceName = sourceName;
+    }
+
+    public NameMatcher matchExactly()
+    {
+        this.exactMatch = true;
+        this.fuzzyMatch = false;
+        return this;
+    }
+
+    public NameMatcher matchNulls()
+    {
+        this.matchNull = true;
+        return this;
+    }
+
+    public NameMatcher matchSimilar()
+    {
+        this.exactMatch = false;
+        this.fuzzyMatch = true;
+        return this;
+    }
+
+    public NameMatcher matchSimilar(final int lavenshteinDistanceThreshold)
+    {
+        this.exactMatch = false;
+        this.fuzzyMatch = true;
+        this.lavenshteinDistanceThreshold = lavenshteinDistanceThreshold;
+        return this;
+    }
+
+    @Override
+    public boolean test(final String candidateName)
+    {
+        if (candidateName == null)
+        {
+            return matchNull;
+        }
+        if (exactMatch)
+        {
+            return candidateName.equals(sourceName);
+        }
+        if (fuzzyMatch)
+        {
+            return nameFuzzyMatch(sourceName, candidateName);
+        }
+        return candidateName.equalsIgnoreCase(sourceName);
+    }
+
+    private boolean nameFuzzyMatch(final String nameA, final String nameB)
+    {
+        return nameA.equalsIgnoreCase(nameB) || StringUtils.getLevenshteinDistance(nameA, nameB,
+                lavenshteinDistanceThreshold) != -1;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
@@ -1,0 +1,78 @@
+package org.openstreetmap.atlas.utilities.matching;
+
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link NameMatcher}
+ *
+ * @author brian_l_davis
+ */
+public class NameMatcherTestCase
+{
+    private final String[] data = new String[] { "Main Street", "main street", "Rain Street",
+            "Second Street", "Second Avenue", null };
+    private final String source = "Main Street";
+
+    @Test
+    public void testExactMatch()
+    {
+        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchExactly())
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street" }, results);
+    }
+
+    @Test
+    public void testExactMatchWithNulls()
+    {
+        final String[] results = Stream.of(data)
+                .filter(new NameMatcher(source).matchExactly().matchNulls()).toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street", null }, results);
+    }
+
+    @Test
+    public void testFuzzyMatch()
+    {
+        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchSimilar())
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street" },
+                results);
+    }
+
+    @Test
+    public void testFuzzyMatchWithNulls()
+    {
+        final String[] results = Stream.of(data)
+                .filter(new NameMatcher(source).matchSimilar().matchNulls()).toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street", null },
+                results);
+    }
+
+    @Test
+    public void testReallyFuzzyMatch()
+    {
+        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchSimilar(10))
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(
+                new String[] { "Main Street", "main street", "Rain Street", "Second Street" },
+                results);
+    }
+
+    @Test
+    public void testUncasedMatch()
+    {
+        final String[] results = Stream.of(data).filter(new NameMatcher(source))
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street", "main street" }, results);
+    }
+
+    @Test
+    public void testUncasedMatchWithNulls()
+    {
+        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchNulls())
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(new String[] { "Main Street", "main street", null }, results);
+    }
+}


### PR DESCRIPTION
Credits to @davis20 

This is a small utility to match names. The default usage ignores case while matching, but supports exact and fuzzy matching as well.