### PR TITLE
OsmPbfReader to close the pbf InputStreams once Atlas is produced

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoader.java
@@ -42,7 +42,6 @@ public class OsmPbfLoader
         {
             super(input);
             this.input = input;
-
         }
 
         @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoader.java
@@ -1,5 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.pbf;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.function.Supplier;
 
 import org.openstreetmap.atlas.geography.MultiPolygon;
@@ -7,6 +10,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
+import org.openstreetmap.atlas.streaming.Streams;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.slf4j.Logger;
@@ -24,11 +28,35 @@ import crosby.binary.osmosis.OsmosisReader;
  */
 public class OsmPbfLoader
 {
+    /**
+     * {@link Closeable} version of an {@link OsmosisReader} that prevents {@link InputStream}
+     * leaks.
+     *
+     * @author matthieun
+     */
+    public static class CloseableOsmosisReader extends OsmosisReader implements Closeable
+    {
+        private final InputStream input;
+
+        public CloseableOsmosisReader(final InputStream input)
+        {
+            super(input);
+            this.input = input;
+
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            this.input.close();
+        }
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(OsmPbfLoader.class);
     private final PackedAtlasBuilder builder = new PackedAtlasBuilder();
     private final OsmPbfProcessor processor;
-    private final Supplier<OsmosisReader> osmosisReaderSupplier;
-    private OsmosisReader reader;
+    private final Supplier<CloseableOsmosisReader> osmosisReaderSupplier;
+    private CloseableOsmosisReader reader;
     private Atlas atlas;
     private AtlasMetaData metaData = new AtlasMetaData();
     private final AtlasLoadingOption atlasLoadingOption;
@@ -51,10 +79,10 @@ public class OsmPbfLoader
     public OsmPbfLoader(final Resource resource, final MultiPolygon polygon,
             final AtlasLoadingOption loadingOption)
     {
-        this(() -> new OsmosisReader(resource.read()), polygon, loadingOption);
+        this(() -> new CloseableOsmosisReader(resource.read()), polygon, loadingOption);
     }
 
-    protected OsmPbfLoader(final Supplier<OsmosisReader> osmosisReaderSupplier,
+    protected OsmPbfLoader(final Supplier<CloseableOsmosisReader> osmosisReaderSupplier,
             final MultiPolygon polygon, final AtlasLoadingOption loadingOption)
     {
         this.osmosisReaderSupplier = osmosisReaderSupplier;
@@ -97,8 +125,8 @@ public class OsmPbfLoader
                 logger.info("No Atlas (empty) for shard {}",
                         this.metaData.getShardName().orElse("unknown"));
             }
-
         }
+        this.closeReader();
         return this.atlas;
     }
 
@@ -120,8 +148,17 @@ public class OsmPbfLoader
         return this;
     }
 
+    private void closeReader()
+    {
+        if (this.reader != null)
+        {
+            Streams.close(this.reader);
+        }
+    }
+
     private void makeNewReader()
     {
+        closeReader();
         this.reader = this.osmosisReaderSupplier.get();
         // set processor which define how to process OSM entities
         this.reader.setSink(this.processor);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmosisReaderMock.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmosisReaderMock.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.pbf;
 import java.util.HashMap;
 
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveObjectStore;
+import org.openstreetmap.atlas.geography.atlas.pbf.OsmPbfLoader.CloseableOsmosisReader;
 import org.openstreetmap.atlas.geography.atlas.pbf.converters.AtlasPrimitiveAreaToOsmosisWayConverter;
 import org.openstreetmap.atlas.geography.atlas.pbf.converters.AtlasPrimitiveLineItemToOsmosisWayConverter;
 import org.openstreetmap.atlas.geography.atlas.pbf.converters.AtlasPrimitiveLocationItemToOsmosisNodeConverter;
@@ -13,8 +14,6 @@ import org.openstreetmap.osmosis.core.container.v0_6.RelationContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.WayContainer;
 import org.openstreetmap.osmosis.core.task.v0_6.Sink;
 
-import crosby.binary.osmosis.OsmosisReader;
-
 /**
  * Mock an Osmosis reader to be able to test without any PBF resource. Note: This assumes all PBF
  * Nodes making up the Lines/Edges have been added before-hand.
@@ -22,7 +21,7 @@ import crosby.binary.osmosis.OsmosisReader;
  * @author matthieun
  * @author mgostintsev
  */
-public class OsmosisReaderMock extends OsmosisReader
+public class OsmosisReaderMock extends CloseableOsmosisReader
 {
     private final AtlasPrimitiveObjectStore source;
     private Sink sink;


### PR DESCRIPTION
The osmosis reader does not close the included input stream once the passes are done, which causes resource leaks.

This updates the `OsmPbfLoader` to keep track of those input streams and close them when the Atlas has been produced.

I am not sure how to unit-test this change directly, so suggestions are welcome! On the other side, it is already covered by all test classes using the `OsmosisReaderMock`.