### PR TITLE
Change log level to debug for subAtlas call

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -625,7 +625,7 @@ public abstract class BareAtlas implements Atlas
     @Override
     public Optional<Atlas> subAtlas(final Predicate<AtlasEntity> matcher)
     {
-        logger.info("Filtering Atlas {} with meta-data {}", this.getName(), this.metaData());
+        logger.debug("Filtering Atlas {} with meta-data {}", this.getName(), this.metaData());
         final Time begin = Time.now();
 
         // Using a predicate here can create wild changes in entity numbers. For example a predicate


### PR DESCRIPTION
Due to meta data of an atlas can be a lot, change the log level to debug to avoid log files becoming a big file. 