### PR TITLE
Remove fail-fast condition from areasIntersecting

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -121,10 +121,6 @@ public abstract class AbstractAtlas extends BareAtlas
     public Iterable<Area> areasIntersecting(final Polygon polygon)
     {
         final Iterable<Area> areas = this.getAreaSpatialIndex().get(polygon.bounds());
-        if (polygon instanceof Rectangle)
-        {
-            return areas;
-        }
         return Iterables.filter(areas, area ->
         {
             final Polygon areaPolygon = area.asPolygon();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
@@ -54,6 +54,22 @@ public class AtlasItemIntersectionTest
     }
 
     @Test
+    public void testAreasNoIntersectingPolygon()
+    {
+        final Atlas atlas = this.rule.getNoIntersectionAtlas();
+
+        final Polygon triangle = new Polygon(Location.forString("47.6263, -122.209198"),
+                Location.forString("47.628685, -122.209305"),
+                Location.forString("47.628704, -122.211761"));
+
+        Assert.assertEquals("There should be no intersecting area", 0,
+                Iterables.size(atlas.areasIntersecting(triangle)));
+
+        Assert.assertEquals("There should be no intersecting area", 0,
+                Iterables.size(atlas.areasIntersecting(triangle.bounds())));
+    }
+
+    @Test
     public void testEdgesIntersectingPolygon()
     {
         final Atlas atlas = this.rule.getIntersectionAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTestRule.java
@@ -3,6 +3,8 @@ package org.openstreetmap.atlas.geography.atlas.items;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 
 /**
  * {@link AtlasItemIntersectionTest} test data.
@@ -11,11 +13,24 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas;
  */
 public class AtlasItemIntersectionTestRule extends CoreTestRule
 {
+    private static final String LOCATION_1 = "47.625534, -122.210083";
+    private static final String LOCATION_2 = "47.625576, -122.208305";
+    private static final String LOCATION_3 = "47.626934, -122.208412";
+
     @TestAtlas(loadFromTextResource = "intersectionAtlas.atlas.txt")
     private Atlas intersectionAtlas;
+
+    @TestAtlas(areas = { @Area(coordinates = { @Loc(value = LOCATION_1), @Loc(value = LOCATION_2),
+            @Loc(value = LOCATION_3), @Loc(value = LOCATION_1) }) })
+    private Atlas noIntersectionAtlas;
 
     public Atlas getIntersectionAtlas()
     {
         return this.intersectionAtlas;
+    }
+
+    public Atlas getNoIntersectionAtlas()
+    {
+        return this.noIntersectionAtlas;
     }
 }


### PR DESCRIPTION
This PR addresses one more issue with fail-fast condition in spatial queries (following https://github.com/osmlab/atlas/pull/62 from @MikeGost). In the case of `areasIntersecting` if given polygon was a rectangle, then results were returned without further filtering. However, spatial index is returning results based on feature bounds. So actual feature geometries don't have to intersect.

Fail-fast condition is removed and a test case is created. Test uses the following two triangles.
![screen shot 2018-01-23 at 2 05 42 pm](https://user-images.githubusercontent.com/597707/35303592-5a82306c-0047-11e8-9fe6-ffa5275fa8ee.png)

When you call `areasIntersecting` with orange triangle's bounds, the method was returning the purple triangle, which is a false positive. After the update, it doesn't return it.