### PR TITLE
Fixing Atlas intersecting Polygon methods

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -159,10 +159,6 @@ public abstract class AbstractAtlas extends BareAtlas
     public Iterable<Edge> edgesIntersecting(final Polygon polygon)
     {
         final Iterable<Edge> edges = this.getEdgeSpatialIndex().get(polygon.bounds());
-        if (polygon instanceof Rectangle)
-        {
-            return edges;
-        }
         return Iterables.filter(edges, edge ->
         {
             final PolyLine polyline = edge.asPolyLine();
@@ -233,10 +229,6 @@ public abstract class AbstractAtlas extends BareAtlas
     public Iterable<Line> linesIntersecting(final Polygon polygon)
     {
         final Iterable<Line> lines = this.getLineSpatialIndex().get(polygon.bounds());
-        if (polygon instanceof Rectangle)
-        {
-            return lines;
-        }
         return Iterables.filter(lines, line ->
         {
             final PolyLine polyline = line.asPolyLine();
@@ -302,10 +294,6 @@ public abstract class AbstractAtlas extends BareAtlas
     public Iterable<Relation> relationsWithEntitiesIntersecting(final Polygon polygon)
     {
         final Iterable<Relation> relations = this.getRelationSpatialIndex().get(polygon.bounds());
-        if (polygon instanceof Rectangle)
-        {
-            return relations;
-        }
         return Iterables.filter(relations, relation ->
         {
             return relation.intersects(polygon);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
@@ -1,0 +1,167 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+/**
+ * Tests atlas item intersection with {@link Polygon} functionality.
+ *
+ * @author mgostintsev
+ */
+public class AtlasItemIntersectionTest
+{
+    @Rule
+    public final AtlasItemIntersectionTestRule rule = new AtlasItemIntersectionTestRule();
+
+    @Test
+    public void testAreasIntersectingPolygon()
+    {
+        final Atlas atlas = this.rule.getIntersectionAtlas();
+
+        final Rectangle notTouching = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288925 47.618916)"),
+                Location.forWkt("POINT (-122.288935 47.618946)"));
+
+        final Rectangle fullyInside = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288798 47.618482)"),
+                Location.forWkt("POINT (-122.288788 47.618472)"));
+
+        final Rectangle touchingAtCorner = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.288635 47.618286)"));
+
+        final Rectangle overlapping = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.618416)"));
+
+        Assert.assertEquals("There should be zero intersecting areas", 0,
+                Iterables.size(atlas.areasIntersecting(notTouching)));
+
+        Assert.assertEquals("There should be a single intersecting area", 1,
+                Iterables.size(atlas.areasIntersecting(fullyInside)));
+
+        Assert.assertEquals("There should be a single intersecting area", 1,
+                Iterables.size(atlas.areasIntersecting(touchingAtCorner)));
+
+        Assert.assertEquals("There should be a single intersecting area", 1,
+                Iterables.size(atlas.areasIntersecting(overlapping)));
+    }
+
+    @Test
+    public void testEdgesIntersectingPolygon()
+    {
+        final Atlas atlas = this.rule.getIntersectionAtlas();
+
+        final Rectangle notTouching = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288798 47.618482)"),
+                Location.forWkt("POINT (-122.288788 47.618472)"));
+
+        final Rectangle touchingAtCorner = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.288635 47.618286)"));
+
+        final Rectangle overlapping = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.618416)"));
+
+        Assert.assertEquals("There should be zero intersections", 0,
+                Iterables.size(atlas.edgesIntersecting(notTouching)));
+
+        Assert.assertEquals("There should be a single intersection", 1,
+                Iterables.size(atlas.edgesIntersecting(touchingAtCorner)));
+
+        Assert.assertEquals("There should be a single intersection", 1,
+                Iterables.size(atlas.edgesIntersecting(overlapping)));
+    }
+
+    @Test
+    public void testLinesIntersectingPolygon()
+    {
+        final Atlas atlas = this.rule.getIntersectionAtlas();
+
+        final Rectangle notTouching = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288798 47.618482)"),
+                Location.forWkt("POINT (-122.288788 47.618472)"));
+
+        final Rectangle touchingAtCorner = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.288635 47.618286)"));
+
+        final Rectangle overlapping = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.618416)"));
+
+        Assert.assertEquals("There should be zero intersections", 0,
+                Iterables.size(atlas.linesIntersecting(notTouching)));
+
+        Assert.assertEquals("There should be a single intersection", 1,
+                Iterables.size(atlas.linesIntersecting(touchingAtCorner)));
+
+        Assert.assertEquals("There should be a single intersection", 1,
+                Iterables.size(atlas.linesIntersecting(overlapping)));
+    }
+
+    @Test
+    public void testNodesWithinPolygon()
+    {
+        final Atlas atlas = this.rule.getIntersectionAtlas();
+
+        final Rectangle notTouching = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288798 47.618482)"),
+                Location.forWkt("POINT (-122.288788 47.618472)"));
+
+        final Rectangle touchingAtCorner = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.618416)"));
+
+        final Rectangle containingMultipleNodes = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.621016)"));
+
+        Assert.assertEquals("There should be zero nodes in this Polygon", 0,
+                Iterables.size(atlas.nodesWithin(notTouching)));
+
+        Assert.assertEquals("There should be a single node in this Polygon", 1,
+                Iterables.size(atlas.nodesWithin(touchingAtCorner)));
+
+        Assert.assertEquals("There should be two nodes in this Polygon", 2,
+                Iterables.size(atlas.nodesWithin(containingMultipleNodes)));
+    }
+
+    @Test
+    public void testRelationsIntersectingPolygon()
+    {
+        final Atlas atlas = this.rule.getIntersectionAtlas();
+
+        final Rectangle notTouching = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.288798 47.618482)"),
+                Location.forWkt("POINT (-122.288788 47.618472)"));
+
+        final Rectangle intersectingSingleEdge = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.618416)"));
+
+        final Rectangle containingMultipleEdges = Rectangle.forCorners(
+                Location.forWkt("POINT (-122.2886447 47.6182798)"),
+                Location.forWkt("POINT (-122.289001 47.621016)"));
+
+        Assert.assertEquals("There should be no parts of the relation touching this Polygon", 0,
+                Iterables.size(atlas.relationsWithEntitiesIntersecting(notTouching)));
+
+        Assert.assertEquals(
+                "There should be a single edge, part of one relation, running through this Polygon",
+                1, Iterables.size(atlas.relationsWithEntitiesIntersecting(intersectingSingleEdge)));
+
+        Assert.assertEquals(
+                "There should be two edges, both part of the same relation, running through this Polygon",
+                1,
+                Iterables.size(atlas.relationsWithEntitiesIntersecting(containingMultipleEdges)));
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTestRule.java
@@ -1,0 +1,21 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * {@link AtlasItemIntersectionTest} test data.
+ *
+ * @author mgostintsev
+ */
+public class AtlasItemIntersectionTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromTextResource = "intersectionAtlas.atlas.txt")
+    private Atlas intersectionAtlas;
+
+    public Atlas getIntersectionAtlas()
+    {
+        return this.intersectionAtlas;
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/items/intersectionAtlas.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/items/intersectionAtlas.atlas.txt
@@ -1,0 +1,14 @@
+# Nodes
+3558267680000000 && 47.618416,-122.289001 && last_edit_user_name -> dle0 || last_edit_changeset -> 31582804 || last_edit_time -> 1432987007000 || last_edit_user_id -> 37744 || last_edit_version -> 1
+3558267681000000 && 47.618671,-122.289352 && last_edit_user_name -> dle0 || last_edit_changeset -> 31582804 || last_edit_time -> 1432987007000 || last_edit_user_id -> 37744 || last_edit_version -> 1 
+3558267682000000 && 47.618946,-122.288925 && last_edit_user_name -> dle0 || last_edit_changeset -> 31582804 || last_edit_time -> 1432987007000 || last_edit_user_id -> 37744 || last_edit_version -> 1 
+# Edges
+1234567000001 && 47.618416,-122.289001:47.618286,-122.288635:47.618492,-122.288788:47.618671,-122.289352 && highway -> trunk
+1234567000002 && 47.618671,-122.289352:47.618759,-122.289635:47.618946,-122.288925 && highway -> trunk
+# Areas
+247059838000000 && 47.618416,-122.289001:47.618286,-122.288635:47.618492,-122.288788:47.618671,-122.289352 && last_edit_changeset -> 20186822 || last_edit_user_name -> muralito || last_edit_time -> 1390609954000 || last_edit_user_id -> 755114 || last_edit_version -> 4
+# Lines
+1234599000001 && 47.618416,-122.289001:47.618286,-122.288635:47.618492,-122.288788:47.618671,-122.289352 && power -> line
+# Points
+# Relations
+5218860000000 && 1234567000001 -> from -> E || 1234567000002 -> to -> E || 3558267681000000 -> via -> N && last_edit_user_name -> dle0 || last_edit_changeset -> 41287685 || last_edit_time -> 1470490850000 || last_edit_user_id -> 37744 || type -> restriction || last_edit_version -> 4


### PR DESCRIPTION
This was an issue reported by @mertemin and I also ran into this when debugging routing issues. For all Atlas item intersection with `Polygon` methods, there was an optimization in place that directly returned the results from the spatial index, if the given `Polygon` was a `Rectangle`. However, for any `LineItem` or entity made up of `LineItem`s (see `Relation`s), this produced false positives. This is because the results from the spatial index relied on bounds intersections, but a `LineItem`'s bounds does not mean that it actually intersects the `Polygon`. This optimization actually makes sense for `Point`s, `Node`s and `Area`s - hence the logic for these methods is unchanged. See test case for more details.