### PR TITLE
Changed how compression works with ZipWritableResource

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipWritableResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipWritableResource.java
@@ -20,7 +20,9 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  */
 public class ZipWritableResource extends ZipResource
 {
-    private boolean compression = false;
+    private static final int ZIP_MAXIMUM_COMPRESSION_LEVEL = 9;
+
+    private boolean compression = true;
 
     public ZipWritableResource(final WritableResource source)
     {
@@ -58,12 +60,8 @@ public class ZipWritableResource extends ZipResource
         try (ZipOutputStream output = new ZipOutputStream(
                 new BufferedOutputStream(getWritableSource().write())))
         {
-            if (!this.compression)
-            {
-                // Do not compress the entries.
-                output.setMethod(ZipOutputStream.DEFLATED);
-                output.setLevel(Deflater.NO_COMPRESSION);
-            }
+            output.setLevel(
+                    this.compression ? ZIP_MAXIMUM_COMPRESSION_LEVEL : Deflater.NO_COMPRESSION);
             int counter = 0;
             for (final Resource resource : entries)
             {


### PR DESCRIPTION
`STORED` does not mean 0 compression, it means the caller needs to specify the actual sizes.

I’ve changed the default behavior to use highest compression.  A longer term solution would allow us to optionally specify the level per entry so we can disable compression for entries that have items that don’t compress well (image files, etc…)