### PR TITLE
Fix rectangle parsing issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapArchiver.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapArchiver.java
@@ -34,7 +34,7 @@ public class CountryBoundaryMapArchiver extends Command
             path -> new File(path));
     private static final Switch<Rectangle> BOUNDS = new Switch<>("bounds", "The bounds",
             rectangle -> Rectangle.forString(rectangle), Optionality.OPTIONAL,
-            Rectangle.MAXIMUM.toString());
+            Rectangle.MAXIMUM.toCompactString());
     private static final Switch<Boolean> CREATE_SPATIAL_INDEX = new Switch<>("createSpatialIndex",
             "Default true, performance optimization to create and serialize a spatial index.",
             Boolean::parseBoolean, Optionality.OPTIONAL, Boolean.FALSE.toString());


### PR DESCRIPTION
When parsing the `BOUNDS` parameter in the `CountryBoundaryMapArchiver`, the default value would never be accepted:
```
org.openstreetmap.atlas.exception.CoreException: Invalid Rectangle String: POLYGON ((-180 -90, -180 90, 179.9999999 90, 179.9999999 -90, -180 -90))
```

This simple change fixes that issue.