### PR TITLE
Keyword Configuration Overrides

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/Configuration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/Configuration.java
@@ -10,13 +10,13 @@ import java.util.function.Function;
 public interface Configuration
 {
     /**
-     * Returns a {@link Configurable} wrapper around the configured property.
+     * Returns a returns a copy Configuration specific to a keyword with overwritten values
      *
-     * @param key
-     *            property key
-     * @return a {@link Configurable} wrapper
+     * @param keyword
+     *            keyword string
+     * @return Configuration
      */
-    Configurable get(String key);
+    Configuration configurationForKeyword(String keyword);
 
     /**
      * Returns a {@link Configurable} wrapper around the configured property.
@@ -63,4 +63,13 @@ public interface Configuration
      * @return a {@link Configurable} wrapper
      */
     <Type> Configurable get(String key, Type defaultValue);
+
+    /**
+     * Returns a {@link Configurable} wrapper around the configured property.
+     *
+     * @param key
+     *            property key
+     * @return a {@link Configurable} wrapper
+     */
+    Configurable get(String key);
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/MergedConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/MergedConfiguration.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.utilities.configuration;
 
 import static org.openstreetmap.atlas.utilities.collections.Iterables.join;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -22,6 +23,7 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  *
  * @author cstaylor
  * @author brian_l_davis
+ * @author jklamer
  */
 public class MergedConfiguration implements Configuration
 {
@@ -36,8 +38,8 @@ public class MergedConfiguration implements Configuration
      */
     private class MergedConfigurable<Raw, Transformed> implements Configurable
     {
-        private final String key;
         private final Raw defaultValue;
+        private final String key;
         private final Function<Raw, Transformed> transform;
 
         MergedConfigurable(final String key, final Raw defaultValue,
@@ -87,9 +89,28 @@ public class MergedConfiguration implements Configuration
         this.configurations = Collections.unmodifiableList(mergedConfigurations);
     }
 
+    public MergedConfiguration(final List<Configuration> configurations)
+    {
+        this.configurations = Collections.unmodifiableList(configurations);
+    }
+
+    public MergedConfiguration(final Configuration... configurations)
+    {
+        this(Arrays.asList(configurations));
+    }
+
     public MergedConfiguration(final Resource first, final Resource... configurations)
     {
         this(first, Iterables.iterable(configurations));
+    }
+
+    public Configuration configurationForKeyword(final String keyword)
+    {
+        final List<Configuration> configurationsByKeyword = this.configurations.stream()
+                .map(configuration -> configuration.configurationForKeyword(keyword))
+                .collect(Collectors.toList());
+        return Iterables.equals(this.configurations, configurationsByKeyword) ? this
+                : new MergedConfiguration(configurationsByKeyword);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
@@ -1,7 +1,9 @@
 package org.openstreetmap.atlas.utilities.configuration;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -23,6 +25,7 @@ import com.google.common.base.Joiner;
  *
  * @author cstaylor
  * @author brian_l_davis
+ * @author jklamer
  */
 public class StandardConfiguration implements Configuration
 {
@@ -38,8 +41,8 @@ public class StandardConfiguration implements Configuration
      */
     private final class StandardConfigurable<Raw, Transformed> implements Configurable
     {
-        private final String key;
         private final Transformed defaultValue;
+        private final String key;
         private final Function<Raw, Transformed> transform;
 
         private StandardConfigurable(final String key, final Raw defaultValue,
@@ -75,6 +78,7 @@ public class StandardConfiguration implements Configuration
         }
     }
 
+    private static final String OVERRIDE_STRING = "override";
     private static final Logger logger = LoggerFactory.getLogger(StandardConfiguration.class);
     private Map<String, Object> configurationData;
     private final String name;
@@ -97,6 +101,24 @@ public class StandardConfiguration implements Configuration
         {
             throw new CoreException("Failure to load configuration", oops);
         }
+    }
+
+    public StandardConfiguration(final String name, final Map<String, Object> configurationData)
+    {
+        this.name = name;
+        this.configurationData = configurationData;
+    }
+
+    public Configuration configurationForKeyword(final String keyword)
+    {
+        final Optional<Map<String, Object>> overrideDataForKeyword = this
+                .getOverrideDataForKeyword(keyword, this.configurationData);
+        if (overrideDataForKeyword.isPresent())
+        {
+            return new MergedConfiguration(
+                    new StandardConfiguration(this.name, overrideDataForKeyword.get()), this);
+        }
+        return this;
     }
 
     @Override
@@ -129,6 +151,38 @@ public class StandardConfiguration implements Configuration
     public String toString()
     {
         return this.name != null ? this.name : super.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Map<String, Object>> getOverrideDataForKeyword(final String keyword,
+            final Map<String, Object> currentContext)
+    {
+        final List<String> overrideKeyPrefixList = Arrays.asList(OVERRIDE_STRING, keyword);
+        final String overrideKeyPrefixString = Joiner.on(".").join(overrideKeyPrefixList);
+        final Map<String, Object> overrideData = new HashMap<>();
+        for (final String key : currentContext.keySet())
+        {
+            if (!key.equals(OVERRIDE_STRING))
+            {
+                final String overrideKey = Joiner.on(".").join(overrideKeyPrefixString, key);
+                final Optional<Object> specificOverrideData = Optional
+                        .ofNullable(this.resolve(overrideKey, currentContext));
+                if (specificOverrideData.isPresent())
+                {
+                    overrideData.put(key, specificOverrideData.get());
+                }
+                else
+                {
+                    final Object nextContext = currentContext.get(key);
+                    if (nextContext instanceof Map)
+                    {
+                        this.getOverrideDataForKeyword(keyword, (Map) nextContext).ifPresent(
+                                moreOverrideData -> overrideData.put(key, moreOverrideData));
+                    }
+                }
+            }
+        }
+        return Optional.of(overrideData).filter(data -> !data.isEmpty());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
@@ -78,6 +78,7 @@ public class StandardConfiguration implements Configuration
         }
     }
 
+    // "override" is no longer available to use as a configuration key
     private static final String OVERRIDE_STRING = "override";
     private static final Logger logger = LoggerFactory.getLogger(StandardConfiguration.class);
     private Map<String, Object> configurationData;

--- a/src/test/java/org/openstreetmap/atlas/utilities/configuration/MergedConfigurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/configuration/MergedConfigurationTest.java
@@ -9,14 +9,20 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.streaming.StringInputStream;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.scalars.Angle;
 
 /**
+ * Test Cases for MergedConfiguration implementations
+ * 
  * @author brian_l_davis
+ * @author jklamer
  */
 public class MergedConfigurationTest
 {
 
     private static final String BASE_CONFIGURATION = "org/openstreetmap/atlas/utilities/configuration/application.json";
+    private static final String KEYWORD_OVERRIDDEN_CONFIGURATION = "org/openstreetmap/atlas/utilities/configuration/keywordOverridingApplication.json";
+    private static final String KEYWORD_OVERRIDDEN_DEV_CONFIGURATION = "org/openstreetmap/atlas/utilities/configuration/developmentOverriding.json";
     private static final String OVERRIDE_CONFIGURATION = "org/openstreetmap/atlas/utilities/configuration/development.json";
     private static final String PARTIAL_CONFIGURATION = "org/openstreetmap/atlas/utilities/configuration/feature.json";
 
@@ -45,8 +51,8 @@ public class MergedConfigurationTest
             final Configuration configuration = new MergedConfiguration(
                     new InputStreamResource(base), new InputStreamResource(override));
 
-            final String country = "AIA";
-            final String key = String.format("feature.%s.range", country);
+            final String keyword = "ABC";
+            final String key = String.format("feature.%s.range", keyword);
 
             final Optional<Map<String, Double>> rangeOption = configuration.get(key).valueOption();
 
@@ -57,12 +63,51 @@ public class MergedConfigurationTest
                 Assert.assertEquals(30.0, range.get("max"), 0.1);
             });
 
-            final String baseCountry = "AIA";
-            final String baseKey = String.format("feature.%s.range", baseCountry);
+            final String baseKeyword = "ABC";
+            final String baseKey = String.format("feature.%s.range", baseKeyword);
             final Double max = configuration.get(baseKey + ".min", Double.NaN).value();
             Assert.assertNotEquals(Double.NaN, max);
 
             Assert.assertFalse(configuration.get("foo").valueOption().isPresent());
+        }
+    }
+
+    @Test
+    public void testMergedOverriddenConfigurations() throws IOException
+    {
+        final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream countryOverriddenBaseConfiguration = loader
+                .getResourceAsStream(KEYWORD_OVERRIDDEN_CONFIGURATION);
+                InputStream developmentConfiguration = loader
+                        .getResourceAsStream(KEYWORD_OVERRIDDEN_DEV_CONFIGURATION))
+        {
+            final Configuration configuration = new MergedConfiguration(
+                    new InputStreamResource(countryOverriddenBaseConfiguration),
+                    new InputStreamResource(developmentConfiguration));
+
+            final String keyword1 = "ABC";
+            final String keyword2 = "XYZ";
+            final String keyword3 = "ZZZ";
+            final Configuration configuration1 = configuration.configurationForKeyword(keyword1);
+            final Configuration configuration2 = configuration.configurationForKeyword(keyword2);
+
+            final String minKey = "feature.range.min";
+            final String maxKey = "feature.range.max";
+
+            // Assert that configuration not changed for not overriding keywords.
+            Assert.assertEquals(configuration, configuration.configurationForKeyword(keyword3));
+            // value derived from default of higher layer development configuration instead of
+            // keyword specific view of base configuration
+            Assert.assertEquals(Angle.degrees(35.0),
+                    configuration2.get(maxKey, Angle::degrees).value());
+            // value derived from keyword specific view of development configuration
+            Assert.assertEquals(Angle.degrees(70.0),
+                    configuration1.get(maxKey, Angle::degrees).value());
+            // value derived from default of base configuration
+            Assert.assertEquals(Angle.degrees(10.0),
+                    configuration1.get(minKey, Angle::degrees).value());
+            Assert.assertEquals(Angle.degrees(10.0),
+                    configuration2.get(minKey, Angle::degrees).value());
         }
     }
 
