### PR TITLE
Fixing OptionalIterable Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
@@ -9,6 +9,7 @@ import java.util.Optional;
  * @param <T>
  *            The type of the {@link Optional} iterator
  * @author cuthbertm
+ * @author jklamer
  */
 public class OptionalIterable<T> implements Iterable<T>
 {
@@ -31,17 +32,24 @@ public class OptionalIterable<T> implements Iterable<T>
             @Override
             public boolean hasNext()
             {
-                while (this.iterator.hasNext())
+                if (previousElement.isPresent())
                 {
-                    final Optional<T> current = this.iterator.next();
-                    if (current.isPresent())
-                    {
-                        this.previousElement = current;
-                        return true;
-                    }
-                    this.previousElement = Optional.empty();
+                    return true;
                 }
-                return false;
+                else
+                {
+                    while (this.iterator.hasNext())
+                    {
+                        final Optional<T> current = this.iterator.next();
+                        if (current.isPresent())
+                        {
+                            this.previousElement = current;
+                            return true;
+                        }
+                        this.previousElement = Optional.empty();
+                    }
+                    return false;
+                }
             }
 
             @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
@@ -46,7 +46,6 @@ public class OptionalIterable<T> implements Iterable<T>
                             this.previousElement = current;
                             return true;
                         }
-                        this.previousElement = Optional.empty();
                     }
                     return false;
                 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/OptionalIterableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/OptionalIterableTest.java
@@ -31,6 +31,8 @@ public class OptionalIterableTest
         Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(1), iterator.next());
         Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(2), iterator.next());
         Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(3), iterator.next());

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/OptionalIterableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/OptionalIterableTest.java
@@ -26,8 +26,8 @@ public class OptionalIterableTest
         list.add(Optional.of(4));
         list.add(Optional.empty());
 
-        final OptionalIterable<Integer> optIt = new OptionalIterable<>(list);
-        final Iterator<Integer> iterator = optIt.iterator();
+        final OptionalIterable<Integer> optionalIterable = new OptionalIterable<>(list);
+        final Iterator<Integer> iterator = optionalIterable.iterator();
         Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(1), iterator.next());
         Assert.assertTrue(iterator.hasNext());
@@ -36,7 +36,6 @@ public class OptionalIterableTest
         Assert.assertEquals(Integer.valueOf(2), iterator.next());
         Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(3), iterator.next());
-        Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(Integer.valueOf(4), iterator.next());
         Assert.assertFalse(iterator.hasNext());
         Assert.assertNull(iterator.next());


### PR DESCRIPTION
OptionalIterable's iterator's hasNext() method called next() on the underlying iterable, such that multiple hasNext Method calls in a row would result in lost item(s) depending on how many hasNext() calls were made. Added multiple hasNext() calls to the test and used the cached item as a hasNext() indicator. 