### PR TITLE
Update ShardFileOverlapsPolygon to match shard resources of other types

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/ShardFileOverlapsPolygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/ShardFileOverlapsPolygon.java
@@ -6,10 +6,8 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FilenameUtils;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.sharding.DynamicTileSharding;
-import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,34 +68,33 @@ public class ShardFileOverlapsPolygon implements Predicate<Resource>
     public boolean test(final Resource resource)
     {
         boolean result = false;
-
-        if (resource instanceof File)
+        final String resourceName = resource.getName();
+        if (resourceName != null)
         {
-            final String filename = FilenameUtils.getName(((File) resource).getFile().getName());
-            final Matcher matcher = this.shardFilePattern.matcher(filename);
+            final Matcher matcher = this.shardFilePattern.matcher(resourceName);
             if (matcher.find())
             {
                 final String shardName = matcher.group(1);
                 if (this.shardsOverlappingPolygon.contains(shardName))
                 {
-                    logger.debug("Resource {} overlaps polygon.", resource.getName());
+                    logger.debug("Resource {} overlaps polygon.", resourceName);
                     result = true;
                 }
                 else
                 {
-                    logger.debug("Resource {} does not overlap polygon.", resource.getName());
+                    logger.debug("Resource {} does not overlap polygon.", resourceName);
                 }
             }
             else
             {
-                logger.debug("Resource {} does not match shard filename pattern.",
-                        resource.getName());
+                logger.debug("Resource {} does not match shard filename pattern.", resourceName);
             }
         }
         else
         {
-            logger.debug("Resource {} is not a File.", resource.getName());
+            logger.debug("Resource {} name is null.", resource.toString());
         }
+
         return result;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/ShardFileOverlapsPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/ShardFileOverlapsPolygonTest.java
@@ -8,7 +8,9 @@ import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.sharding.DynamicTileSharding;
+import org.openstreetmap.atlas.streaming.StringInputStream;
 import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 
@@ -79,11 +81,13 @@ public class ShardFileOverlapsPolygonTest
     }
 
     @Test
-    public void testNotAFile()
+    public void testInputStreamResource()
     {
-        // resources that are not files
+        // input stream resources require name to be set explicitly
+        Assert.assertTrue(PREDICATE.test(new InputStreamResource(new StringInputStream("foo bar"))
+                .withName("/some/path/XYZ_11-1095-641.atlas.gz")));
         Assert.assertFalse(
-                PREDICATE.test(new StringResource("/some/path/XYZ_11-1095-641.atlas.gz")));
+                PREDICATE.test(new InputStreamResource(new StringInputStream("foo bar"))));
     }
 
     @Test
@@ -112,4 +116,13 @@ public class ShardFileOverlapsPolygonTest
         Assert.assertFalse(PREDICATE.test(new File("/some/path/XYZ_10-548-321.atlas.gz")));
     }
 
+    @Test
+    public void testStringResource()
+    {
+        // string resources require name to be set explicitly
+        final String path = "/some/path/XYZ_11-1095-641.atlas.gz";
+        Assert.assertTrue(PREDICATE.test(new StringResource(path).withName(path)));
+        Assert.assertFalse(PREDICATE.test(new StringResource(path)));
+        Assert.assertFalse(PREDICATE.test(new StringResource(path).withName("foo")));
+    }
 }


### PR DESCRIPTION
Update ShardFileOverlapsPolygon to be able to match shard resources of other types. Previously only File resources could be matched. Rather than looking for the shard name in the file name explicitly, it will call the resources getName() method.