@@ -76,8 +121,8 @@ public class MergedConfigurationTest
             final Configuration configuration = new MergedConfiguration(
                     new InputStreamResource(base), new InputStreamResource(partial));
 
-            final String country = "CYM";
-            final String key = String.format("feature.%s.range", country);
+            final String keyword = "XYZ";
+            final String key = String.format("feature.%s.range", keyword);
 
             final Optional<Map<String, Double>> rangeOption = configuration.get(key).valueOption();
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/configuration/MergedConfigurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/configuration/MergedConfigurationTest.java
@@ -76,13 +76,13 @@ public class MergedConfigurationTest
     public void testMergedOverriddenConfigurations() throws IOException
     {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try (InputStream countryOverriddenBaseConfiguration = loader
+        try (InputStream keywordOverriddenBaseConfiguration = loader
                 .getResourceAsStream(KEYWORD_OVERRIDDEN_CONFIGURATION);
                 InputStream developmentConfiguration = loader
                         .getResourceAsStream(KEYWORD_OVERRIDDEN_DEV_CONFIGURATION))
         {
             final Configuration configuration = new MergedConfiguration(
-                    new InputStreamResource(countryOverriddenBaseConfiguration),
+                    new InputStreamResource(keywordOverriddenBaseConfiguration),
                     new InputStreamResource(developmentConfiguration));
 
             final String keyword1 = "ABC";

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/application.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/application.json
@@ -1,6 +1,6 @@
 {
   "feature": {
-    "AIA": {
+    "ABC": {
       "enable": true,
       "list": [
         "nodes",

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/development.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/development.json
@@ -1,5 +1,5 @@
 {
-  "feature.AIA.range": {
+  "feature.ABC.range": {
     "max": 30.0,
     "min": 5.0
   }

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/developmentOverriding.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/developmentOverriding.json
@@ -1,0 +1,6 @@
+{
+  "feature.range": {
+    "max": 35.0,
+    "override.ABC.max":70.0
+  }
+}

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/feature.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/feature.json
@@ -1,6 +1,6 @@
 {
   "feature": {
-    "CYM": {
+    "XYZ": {
       "range": {
         "max": 40.0,
         "min": 20.0

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/keywordOverridingApplication.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/keywordOverridingApplication.json
@@ -1,0 +1,21 @@
+{
+  "feature":{
+    "enable":true,
+    "list":[
+      "nodes",
+      "edges"
+    ],
+    "range":{
+      "max":20.0,
+      "min":10.0
+    },
+    "override": {
+      "XYZ":{
+        "range":{
+          "max": 30.0
+        }
+      },
+      "ABC.list":["nodes"]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds functionality to the configuration framework by allowing flexible single or multiple element overriding per keyword in the same file.

To implement: construct a configuration the normal way. Then for every keyword specific configurable operation, call `Configuration::configurationForKeyword(String)`. This returns a configuration with a lightweight keyword specific configuration as a configuration layer over the original in a `MergedConfiguration`.

To do this, it looks at every key in the JSON other than 'override' and looks in the same context for data with key/data path of "override.key". If override data is present it populates a `configurationData` map that is then used to construct a `StandardConfiguration` for the top layer in the returned `MergedConfiguration`.

Downside: 'override' is no longer a viable configuration key.

Example Configurations:
This configuration will override the feature.range.max value for the Keyword ABC

```
{
  "feature.range": {
    "max": 35.0,
    "override.ABC.max":70.0
  }
}
```
This configuration will overwrite the feature.list for ABC and feature.range.max for XYZ.

```
{
  "feature":{
    "enable":true,
    "list":[
      "nodes",
      "edges"
    ],
    "range":{
      "max":20.0,
      "min":10.0
    },
    "override": {
      "XYZ":{
        "range":{
          "max": 30.0
        }
      },
      "ABC.list":["nodes"]
    }
  }
}
```