### PR TITLE
Configurable Atlas entity filter based on include or exclude polygons

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -1,0 +1,168 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.geography.converters.WktPolygonConverter;
+import org.openstreetmap.atlas.geography.index.QuadTree;
+import org.openstreetmap.atlas.streaming.readers.GeoJsonReader;
+import org.openstreetmap.atlas.streaming.readers.json.serializers.PropertiesLocated;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.io.WKBReader;
+
+/**
+ * Configurable {@link AtlasEntity} filter that passes through anything that intersects with include
+ * polygons or anything that doesn't intersect with exclude polygons. Exclude polygons are looked at
+ * only if no include polygons exist. Include takes precedence and polygons intersecting with
+ * previously read polygons are dropped with a warning.
+ * 
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serializable
+{
+
+    public static final String EXCLUDED_POLYGONS_KEY = "filter.polygons.exclude";
+    public static final String INCLUDED_POLYGONS_KEY = "filter.polygons.include";
+    private static final PolygonStringConverter POLYGON_STRING_CONVERTER = new PolygonStringConverter();
+    private static final List<String> POLYGON_STRING_FORMATS = Arrays.asList("atlas", "geojson",
+            "wkt", "wkb");
+    private static final WkbPolygonConverter WKB_POLYGON_CONVERTER = new WkbPolygonConverter();
+    private static final WktPolygonConverter WKT_POLYGON_CONVERTER = new WktPolygonConverter();
+    private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
+    private static final long serialVersionUID = -3474748398986569205L;
+    private List<Polygon> exclude = new ArrayList<>();
+    private List<Polygon> include = new ArrayList<>();
+
+    private static StringConverter<Optional<List<Polygon>>> getConverterForFormat(
+            final String format)
+    {
+        switch (format)
+        {
+            case "atlas":
+                return string -> Optional
+                        .of(Collections.singletonList(POLYGON_STRING_CONVERTER.convert(string)));
+            case "geojson":
+                return string ->
+                {
+                    final List<Polygon> polygons = new ArrayList<>();
+                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
+                    while (reader.hasNext())
+                    {
+                        final PropertiesLocated propertiesLocated = reader.next();
+                        if (propertiesLocated.getItem() instanceof Polygon)
+                        {
+                            polygons.add((Polygon) propertiesLocated.getItem());
+                        }
+                        else
+                        {
+                            logger.warn("Polygon Filter does not support item {}",
+                                    propertiesLocated.toString());
+                        }
+                    }
+                    return Optional.of(polygons).filter(list -> !list.isEmpty());
+                };
+            case "wkt":
+                return string -> Optional.of(
+                        Collections.singletonList(WKT_POLYGON_CONVERTER.backwardConvert(string)));
+            case "wkb":
+                return string -> Optional.of(Collections.singletonList(
+                        WKB_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+            default:
+                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                        POLYGON_STRING_FORMATS);
+                return string -> Optional.empty();
+        }
+    }
+
+    private static Predicate<Polygon> notOverlapping(final QuadTree<Polygon> vettedPolygons,
+            final String polygonType)
+    {
+        return polygon ->
+        {
+            if (vettedPolygons.get(polygon.bounds()).stream().noneMatch(polygon::overlaps))
+            {
+                vettedPolygons.add(polygon.bounds(), polygon);
+                return true;
+            }
+            else
+            {
+                logger.warn("Dropping {} polygon {}", polygonType, polygon);
+                return false;
+            }
+        };
+    }
+
+    public AtlasEntityPolygonsFilter(final Map<String, List<String>> includePolygonMap,
+            final Map<String, List<String>> excludePolygonMap)
+    {
+        final QuadTree<Polygon> vettedPolygons = new QuadTree<>();
+        if (includePolygonMap != null)
+        {
+            this.include = this.getPolygonsFromMap(includePolygonMap)
+                    .filter(notOverlapping(vettedPolygons, "include")).collect(Collectors.toList());
+        }
+        if (excludePolygonMap != null)
+        {
+            this.exclude = this.getPolygonsFromMap(excludePolygonMap)
+                    .filter(notOverlapping(vettedPolygons, "exclude")).collect(Collectors.toList());
+        }
+    }
+
+    public AtlasEntityPolygonsFilter(final Configuration configuration)
+    {
+        this(configuration.get(INCLUDED_POLYGONS_KEY).value(),
+                configuration.get(EXCLUDED_POLYGONS_KEY).value());
+    }
+
+    @Override
+    public boolean test(final AtlasEntity object)
+    {
+        return noPolygons().or(isIncluded()).or(isNotExcluded()).test(object);
+    }
+
+    private Stream<Polygon> getPolygonsFromMap(final Map<String, List<String>> polygonLists)
+    {
+        if (polygonLists.isEmpty())
+        {
+            return Stream.empty();
+        }
+        return polygonLists.entrySet().stream()
+                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream()
+                        .map(getConverterForFormat(formatAndPolygonStrings.getKey())::convert)
+                        .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream));
+    }
+
+    private Predicate<AtlasEntity> isIncluded()
+    {
+        return entity -> this.include.stream().anyMatch(entity::intersects);
+    }
+
+    private Predicate<AtlasEntity> isNotExcluded()
+    {
+        // if there are include polygons the entity needs to be in them which is not tested here
+        return entity -> this.include.isEmpty()
+                && this.exclude.stream().noneMatch(entity::intersects);
+    }
+
+    private Predicate<AtlasEntity> noPolygons()
+    {
+        return entity -> this.include.isEmpty() && this.exclude.isEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -1,0 +1,193 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+
+import com.vividsolutions.jts.io.WKBWriter;
+
+/**
+ * Tests for {@link AtlasEntityPolygonsFilter}
+ *
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilterTest
+{
+    @Rule
+    public final AtlasEntityPolygonsFilterTestRule setup = new AtlasEntityPolygonsFilterTestRule();
+
+    /**
+     * Test Standard use cases by validating counts and asserting symmetry of include vs. exclude
+     */
+    @Test
+    public void testCounts()
+    {
+        final Atlas testCountsAtlas = this.setup.getTestCounts();
+        final String includeConfigurationFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"]}}";
+        final String excludeConfigurationFormat = "{\"filter.polygons\":{\"exclude.wkt\":[\"%s\"]}}";
+        final Polygon polygon1 = this.getPolygonWithName(testCountsAtlas, "polygon1");
+        final Polygon polygon2 = this.getPolygonWithName(testCountsAtlas, "polygon2");
+
+        final long totalPointCount = testCountsAtlas.numberOfPoints();
+        final long totalLineCount = testCountsAtlas.numberOfLines();
+        final long totalAreaCount = testCountsAtlas.numberOfAreas();
+        final long totalRelationCount = testCountsAtlas.numberOfRelations();
+        final AtlasEntityPolygonsFilter includePolygon1 = this
+                .constructFilter(includeConfigurationFormat, polygon1.toWkt());
+        final AtlasEntityPolygonsFilter includePolygon2 = this
+                .constructFilter(includeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter includePolygon1And2 = this.constructFilter(
+                includeConfigurationFormat,
+                String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
+        final AtlasEntityPolygonsFilter excludePolygon1 = this
+                .constructFilter(excludeConfigurationFormat, polygon1.toWkt());
+        final AtlasEntityPolygonsFilter excludePolygon2 = this
+                .constructFilter(excludeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter excludePolygon1And2 = this.constructFilter(
+                excludeConfigurationFormat,
+                String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
+
+        // testing polygon1
+        this.assertCounts(testCountsAtlas, includePolygon1, 2L, 3L, 1L, 0L);
+        this.assertCounts(testCountsAtlas, excludePolygon1, totalPointCount - 2L,
+                totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+        this.assertCounts(testCountsAtlas, includePolygon1.negate(), totalPointCount - 2L,
+                totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+
+        // testing polygon2
+        this.assertCounts(testCountsAtlas, includePolygon2, 0L, 2L, 1L, 1L);
+        this.assertCounts(testCountsAtlas, excludePolygon2, totalPointCount, totalLineCount - 2L,
+                totalAreaCount - 1L, totalRelationCount - 1L);
+        this.assertCounts(testCountsAtlas, excludePolygon2.negate(), 0L, 2L, 1L, 1L);
+
+        // testing tandem filter
+        this.assertCounts(testCountsAtlas, includePolygon1And2, totalPointCount - 1L,
+                totalLineCount - 2L, totalAreaCount, totalRelationCount);
+        this.assertCounts(testCountsAtlas, excludePolygon1And2, 1L, 2L, 0L, 0L);
+        this.assertCounts(testCountsAtlas, includePolygon1And2.negate(), 1L, 2L, 0L, 0L);
+
+    }
+
+    /**
+     * Tests every input form supported by the filter
+     */
+    @Test
+    public void testForms()
+    {
+        final Atlas testFormsAtlas = this.setup.getTestForm();
+        final String wktConfigurationStringFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"]}}";
+        final String wkbConfigurationStringFormat = "{\"filter.polygons\":{\"include.wkb\":[\"%s\"]}}";
+        final String atlasConfigurationStringFormat = "{\"filter.polygons\":{\"include.atlas\":[\"%s\"]}}";
+        final String geojsonConfigurationStringFormat = "{\"filter.polygons\":{\"include.geojson\":[\"%s\"]}}";
+        final Polygon includeBoundary = this.getPolygonWithName(testFormsAtlas, "include");
+
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(wktConfigurationStringFormat, includeBoundary.toWkt()), 2, 2,
+                2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(wkbConfigurationStringFormat,
+                        WKBWriter.toHex(new WkbPolygonConverter().convert(includeBoundary))),
+                2, 2, 2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(atlasConfigurationStringFormat,
+                        new PolygonStringConverter().backwardConvert(includeBoundary)),
+                2, 2, 2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(geojsonConfigurationStringFormat,
+                        includeBoundary.asGeoJson().toString().replaceAll("\"", "\\\\\"")),
+                2, 2, 2, 0);
+    }
+
+    /**
+     * Tests every arrangement of 1 include and 1 exclude polygon. Each situation the exclude
+     * polygon is either dropped for overlapping or ignored because of the include dominance of the
+     * filter. Each situation designed to have same count result.
+     */
+    @Test
+    public void testIncludeDominant()
+    {
+        final int numberOfCases = 4;
+        final Atlas includeExcludeArrangements = this.setup.getIncludeExcludeArrangements();
+        final String configurationStringFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"],\"exclude.wkt\":[\"%s\"]}}";
+        final Polygon includePolygon = this.getPolygonWithName(includeExcludeArrangements,
+                "include");
+
+        for (int caseNum = 1; caseNum <= numberOfCases; caseNum++)
+        {
+            final String caseString = String.format("case_%d", caseNum);
+            final String excludePolygonName = "exclude_".concat(caseString);
+            final Polygon excludePolygon = this.getPolygonWithName(includeExcludeArrangements,
+                    excludePolygonName);
+            final AtlasEntityPolygonsFilter filter = this.constructFilter(configurationStringFormat,
+                    includePolygon.toWkt(), excludePolygon.toWkt());
+
+            Assert.assertEquals(2L, StreamSupport
+                    .stream(includeExcludeArrangements
+                            .lines(line -> line.getTag("name")
+                                    .filter(value -> value.contains(caseString)).isPresent())
+                            .spliterator(), false)
+                    .filter(filter).map(line -> line.getTag("name")).filter(Optional::isPresent)
+                    .map(Optional::get).peek(name -> Assert.assertTrue(name.contains("included")))
+                    .count());
+
+            Assert.assertEquals(1L, StreamSupport
+                    .stream(includeExcludeArrangements
+                            .lines(line -> line.getTag("name")
+                                    .filter(value -> value.contains(caseString)).isPresent())
+                            .spliterator(), false)
+                    .filter(filter.negate()).map(line -> line.getTag("name"))
+                    .filter(Optional::isPresent).map(Optional::get)
+                    .peek(name -> Assert.assertTrue(name.contains("excluded"))).count());
+        }
+    }
+
+    private void assertCounts(final Atlas atlas, final Predicate<AtlasEntity> filter,
+            final long expectedPointCount, final long expectedLineCount,
+            final long expectedAreaCount, final long expectedRelationCount)
+    {
+        if (expectedPointCount >= 0)
+        {
+            Assert.assertEquals(expectedPointCount, Iterables.size(atlas.points(filter::test)));
+        }
+        if (expectedLineCount >= 0)
+        {
+            Assert.assertEquals(expectedLineCount, Iterables.size(atlas.lines(filter::test)));
+        }
+        if (expectedAreaCount >= 0)
+        {
+            Assert.assertEquals(expectedAreaCount, Iterables.size(atlas.areas(filter::test)));
+        }
+        if (expectedRelationCount >= 0)
+        {
+            Assert.assertEquals(expectedRelationCount,
+                    Iterables.size(atlas.relations(filter::test)));
+        }
+    }
+
+    private AtlasEntityPolygonsFilter constructFilter(final String format,
+            final Object... polygonStrings)
+    {
+        return new AtlasEntityPolygonsFilter(new StandardConfiguration(
+                new StringResource(String.format(format, polygonStrings))));
+    }
+
+    private Polygon getPolygonWithName(final Atlas atlas, final String name)
+    {
+        return StreamSupport
+                .stream(atlas.areas(area -> area.getTag("name")
+                        .filter(string -> string.equals(name)).isPresent()).spliterator(), false)
+                .findFirst().get().asPolygon();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
@@ -1,0 +1,35 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * Test Rule for {@link AtlasEntityPolygonsFilterTest}
+ *
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "includeExcludePolygonArrangements.osm")
+    private Atlas includeExcludeArrangements;
+    @TestAtlas(loadFromJosmOsmResource = "testCounts.osm")
+    private Atlas testCounts;
+    @TestAtlas(loadFromJosmOsmResource = "testForms.osm")
+    private Atlas testForm;
+
+    public Atlas getIncludeExcludeArrangements()
+    {
+        return this.includeExcludeArrangements;
+    }
+
+    public Atlas getTestCounts()
+    {
+        return this.testCounts;
+    }
+
+    public Atlas getTestForm()
+    {
+        return this.testForm;
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/includeExcludePolygonArrangements.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/includeExcludePolygonArrangements.osm
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-38986' action='modify' lat='26.97532157261' lon='-45.28701816559' />
+  <node id='-38988' action='modify' lat='26.97470963111' lon='-45.17200504303' />
+  <node id='-38990' action='modify' lat='26.87491874122' lon='-45.17440830231' />
+  <node id='-38992' action='modify' lat='26.87614370399' lon='-45.29045139313' />
+  <node id='-38994' action='modify' lat='26.95910399899' lon='-45.21869693756' />
+  <node id='-38996' action='modify' lat='26.95910399899' lon='-45.19363437653' />
+  <node id='-38998' action='modify' lat='26.93706883755' lon='-45.19397769928' />
+  <node id='-39000' action='modify' lat='26.93676276331' lon='-45.21869693756' />
+  <node id='-39002' action='modify' lat='26.88808639533' lon='-45.30864749908' />
+  <node id='-39004' action='modify' lat='26.88533050164' lon='-45.12874637604' />
+  <node id='-39006' action='modify' lat='26.78116977658' lon='-45.13114963531' />
+  <node id='-39008' action='modify' lat='26.78392820597' lon='-45.31585727692' />
+  <node id='-39010' action='modify' lat='26.98266461115' lon='-45.38589511871' />
+  <node id='-39012' action='modify' lat='26.98235866077' lon='-45.33439670563' />
+  <node id='-39014' action='modify' lat='26.93278372258' lon='-45.33508335114' />
+  <node id='-39016' action='modify' lat='26.93339589183' lon='-45.38658176422' />
+  <node id='-39018' action='modify' lat='27.05178835252' lon='-45.426407547' />
+  <node id='-39020' action='modify' lat='27.05056529863' lon='-45.0487525177' />
+  <node id='-39022' action='modify' lat='26.69286497728' lon='-45.04463264465' />
+  <node id='-39024' action='modify' lat='26.70513367403' lon='-45.44563362122' />
+  <node id='-39026' action='modify' lat='26.95436052931' lon='-45.23019807816' />
+  <node id='-39028' action='modify' lat='26.95436052931' lon='-45.20891206741' />
+  <node id='-39030' action='modify' lat='26.94808680378' lon='-45.24942415237' />
+  <node id='-39032' action='modify' lat='26.94823982563' lon='-45.23019807816' />
+  <node id='-39034' action='modify' lat='26.94833588924' lon='-45.16047971726' />
+  <node id='-39036' action='modify' lat='26.94848891076' lon='-45.14588850021' />
+  <node id='-39038' action='modify' lat='26.90462034578' lon='-45.26744876862' />
+  <node id='-39040' action='modify' lat='26.89237320746' lon='-45.26744876862' />
+  <node id='-39042' action='modify' lat='26.89145461855' lon='-45.257149086' />
+  <node id='-39044' action='modify' lat='26.87116721019' lon='-45.257149086' />
+  <node id='-39046' action='modify' lat='26.86955921994' lon='-45.26916521072' />
+  <node id='-39048' action='modify' lat='26.850110237' lon='-45.26950853348' />
+  <node id='-39050' action='modify' lat='26.96124607654' lon='-45.27774845123' />
+  <node id='-39052' action='modify' lat='26.96430611665' lon='-45.34469638824' />
+  <node id='-39054' action='modify' lat='26.9523714901' lon='-45.27362857819' />
+  <node id='-39056' action='modify' lat='26.95267752196' lon='-45.28427158356' />
+  <node id='-39058' action='modify' lat='26.97623947862' lon='-45.30590091705' />
+  <node id='-39060' action='modify' lat='26.97654544563' lon='-45.32203708649' />
+  <node id='-39062' action='modify' lat='26.9572679001' lon='-45.25680576324' />
+  <node id='-39064' action='modify' lat='26.96644809526' lon='-45.25680576324' />
+  <node id='-39066' action='modify' lat='26.96736607362' lon='-45.24616275787' />
+  <node id='-39068' action='modify' lat='27.0001024073' lon='-45.24547611237' />
+  <node id='-39070' action='modify' lat='26.99979650435' lon='-45.26195560455' />
+  <node id='-39072' action='modify' lat='27.02579528372' lon='-45.26195560455' />
+  <way id='-39074' action='modify'>
+    <nd ref='-38986' />
+    <nd ref='-38988' />
+    <nd ref='-38990' />
+    <nd ref='-38992' />
+    <nd ref='-38986' />
+    <tag k='name' v='include' />
+  </way>
+  <way id='-39076' action='modify'>
+    <nd ref='-38994' />
+    <nd ref='-38996' />
+    <nd ref='-38998' />
+    <nd ref='-39000' />
+    <nd ref='-38994' />
+    <tag k='name' v='exclude_case_1' />
+  </way>
+  <way id='-39078' action='modify'>
+    <nd ref='-39002' />
+    <nd ref='-39004' />
+    <nd ref='-39006' />
+    <nd ref='-39008' />
+    <nd ref='-39002' />
+    <tag k='name' v='exclude_case_2' />
+  </way>
+  <way id='-39080' action='modify'>
+    <nd ref='-39010' />
+    <nd ref='-39012' />
+    <nd ref='-39014' />
+    <nd ref='-39016' />
+    <nd ref='-39010' />
+    <tag k='name' v='exclude_case_3' />
+  </way>
+  <way id='-39082' action='modify'>
+    <nd ref='-39018' />
+    <nd ref='-39020' />
+    <nd ref='-39022' />
+    <nd ref='-39024' />
+    <nd ref='-39018' />
+    <tag k='name' v='exclude_case_4' />
+  </way>
+  <way id='-39084' action='modify'>
+    <nd ref='-39026' />
+    <nd ref='-39028' />
+    <tag k='name' v='case_1_included' />
+  </way>
+  <way id='-39086' action='modify'>
+    <nd ref='-39030' />
+    <nd ref='-39032' />
+    <tag k='name' v='case_1_included' />
+  </way>
+  <way id='-39088' action='modify'>
+    <nd ref='-39034' />
+    <nd ref='-39036' />
+    <tag k='name' v='case_1_excluded' />
+  </way>
+  <way id='-39090' action='modify'>
+    <nd ref='-39038' />
+    <nd ref='-39040' />
+    <tag k='name' v='case_2_included' />
+  </way>
+  <way id='-39092' action='modify'>
+    <nd ref='-39042' />
+    <nd ref='-39044' />
+    <tag k='name' v='case_2_included' />
+  </way>
+  <way id='-39094' action='modify'>
+    <nd ref='-39046' />
+    <nd ref='-39048' />
+    <tag k='name' v='case_2_excluded' />
+  </way>
+  <way id='-39096' action='modify'>
+    <nd ref='-39050' />
+    <nd ref='-39052' />
+    <tag k='name' v='case_3_included' />
+  </way>
+  <way id='-39098' action='modify'>
+    <nd ref='-39054' />
+    <nd ref='-39056' />
+    <tag k='name' v='case_3_included' />
+  </way>
+  <way id='-39100' action='modify'>
+    <nd ref='-39058' />
+    <nd ref='-39060' />
+    <tag k='name' v='case_3_excluded' />
+  </way>
+  <way id='-39102' action='modify'>
+    <nd ref='-39062' />
+    <nd ref='-39064' />
+    <tag k='name' v='case_4_included' />
+  </way>
+  <way id='-39104' action='modify'>
+    <nd ref='-39066' />
+    <nd ref='-39068' />
+    <tag k='name' v='case_4_included' />
+  </way>
+  <way id='-39106' action='modify'>
+    <nd ref='-39070' />
+    <nd ref='-39072' />
+    <tag k='name' v='case_4_excluded' />
+  </way>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/testCounts.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/testCounts.osm
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-39463' action='modify' lat='22.51657258543' lon='-81.15236564257' />
+  <node id='-39464' action='modify' lat='22.52022381399' lon='-81.11409741146' />
+  <node id='-39466' action='modify' lat='22.50727811384' lon='-81.07870378927' />
+  <node id='-39468' action='modify' lat='22.47092409354' lon='-81.0769071587' />
+  <node id='-39470' action='modify' lat='22.44933956686' lon='-81.11194145478' />
+  <node id='-39472' action='modify' lat='22.44817722775' lon='-81.17320655716' />
+  <node id='-39474' action='modify' lat='22.47407847354' lon='-81.19710174372' />
+  <node id='-39476' action='modify' lat='22.50910386294' lon='-81.19243050424' />
+  <node id='-39478' action='modify' lat='22.52885360709' lon='-81.15775553427' />
+  <node id='-39482' action='modify' lat='22.45564973583' lon='-81.34783958738' />
+  <node id='-39483' action='modify' lat='22.50213318921' lon='-81.30400180151' />
+  <node id='-39485' action='modify' lat='22.53466231595' lon='-81.25225884115' />
+  <node id='-39487' action='modify' lat='22.52204988998' lon='-81.21560757756' />
+  <node id='-39489' action='modify' lat='22.57249268064' lon='-81.17967496619' />
+  <node id='-39491' action='modify' lat='22.41380196055' lon='-81.18758085934' />
+  <node id='-39492' action='modify' lat='22.46428422097' lon='-81.14302442125' />
+  <node id='-39494' action='modify' lat='22.37925089053' lon='-81.02804006489' />
+  <node id='-39496' action='modify' lat='22.48951746297' lon='-81.16170830118' />
+  <node id='-39497' action='modify' lat='22.48785745705' lon='-81.12290108091' />
+  <node id='-39530' action='modify' lat='22.50279679349' lon='-81.17392538905'>
+    <tag k='name' v='point1' />
+  </node>
+  <node id='-39531' action='modify' lat='22.49648927042' lon='-81.10313814466'>
+    <tag k='name' v='point2' />
+  </node>
+  <node id='-39532' action='modify' lat='22.34003765932' lon='-81.20195318524' />
+  <node id='-39533' action='modify' lat='22.29217009178' lon='-81.34783958738' />
+  <node id='-39535' action='modify' lat='22.24495129088' lon='-81.27022514683' />
+  <node id='-39537' action='modify' lat='22.24495129088' lon='-81.05534813087' />
+  <node id='-39539' action='modify' lat='22.26490484086' lon='-81.00360517051' />
+  <node id='-39541' action='modify' lat='22.32408362748' lon='-81.09056209001' />
+  <node id='-39543' action='modify' lat='22.33006660327' lon='-81.16602057387' />
+  <node id='-39546' action='modify' lat='22.4682682159' lon='-81.16817653056' />
+  <node id='-39547' action='modify' lat='22.42310203991' lon='-81.25800805897' />
+  <node id='-39549' action='modify' lat='22.31830515826' lon='-81.26819371853' />
+  <node id='-39552' action='modify' lat='22.28352558777' lon='-81.23860444883' />
+  <node id='-39625' action='modify' lat='22.332726286' lon='-81.00648049807' />
+  <node id='-39626' action='modify' lat='22.33139678335' lon='-80.87137387933' />
+  <node id='-39628' action='modify' lat='22.19172859815' lon='-80.88143501052' />
+  <node id='-39630' action='modify' lat='22.20104414329' lon='-81.01941623816' />
+  <node id='-39768' action='modify' lat='22.38757524055' lon='-81.40228557444'>
+    <tag k='name' v='point3' />
+  </node>
+  <way id='-39465' action='modify'>
+    <nd ref='-39463' />
+    <nd ref='-39464' />
+    <nd ref='-39466' />
+    <nd ref='-39468' />
+    <nd ref='-39470' />
+    <nd ref='-39472' />
+    <nd ref='-39474' />
+    <nd ref='-39476' />
+    <nd ref='-39478' />
+    <nd ref='-39463' />
+    <tag k='name' v='polygon1' />
+  </way>
+  <way id='-39484' action='modify'>
+    <nd ref='-39482' />
+    <nd ref='-39483' />
+    <nd ref='-39485' />
+    <nd ref='-39487' />
+    <nd ref='-39489' />
+  </way>
+  <way id='-39493' action='modify'>
+    <nd ref='-39491' />
+    <nd ref='-39492' />
+    <nd ref='-39494' />
+  </way>
+  <way id='-39498' action='modify'>
+    <nd ref='-39496' />
+    <nd ref='-39497' />
+  </way>
+  <way id='-39534' action='modify'>
+    <nd ref='-39532' />
+    <nd ref='-39549' />
+    <nd ref='-39533' />
+    <nd ref='-39535' />
+    <nd ref='-39537' />
+    <nd ref='-39539' />
+    <nd ref='-39541' />
+    <nd ref='-39543' />
+    <nd ref='-39532' />
+    <tag k='name' v='polygon2' />
+  </way>
+  <way id='-39548' action='modify'>
+    <nd ref='-39546' />
+    <nd ref='-39547' />
+    <nd ref='-39549' />
+    <nd ref='-39552' />
+  </way>
+  <way id='-39627' action='modify'>
+    <nd ref='-39625' />
+    <nd ref='-39626' />
+    <nd ref='-39628' />
+  </way>
+  <way id='-39631' action='modify'>
+    <nd ref='-39630' />
+    <nd ref='-39625' />
+  </way>
+  <relation id='-39636' action='modify'>
+    <member type='way' ref='-39631' role='barrier' />
+    <member type='way' ref='-39627' role='barrier' />
+    <tag k='name' v='relation1' />
+  </relation>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/testForms.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/testForms.osm
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-39232' action='modify' lat='22.47789683741' lon='-81.11176179172' />
+  <node id='-39233' action='modify' lat='22.47806285085' lon='-81.06864265809' />
+  <node id='-39235' action='modify' lat='22.50860593376' lon='-81.06702569057' />
+  <node id='-39237' action='modify' lat='22.50727811384' lon='-81.11122280255' />
+  <node id='-39252' action='modify' lat='22.49350122996' lon='-81.10259897583' />
+  <node id='-39253' action='modify' lat='22.49798301747' lon='-81.08984289879' />
+  <node id='-39255' action='modify' lat='22.4886872965' lon='-81.09487346438' />
+  <node id='-39256' action='modify' lat='22.49433120156' lon='-81.08193772429' />
+  <node id='-39258' action='modify' lat='22.48769128936' lon='-81.08283603958'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39259' action='modify' lat='22.49964290192' lon='-81.10008369303'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39260' action='modify' lat='22.50254756879' lon='-81.10583282102' />
+  <node id='-39261' action='modify' lat='22.50296252808' lon='-81.07457144913' />
+  <node id='-39263' action='modify' lat='22.48320908553' lon='-81.07627824817' />
+  <node id='-39265' action='modify' lat='22.48337509259' lon='-81.10915658757' />
+  <node id='-39286' action='modify' lat='22.51790023309' lon='-81.11562445761' />
+  <node id='-39287' action='modify' lat='22.51980882353' lon='-81.0896631459' />
+  <node id='-39289' action='modify' lat='22.51524475905' lon='-81.08696820005' />
+  <node id='-39290' action='modify' lat='22.52196632882' lon='-81.07016970424' />
+  <node id='-39292' action='modify' lat='22.5008877192' lon='-81.12308047447'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39299' action='modify' lat='22.46893173352' lon='-81.06262385585' />
+  <node id='-39300' action='modify' lat='22.46926378168' lon='-81.04977794729' />
+  <node id='-39302' action='modify' lat='22.46303774628' lon='-81.05346103995' />
+  <node id='-39304' action='modify' lat='22.46278869905' lon='-81.06603745393' />
+  <way id='-39234' action='modify'>
+    <nd ref='-39232' />
+    <nd ref='-39233' />
+    <nd ref='-39235' />
+    <nd ref='-39237' />
+    <nd ref='-39232' />
+    <tag k='name' v='include' />
+  </way>
+  <way id='-39254' action='modify'>
+    <nd ref='-39252' />
+    <nd ref='-39253' />
+  </way>
+  <way id='-39257' action='modify'>
+    <nd ref='-39255' />
+    <nd ref='-39256' />
+  </way>
+  <way id='-39262' action='modify'>
+    <nd ref='-39260' />
+    <nd ref='-39261' />
+    <nd ref='-39263' />
+    <nd ref='-39265' />
+    <nd ref='-39260' />
+  </way>
+  <way id='-39288' action='modify'>
+    <nd ref='-39286' />
+    <nd ref='-39287' />
+  </way>
+  <way id='-39291' action='modify'>
+    <nd ref='-39289' />
+    <nd ref='-39290' />
+  </way>
+  <way id='-39301' action='modify'>
+    <nd ref='-39299' />
+    <nd ref='-39300' />
+    <nd ref='-39302' />
+    <nd ref='-39304' />
+    <nd ref='-39299' />
+  </way>
+</osm>


### PR DESCRIPTION
This PR contains a configurable AtlasEntity filter based on either include or exclude polygons. If include polygons are present then AtlasEntity::intersects must return true for one or more include polygons. If no include polygons are present, AtlasEntity::intersects must return false for all exclude polygons. If there are not filter polygons in the configuration then every entity is passed through. Polygons are not allowed to overlap and they are dropped with a warning as they are read in if they overlap with any previously read polygon. 
The supported polygon string formats are
<li>Atlas's native format</li>
<li>wkt</li>
<li>wkb</li>
<li>geojson*</li>

*This is the only format where more that one polygon per string is permitted

Example Configurations:
```
{
    "filter.polygons":{
        "include.wkt":["POLYGON ((-81.1523656 22.5165725, -81.1140974 22.5202238, -81.0787037 22.5072781, -81.0769071 22.470924, -81.1119414 22.4493395, -81.1732065 22.4481772, -81.1971017 22.4740784, -81.1924305 22.5091038, -81.1577555 22.5288536, -81.1523656 22.5165725))"]
    }
}

```

```
{
    "filter.polygons":{
        "exclude.geojson":["{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-81.1523656,22.5165725],[-81.1140974,22.5202238],[-81.0787037,22.5072781],[-81.0769071,22.470924],[-81.1119414,22.4493395],[-81.1732065,22.4481772],[-81.1971017,22.4740784],[-81.1924305,22.5091038],[-81.1577555,22.5288536]]]},\"properties\":{}}]}"]
    }
}
```