### PR TITLE
Thread safety on the AtlasFeatureCountsSubCommand

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommand.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.command;
 
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -75,7 +76,8 @@ public class AtlasFeatureCountsSubCommand extends AbstractAtlasSubCommand
     {
         final File file = (File) command.get(OUTPUT_PARAMETER);
 
-        try (PrintStream out = new PrintStream(new FileOutputStream(file.getFile(), true)))
+        try (PrintStream out = new PrintStream(
+                new BufferedOutputStream(new FileOutputStream(file.getFile(), true))))
         {
             for (final String country : this.featureCounts.rowKeySet())
             {
@@ -155,11 +157,14 @@ public class AtlasFeatureCountsSubCommand extends AbstractAtlasSubCommand
         }
 
         // check if there's already a value in the Table
-        if (this.featureCounts.contains(country, type))
+        synchronized (this)
         {
-            oldCount = this.featureCounts.get(country, type);
-        }
+            if (this.featureCounts.contains(country, type))
+            {
+                oldCount = this.featureCounts.get(country, type);
+            }
 
-        this.featureCounts.put(country, type, oldCount + additionalCount);
+            this.featureCounts.put(country, type, oldCount + additionalCount);
+        }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
@@ -267,6 +267,10 @@ public @interface TestAtlas
     // This is for identifiers: by default they will be auto-generated
     String AUTO_GENERATED = "<auto>";
 
+    // This is for the atlas metadata: we only add the ISO country code if it is something besides
+    // unknown
+    String UNKNOWN_ISO_COUNTRY = "UNKNOWN";
+
     /**
      * Areas we want added to the atlas
      *
@@ -288,6 +292,13 @@ public @interface TestAtlas
      * @return the array of edges we want added to the atlas
      */
     Edge[] edges() default {};
+
+    /**
+     * ISO Country Code of the Atlas
+     * 
+     * @return a string containing the ISO3 character code of the country or UNKNOWN if not set
+     */
+    String iso() default UNKNOWN_ISO_COUNTRY;
 
     /**
      * Lines we want added to the atlas

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.geography.Longitude;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.builder.AtlasSize;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
@@ -32,6 +33,7 @@ import org.openstreetmap.atlas.tags.BuildingPartTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area.Known;
@@ -204,8 +206,18 @@ public class TestAtlasHandler implements FieldHandler
     {
 
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
-        builder.setSizeEstimates(convertSizeEstimates(testAtlas.size()));
-
+        final AtlasSize size = convertSizeEstimates(testAtlas.size());
+        final String iso = testAtlas.iso();
+        if (!iso.equals(TestAtlas.UNKNOWN_ISO_COUNTRY))
+        {
+            final AtlasMetaData metaData = new AtlasMetaData(size, true, null, null, iso, null,
+                    Maps.hashMap());
+            builder.withMetaData(metaData);
+        }
+        else
+        {
+            builder.setSizeEstimates(size);
+        }
         handle(builder, testAtlas.nodes());
         handle(builder, testAtlas.edges());
         handle(builder, testAtlas.areas());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCase.java
@@ -8,8 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.openstreetmap.atlas.streaming.resource.File;
-
-import com.google.common.collect.Iterables;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 
 /**
  * Test case verifying that protecting against multiple concurrent threads in the AtlasReader report

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCase.java
@@ -1,0 +1,74 @@
+package org.openstreetmap.atlas.geography.atlas.command;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.openstreetmap.atlas.streaming.resource.File;
+
+/**
+ * Test case verifying that protecting against multiple concurrent threads in the AtlasReader report
+ * the right output AtlasFeatureCountsSubCommand class
+ * 
+ * @author cstaylor
+ */
+public class AtlasFeatureCountsSubCommandTestCase
+{
+    @ClassRule
+    public static AtlasFeatureCountsSubCommandTestCaseRule setup = new AtlasFeatureCountsSubCommandTestCaseRule();
+
+    private static Path temporaryPath;
+
+    @AfterClass
+    public static void cleanupAtlasesOnDisk() throws IOException
+    {
+        Files.walk(temporaryPath).filter(Files::isRegularFile).forEach(path ->
+        {
+            try
+            {
+                Files.deleteIfExists(path);
+            }
+            catch (final IOException oops)
+            {
+                throw new RuntimeException("Error when cleaning up", oops);
+            }
+        });
+        Files.deleteIfExists(temporaryPath);
+    }
+
+    @BeforeClass
+    public static void prepareAtlasesOnDisk() throws IOException
+    {
+        final Path path = Files.createTempDirectory("atlastest");
+        setup.getFirstAtlas().save(new File(path.resolve("first.atlas").toFile()));
+        setup.getSecondAtlas().save(new File(path.resolve("second.atlas").toFile()));
+        setup.getThirdAtlas().save(new File(path.resolve("third.atlas").toFile()));
+        setup.getFourthAtlas().save(new File(path.resolve("fourth.atlas").toFile()));
+        temporaryPath = path;
+    }
+
+    @Test
+    public void testThreadSafety() throws IOException
+    {
+        final Path outputPath = Files.createTempFile("atlas", ".stats");
+        try
+        {
+            AtlasReader.main("featureCounts", String.format("-input=%s", this.temporaryPath),
+                    "-parallel", String.format("-output=%s", outputPath));
+            Files.lines(outputPath).filter(line -> line.contains("JP-NODE")).forEach(line ->
+            {
+                final String[] fields = line.split(":");
+                Assert.assertEquals(4, Integer.parseInt(fields[1].trim()));
+            });
+        }
+        finally
+        {
+            Files.deleteIfExists(outputPath);
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/command/AtlasFeatureCountsSubCommandTestCaseRule.java
@@ -1,0 +1,52 @@
+package org.openstreetmap.atlas.geography.atlas.command;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Test Fixture for the AtlasFeatureCountsSubCommandTestCase class
+ *
+ * @author cstaylor
+ */
+public class AtlasFeatureCountsSubCommandTestCaseRule extends CoreTestRule
+{
+    private static final String ONE = "37.33,-122.00";
+    private static final String TWO = "37.33,-122.03";
+    private static final String THREE = "37.32,-122.03";
+    private static final String FOUR = "37.32,-122.00";
+
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)) }, iso = "JPN")
+    private Atlas firstAtlas;
+
+    @TestAtlas(nodes = { @Node(id = "2", coordinates = @Loc(value = TWO)) }, iso = "JPN")
+    private Atlas secondAtlas;
+
+    @TestAtlas(nodes = { @Node(id = "3", coordinates = @Loc(value = THREE)) }, iso = "JPN")
+    private Atlas thirdAtlas;
+
+    @TestAtlas(nodes = { @Node(id = "4", coordinates = @Loc(value = FOUR)) }, iso = "JPN")
+    private Atlas fourthAtlas;
+
+    public Atlas getFirstAtlas()
+    {
+        return this.firstAtlas;
+    }
+
+    public Atlas getFourthAtlas()
+    {
+        return this.fourthAtlas;
+    }
+
+    public Atlas getSecondAtlas()
+    {
+        return this.secondAtlas;
+    }
+
+    public Atlas getThirdAtlas()
+    {
+        return this.thirdAtlas;
+    }
+}


### PR DESCRIPTION
If `AtlasReader` is used with multiple shards it will use multiple threads in the `handle` method, meaning we need to be careful about how we store values in the non-concurrent hashmap.

I also wrapped the `FileOutputStream` in a `BufferedOutputStream` for smoother I/O performance.