### PR TITLE
Discard restriction relation with more than 1 via node

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.LocationIterableProperties;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.TurnRestrictionTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.StringList;
@@ -240,29 +241,27 @@ public final class TurnRestriction implements Located, Serializable
             // Try to re-build the route, based on the "from", "via" and "to" members of the
             // relation
 
+            // Build the via members
+            final Set<AtlasItem> viaMembers = relation.members().stream()
+                    .filter(member -> member.getRole().equals(RelationTypeTag.RESTRICTION_ROLE_VIA))
+                    .filter(member -> member.getEntity() instanceof Node
+                            || member.getEntity() instanceof Edge)
+                    .map(RelationMember::getEntity).map(entity -> (AtlasItem) entity)
+                    .collect(Collectors.toSet());
+
             // According to OSM Wiki a restriction relation member can not have more than 1 via node
             // https://wiki.openstreetmap.org/wiki/Relation:restriction#Members
             // If the relation has more than 1 via node then discard the restriction as it is
             // incorrectly modeled.
             // To bring back the turn restriction OSM data needs to be modeled correctly
-            final long viaNodeCount = relation.members().stream().filter(
-                    member -> "via".equals(member.getRole()) && member.getEntity() instanceof Node)
-                    .count();
+            final long viaNodeCount = viaMembers.stream()
+                    .filter(atlasItem -> atlasItem instanceof Node).count();
             if (viaNodeCount > 1)
             {
                 throw new CoreException(
                         "Restriction relation should not have more than 1 via node. But, {} has {} via nodes",
                         relation.getOsmIdentifier(), viaNodeCount);
             }
-
-            // Build the via members
-            final Set<AtlasItem> viaMembers = new HashSet<>();
-            relation.members().stream().filter(member -> "via".equals(member.getRole())
-                    && (member.getEntity() instanceof Node || member.getEntity() instanceof Edge))
-                    .forEach(member ->
-                    {
-                        viaMembers.add((AtlasItem) member.getEntity());
-                    });
 
             // If there are no via members, create a temporary unfiltered set of "to" items, to help
             // with future filtering of "from" items by connectivity.
@@ -274,7 +273,8 @@ public final class TurnRestriction implements Located, Serializable
                     throw new CoreException(
                             "This relation has same members in from and to, but has no via members to disambiguate.");
                 }
-                relation.members().stream().filter(member -> "to".equals(member.getRole()))
+                relation.members().stream().filter(
+                        member -> member.getRole().equals(RelationTypeTag.RESTRICTION_ROLE_TO))
                         .forEach(member -> temporaryToMembers.add((AtlasItem) member.getEntity()));
             }
 
