### PR TITLE
Add debug statement when new shard is not within max bounds

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -101,6 +101,13 @@ public class DynamicAtlasPolicy
 
                 }
             }
+            else
+            {
+                logger.debug(
+                        "Skipping atlasFetcher for {} because shard bounds are outside the policy's maximumBounds",
+                        shard.getName());
+            }
+
             return Optional.empty();
         };
     }


### PR DESCRIPTION
Adding a debug statement in getAtlasFetcher for when the new shard to be fetched is outside the maximumBounds.

NOTE: Z1, X1, Y1 and similar 2's are here for example.

Before:
```
2018-01-12 14:32:55 INFO  DynamicAtlas:524 - DynamicAtlas([Z1-X1-Y1]): Loading new shard [Z2]-[X2]-[Y2] found no new Atlas.
```
The before log is somewhat misleading because, in actuality, there was no attempt to fetch the atlas.  By adding an extra debug statement, callers can understand why no new atlas was found.

After:
```
2018-01-12 14:32:55 DEBUG DynamicAtlasPolicy:106 - Skipping atlasFetcher for [Z2]-[X2]-[Y2] because shard bounds are outside the policy's maximumBounds
2018-01-12 14:32:55 INFO  DynamicAtlas:524 - DynamicAtlas([Z1]-[X1]-[Y1]): Loading new shard [Z2]-[X2]-[Y2] found no new Atlas.
```