### PR TITLE
Allow updating AtlasMetaData tags during PackedAtlasCloning

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasMetaData.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasMetaData.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -100,7 +101,7 @@ public final class AtlasMetaData implements Serializable, Taggable
     @Override
     public Map<String, String> getTags()
     {
-        return this.tags;
+        return new HashMap<>(this.tags);
     }
 
     public boolean isOriginal()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
@@ -1,5 +1,9 @@
 package org.openstreetmap.atlas.geography.atlas.packed;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
@@ -15,6 +19,7 @@ import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 public class PackedAtlasCloner
 {
     private String shardName = null;
+    private Optional<Map<String, String>> additionalMetaDataTags = Optional.empty();
 
     public PackedAtlasCloner()
     {
@@ -36,11 +41,24 @@ public class PackedAtlasCloner
     {
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
         builder.setSizeEstimates(atlas.metaData().getSize());
-        final AtlasMetaData metaData = atlas.metaData();
+        AtlasMetaData metaData = atlas.metaData();
         if (this.shardName != null)
         {
             metaData.copyWithNewShardName(this.shardName);
         }
+
+        if (this.additionalMetaDataTags.isPresent())
+        {
+            // Create a new map to avoid modifying the old atlas tags
+            final Map<String, String> atlasTags = new HashMap<>(metaData.getTags());
+            atlasTags.putAll(this.additionalMetaDataTags.get());
+
+            metaData = new AtlasMetaData(metaData.getSize(), metaData.isOriginal(),
+                    metaData.getCodeVersion().orElse(null), metaData.getDataVersion().orElse(null),
+                    metaData.getCountry().orElse(null), metaData.getShardName().orElse(null),
+                    atlasTags);
+        }
+
         builder.setMetaData(metaData);
         atlas.nodes().forEach(
                 node -> builder.addNode(node.getIdentifier(), node.getLocation(), node.getTags()));
@@ -57,6 +75,23 @@ public class PackedAtlasCloner
         atlas.relationsLowerOrderFirst().forEach(relation -> addRelation(builder, relation));
 
         return (PackedAtlas) builder.get();
+    }
+
+    /**
+     * Adds the passed in extra tags to the {@link AtlasMetaData} when the atlas is cloned.
+     * <p>
+     * CAUTION: This will overwrite current tags if there is already a tag with the same key in the
+     * tag map.
+     *
+     * @param additionalMetaDataTags
+     *            Extra {@link AtlasMetaData} tags to add to the cloned atlas
+     * @return The updated {@link PackedAtlasCloner}
+     */
+    public PackedAtlasCloner withAdditionalMetaDataTags(
+            final Map<String, String> additionalMetaDataTags)
+    {
+        this.additionalMetaDataTags = Optional.ofNullable(additionalMetaDataTags);
+        return this;
     }
 
     private void addRelation(final PackedAtlasBuilder builder, final Relation relation)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.geography.atlas.packed;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -49,7 +48,6 @@ public class PackedAtlasCloner
 
         if (this.additionalMetaDataTags.isPresent())
         {
-            // Create a new map to avoid modifying the old atlas tags
             final Map<String, String> atlasTags = metaData.getTags();
             atlasTags.putAll(this.additionalMetaDataTags.get());
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasCloner.java
@@ -50,7 +50,7 @@ public class PackedAtlasCloner
         if (this.additionalMetaDataTags.isPresent())
         {
             // Create a new map to avoid modifying the old atlas tags
-            final Map<String, String> atlasTags = new HashMap<>(metaData.getTags());
+            final Map<String, String> atlasTags = metaData.getTags();
             atlasTags.putAll(this.additionalMetaDataTags.get());
 
             metaData = new AtlasMetaData(metaData.getSize(), metaData.isOriginal(),

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasClonerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasClonerTest.java
@@ -1,5 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.packed;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -10,6 +13,50 @@ import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
  */
 public class PackedAtlasClonerTest
 {
+    private static String TEST_KEY_1 = "TEST_KEY_1";
+    private static String TEST_KEY_2 = "TEST_KEY_2";
+    private static String TEST_KEY_3 = "TEST_KEY_3";
+    private static String TEST_KEY_4 = "TEST_KEY_4";
+
+    private static String TEST_VALUE_1 = "TEST_VALUE_1";
+    private static String TEST_VALUE_2 = "TEST_VALUE_2";
+    private static String TEST_VALUE_3 = "TEST_VALUE_3";
+    private static String TEST_VALUE_4 = "TEST_VALUE_4";
+
+    @Test
+    public void additionalMetaDataTagsTest()
+    {
+        final Map<String, String> additionalTags = new HashMap<>();
+        additionalTags.put(TEST_KEY_1, TEST_VALUE_1);
+        additionalTags.put(TEST_KEY_2, TEST_VALUE_2);
+        additionalTags.put(TEST_KEY_3, TEST_VALUE_3);
+        additionalTags.put(TEST_KEY_4, TEST_VALUE_4);
+
+        final Atlas atlas = RandomPackedAtlasBuilder.generate(50, 0);
+
+        final PackedAtlasCloner cloner = new PackedAtlasCloner()
+                .withAdditionalMetaDataTags(additionalTags);
+        final Atlas copy = cloner.cloneFrom(atlas);
+
+        final Map<String, String> initialTags = atlas.metaData().getTags();
+        final Map<String, String> finalTags = copy.metaData().getTags();
+
+        Assert.assertEquals("Unexpected number of tags found", initialTags.size() + 4,
+                finalTags.size());
+
+        // Validate tags that were found in the old atlas
+        initialTags.forEach((key, value) ->
+        {
+            Assert.assertEquals(value, finalTags.get(key));
+        });
+
+        // Validate additional tags added
+        Assert.assertEquals(TEST_VALUE_1, finalTags.get(TEST_KEY_1));
+        Assert.assertEquals(TEST_VALUE_2, finalTags.get(TEST_KEY_2));
+        Assert.assertEquals(TEST_VALUE_3, finalTags.get(TEST_KEY_3));
+        Assert.assertEquals(TEST_VALUE_4, finalTags.get(TEST_KEY_4));
+    }
+
     @Test
     public void cloneTest()
     {


### PR DESCRIPTION
- Adding functionality to update/add extra metadata tags during PackedAtlasCloning.
- Add tests to verify the new functionality.