@@ -283,7 +283,8 @@ public final class TurnRestriction implements Located, Serializable
             final Set<Edge> fromMembers = new TreeSet<>();
             relation.members().stream().filter(member ->
             {
-                return "from".equals(member.getRole()) && member.getEntity() instanceof Edge
+                return member.getRole().equals(RelationTypeTag.RESTRICTION_ROLE_FROM)
+                        && member.getEntity() instanceof Edge
                         && (!viaMembers.isEmpty()
                                 && ((Edge) member.getEntity()).isConnectedAtEndTo(viaMembers)
                                 || ((Edge) member.getEntity())
@@ -296,7 +297,8 @@ public final class TurnRestriction implements Located, Serializable
             final Set<Edge> toMembers = new TreeSet<>();
             relation.members().stream().filter(member ->
             {
-                return "to".equals(member.getRole()) && member.getEntity() instanceof Edge
+                return member.getRole().equals(RelationTypeTag.RESTRICTION_ROLE_TO)
+                        && member.getEntity() instanceof Edge
                         && (!viaMembers.isEmpty()
                                 && ((Edge) member.getEntity()).isConnectedAtStartTo(viaMembers)
                                 || ((Edge) member.getEntity()).isConnectedAtStartTo(fromMembers));

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.Route;
+import org.openstreetmap.atlas.geography.atlas.items.TurnRestriction;
 import org.openstreetmap.atlas.geography.atlas.items.TurnRestriction.TurnRestrictionType;
 import org.openstreetmap.atlas.geography.atlas.items.complex.Finder;
 import org.openstreetmap.atlas.geography.atlas.items.complex.bignode.BigNode;
@@ -193,5 +194,17 @@ public class ComplexTurnRestrictionTest
                 expectedCountOfRestrictedRoutes, restrictedRoutes.size());
         Assert.assertTrue("Verify that this explicit restricted path is returned", restrictedRoutes
                 .stream().anyMatch(route -> route.toString().equals(expectedRestrictedRoute)));
+    }
+
+    @Test
+    public void testTurnRestrictionWithTwoViaNodesInRelation()
+    {
+        final Atlas testAtlas = this.rule.getRelationWithTwoViaNodes();
+        logger.trace("Atlas relation with 2 via nodes: {}", testAtlas);
+        // For more than 1 via nodes in relation for restriction, TurnRestriction will always
+        // return an empty optional
+        final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
+                .from(testAtlas.relation(1L));
+        Assert.assertEquals(Optional.empty(), possibleTurnRestriction);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
@@ -14,12 +14,12 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
  */
 public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
 {
-    private static final String ONE = "37.780574, -122.472852";
-    private static final String TWO = "37.780592, -122.472242";
-    private static final String THREE = "37.780724, -122.472249";
-    private static final String FOUR = "37.780716, -122.472395";
     private static final String FIVE = "37.780572, -122.472846";
+    private static final String FOUR = "37.780716, -122.472395";
+    private static final String ONE = "37.780574, -122.472852";
     private static final String SIX = "37.780592, -122.472142";
+    private static final String THREE = "37.780724, -122.472249";
+    private static final String TWO = "37.780592, -122.472242";
 
     @TestAtlas(
 
@@ -70,6 +70,27 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "bigNodeWithOnlyTurnRestrictions.txt.gz")
     private Atlas bigNodeWithOnlyTurnRestrictionsAtlas;
 
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+
+            }, edges = { @Edge(id = "102", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = { "highway=trunk" }), @Edge(id = "-102", coordinates = { @Loc(value = TWO), @Loc(value = ONE) }, tags = { "highway=trunk" })
+
+            }, relations = {
+
+                    @Relation(id = "1", tags = { "type=restriction",
+                            "restriction=no_u_turn" }, members = {
+                                    @Member(id = "102", role = "from", type = "edge"),
+                                    @Member(id = "1", role = "via", type = "node"),
+                                    @Member(id = "2", role = "via", type = "node"),
+                                    @Member(id = "-102", role = "to", type = "edge") })
+
+            })
+    private Atlas relationWithTwoViaNodes;
+
     public Atlas getAtlasNo()
     {
         return this.atlasNo;
@@ -83,5 +104,10 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
     public Atlas getBigNodeWithOnlyTurnRestrictionsAtlas()
     {
         return this.bigNodeWithOnlyTurnRestrictionsAtlas;
+    }
+
+    public Atlas getRelationWithTwoViaNodes()
+    {
+        return this.relationWithTwoViaNodes;
     }
 }


### PR DESCRIPTION
According to the Open street map wiki any restriction relation cannot have more than 1 via nodes in it. You can find the specs [here](https://wiki.openstreetmap.org/wiki/Relation:restriction#Members). This PR adds a check in TurnRestriction constructor to discard the relation if it has more than 1 via nodes.

Example:
https://www.openstreetmap.org/relation/4008061

![turn_restriction](https://user-images.githubusercontent.com/4022227/36622319-6cbdc70a-18b1-11e8-89f7-1b3f43d2378d.png)

This one is a bi-directional edge with no_u_turn at each node within a relation. Even though it is a data issue in OSM, atlas should discard such cases.
