### PR TITLE
 Restrain DynamicAtlas in case of initial polygon

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -37,12 +37,17 @@ public class DynamicAtlasPolicy
     };
     private Predicate<AtlasEntity> atlasEntitiesToConsiderForExpansion = entity -> true;
     private boolean aggressivelyExploreRelations = false;
+    // In case the initial shards were found using a Polygon or a MultiPolygon, remember it to
+    // provide the initial shards shape. This will be useful to not over-extend when using
+    // extendIndefinitely=false
+    private Optional<MultiPolygon> shapeCoveringInitialShards = Optional.empty();
 
     public DynamicAtlasPolicy(final Function<Shard, Optional<Atlas>> atlasFetcher,
             final Sharding sharding, final MultiPolygon shapeCoveringInitialShards,
             final Polygon maximumBounds)
     {
         this.initialShards = new HashSet<>();
+        this.shapeCoveringInitialShards = Optional.of(shapeCoveringInitialShards);
         sharding.shards(shapeCoveringInitialShards).forEach(this.initialShards::add);
         this.atlasFetcher = atlasFetcher;
         this.maximumBounds = maximumBounds;
@@ -54,6 +59,8 @@ public class DynamicAtlasPolicy
             final Polygon maximumBounds)
     {
         this.initialShards = new HashSet<>();
+        this.shapeCoveringInitialShards = Optional
+                .of(MultiPolygon.forPolygon(shapeCoveringInitialShards));
         sharding.shards(shapeCoveringInitialShards).forEach(this.initialShards::add);
         this.atlasFetcher = atlasFetcher;
         this.maximumBounds = maximumBounds;
@@ -119,6 +126,10 @@ public class DynamicAtlasPolicy
 
     public MultiPolygon getInitialShardsBounds()
     {
+        if (this.shapeCoveringInitialShards.isPresent())
+        {
+            return this.shapeCoveringInitialShards.get();
+        }
         final MultiMap<Polygon, Polygon> outerToInners = new MultiMap<>();
         this.initialShards.forEach(shard -> outerToInners.put(shard.bounds(), new ArrayList<>()));
         return new MultiPolygon(outerToInners);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
@@ -76,7 +76,7 @@ public class DynamicAtlasRestrainedExpansionWithPolygonTest
     }
 
     @Test
-    public void testNotMovingTooFast()
+    public void testRestrainedExpansionWithPolygon()
     {
         Assert.assertEquals(2, this.dynamicAtlas.numberOfEdges());
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
@@ -1,0 +1,83 @@
+package org.openstreetmap.atlas.geography.atlas.dynamic;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
+import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasRestrainedExpansionWithPolygonTestRule;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * This test ensures that when the initial shards are supplied with a {@link Polygon} or
+ * {@link MultiPolygon}, and the expansion policy is withExtendIndefinitely=false, then the
+ * expansion does not consider the full initial shards for intersection, but the initial polygon.
+ *
+ * @author matthieun
+ */
+public class DynamicAtlasRestrainedExpansionWithPolygonTest
+{
+    @Rule
+    public DynamicAtlasRestrainedExpansionWithPolygonTestRule rule = new DynamicAtlasRestrainedExpansionWithPolygonTestRule();
+
+    private DynamicAtlas dynamicAtlas;
+    private Map<Shard, Atlas> store;
+
+    private final Supplier<DynamicAtlasPolicy> policySupplier = () ->
+    {
+        final Set<Shard> initialTiles = new HashSet<>();
+        initialTiles.add(new SlippyTile(6, 34, 6));
+        return new DynamicAtlasPolicy(shard ->
+        {
+            if (this.store.containsKey(shard))
+            {
+                return Optional.of(this.store.get(shard));
+            }
+            else
+            {
+                return Optional.empty();
+            }
+        }, new SlippyTileSharding(6),
+                initialTiles.iterator().next().bounds().expand(Distance.ONE_METER),
+                Rectangle.MAXIMUM).withExtendIndefinitely(false).withDeferredLoading(true);
+    };
+
+    @Before
+    public void prepare()
+    {
+        prepare(this.policySupplier.get());
+    }
+
+    public void prepare(final DynamicAtlasPolicy policy)
+    {
+        this.store = new HashMap<>();
+        this.store.put(new SlippyTile(5, 34, 6),
+                this.rule.getAtlas().subAtlas(new SlippyTile(5, 34, 6).bounds()).get());
+        this.store.put(new SlippyTile(6, 34, 6),
+                this.rule.getAtlas().subAtlas(new SlippyTile(6, 34, 6).bounds()).get());
+        this.store.put(new SlippyTile(4, 34, 6),
+                this.rule.getAtlas().subAtlas(new SlippyTile(4, 34, 6).bounds()).get());
+        this.dynamicAtlas = new DynamicAtlas(policy);
+        this.dynamicAtlas.preemptiveLoad();
+    }
+
+    @Test
+    public void testNotMovingTooFast()
+    {
+        Assert.assertEquals(2, this.dynamicAtlas.numberOfEdges());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasRestrainedExpansionWithPolygonTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasRestrainedExpansionWithPolygonTestRule.java
@@ -1,0 +1,19 @@
+package org.openstreetmap.atlas.geography.atlas.dynamic.rules;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * @author matthieun
+ */
+public class DynamicAtlasRestrainedExpansionWithPolygonTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "DynamicAtlasRestrainedExpansionWithPolygonTest.osm")
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasRestrainedExpansionWithPolygonTest.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasRestrainedExpansionWithPolygonTest.osm
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-110564' action='modify' lat='-13.47050823382' lon='-143.1336288672' />
+  <node id='-110565' action='modify' lat='-13.00612190883' lon='-143.62472547727' />
+  <node id='-110567' action='modify' lat='-13.36132075379' lon='-147.87621898724' />
+  <node id='-110576' action='modify' lat='-13.9067562404' lon='-151.35598925283' />
+  <node id='-110577' action='modify' lat='-12.9787776583' lon='-152.49252712184' />
+  <node id='-110586' action='modify' lat='-12.88304913169' lon='-155.98632871914' />
+  <node id='-110587' action='modify' lat='-14.72249022486' lon='-154.96204150387' />
+  <way id='-110566' action='modify'>
+    <nd ref='-110564' />
+    <nd ref='-110565' />
+    <nd ref='-110567' />
+    <tag k='highway' v='primary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-110578' action='modify'>
+    <nd ref='-110576' />
+    <nd ref='-110577' />
+    <tag k='highway' v='trunk' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-110588' action='modify'>
+    <nd ref='-110586' />
+    <nd ref='-110587' />
+    <tag k='highway' v='motorway' />
+    <tag k='oneway' v='yes' />
+  </way>
+</osm>


### PR DESCRIPTION
In DynamicAtlas, when the initial shards are supplied with a Polygon or MultiPolygon, and the expansion policy is withExtendIndefinitely=false, then the expansion needs not consider the full initial shards for intersection, but the initial polygon.

This PR fixes that issue. Also added one test.