### PR TITLE
Atlas Entity Polygon Filter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -85,19 +86,29 @@ public class MultiPolygon implements Iterable<Polygon>, Located, Serializable
         return new GeoJsonBuilder().create(asLocationIterableProperties());
     }
 
+    public GeoJsonObject asGeoJsonFeatureCollection()
+    {
+        final GeoJsonBuilder builder = new GeoJsonBuilder();
+        return builder.createFeatureCollection(Iterables.translate(outers(), outerPolygon ->
+        {
+            return builder.createOneOuterMultiPolygon(new MultiIterable<>(
+                    Collections.singleton(outerPolygon), this.outerToInners.get(outerPolygon)));
+        }));
+    }
+
     public Iterable<LocationIterableProperties> asLocationIterableProperties()
     {
         final Iterable<LocationIterableProperties> outers = Iterables.translate(outers(), polygon ->
         {
             final Map<String, String> tags = new HashMap<>();
             tags.put("MultiPolygon", "outer");
-            return new LocationIterableProperties(polygon, new HashMap<>());
+            return new LocationIterableProperties(polygon, tags);
         });
         final Iterable<LocationIterableProperties> inners = Iterables.translate(inners(), polygon ->
         {
             final Map<String, String> tags = new HashMap<>();
             tags.put("MultiPolygon", "inner");
-            return new LocationIterableProperties(polygon, new HashMap<>());
+            return new LocationIterableProperties(polygon, tags);
         });
         return new MultiIterable<>(outers, inners);
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
@@ -314,6 +314,12 @@ public class MultiPolygon implements Iterable<Polygon>, Located, Serializable
         return overlapsInternal(polyLine, true);
     }
 
+    public boolean overlaps(final MultiPolygon otherMultiPolygon)
+    {
+        return this.outers().stream().anyMatch(otherMultiPolygon::overlaps)
+                && otherMultiPolygon.outers().stream().anyMatch(this::overlaps);
+    }
+
     public void saveAsGeoJson(final WritableResource resource)
     {
         final JsonWriter writer = new JsonWriter(resource);

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
@@ -1,0 +1,147 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.streaming.readers.GeoJsonReader;
+import org.openstreetmap.atlas.streaming.readers.json.serializers.PropertiesLocated;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.io.WKBReader;
+
+/**
+ * The enum for supported Polygon and Multipolygon string formats. Contains functions to return
+ * {@link Polygon} and {@link MultiPolygon} {@link StringConverter}s.
+ *
+ * @author jklamer
+ */
+public enum PolygonStringFormat
+{
+    ATLAS("atlas"),
+    GEOJSON("geojson"),
+    WKT("wkt"),
+    WKB("wkb"),
+    UNSUPPORTED("UNSUPPORTED");
+
+    private static final Logger logger = LoggerFactory.getLogger(PolygonStringFormat.class);
+    private String format;
+
+    public static PolygonStringFormat getEnumForFormat(final String format)
+    {
+        for (final PolygonStringFormat polygonStringFormat : values())
+        {
+            if (polygonStringFormat.getFormat().equalsIgnoreCase(format))
+            {
+                return polygonStringFormat;
+            }
+        }
+        return UNSUPPORTED;
+    }
+
+    PolygonStringFormat(final String format)
+    {
+        this.format = format;
+    }
+
+    public String getFormat()
+    {
+        return this.format;
+    }
+
+    public StringConverter<Optional<List<MultiPolygon>>> getMultiPolygonConverter()
+    {
+        switch (this)
+        {
+            case ATLAS:
+                return string -> Optional.of(Collections
+                        .singletonList(new MultiPolygonStringConverter().convert(string)));
+            case GEOJSON:
+                return string ->
+                {
+                    final List<MultiPolygon> multiPolygons = new ArrayList<>();
+                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
+                    while (reader.hasNext())
+                    {
+                        final PropertiesLocated propertiesLocated = reader.next();
+                        if (propertiesLocated.getItem() instanceof MultiPolygon)
+                        {
+                            multiPolygons.add((MultiPolygon) propertiesLocated.getItem());
+                        }
+                        else
+                        {
+                            logger.warn("MultiPolygon Filter does not support item {}",
+                                    propertiesLocated.toString());
+                        }
+                    }
+                    return Optional.of(multiPolygons).filter(list -> !list.isEmpty());
+                };
+            case WKB:
+                return string -> Optional
+                        .of(Collections.singletonList(new WkbMultiPolygonConverter()
+                                .backwardConvert(WKBReader.hexToBytes(string))));
+            case WKT:
+                return string -> Optional.of(Collections
+                        .singletonList(new WktMultiPolygonConverter().backwardConvert(string)));
+            case UNSUPPORTED:
+            default:
+                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                        Arrays.copyOf(values(), values().length - 1));
+                return string -> Optional.empty();
+        }
+    }
+
+    public StringConverter<Optional<List<Polygon>>> getPolygonConverter()
+    {
+        switch (this)
+        {
+            case ATLAS:
+                return string -> Optional.of(
+                        Collections.singletonList(new PolygonStringConverter().convert(string)));
+            case GEOJSON:
+                return string ->
+                {
+                    final List<Polygon> polygons = new ArrayList<>();
+                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
+                    while (reader.hasNext())
+                    {
+                        final PropertiesLocated propertiesLocated = reader.next();
+                        if (propertiesLocated.getItem() instanceof Polygon)
+                        {
+                            polygons.add((Polygon) propertiesLocated.getItem());
+                        }
+                        else
+                        {
+                            logger.warn("Polygon Filter does not support item {}",
+                                    propertiesLocated.toString());
+                        }
+                    }
+                    return Optional.of(polygons).filter(list -> !list.isEmpty());
+                };
+            case WKT:
+                return string -> Optional.of(Collections
+                        .singletonList(new WktPolygonConverter().backwardConvert(string)));
+            case WKB:
+                return string -> Optional.of(Collections.singletonList(
+                        new WkbPolygonConverter().backwardConvert(WKBReader.hexToBytes(string))));
+            case UNSUPPORTED:
+            default:
+                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                        Arrays.copyOf(values(), values().length - 1));
+                return string -> Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return getFormat();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
@@ -1,0 +1,42 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBReader;
+import com.vividsolutions.jts.io.WKBWriter;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.converters.jts.JtsMultiPolygonToMultiPolygonConverter;
+import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
+
+/**
+ * Converter class for conversion between Wkb byte array and {@link MultiPolygon}
+ *
+ * @author jklamer
+ */
+public class WkbMultiPolygonConverter implements TwoWayConverter<MultiPolygon, byte[]>
+{
+    @Override
+    public MultiPolygon backwardConvert(final byte[] wkb)
+    {
+        com.vividsolutions.jts.geom.MultiPolygon geometry = null;
+        final WKBReader myReader = new WKBReader();
+        try
+        {
+            geometry = (com.vividsolutions.jts.geom.MultiPolygon) myReader.read(wkb);
+        }
+        catch (final ParseException | ClassCastException e)
+        {
+            throw new CoreException("Cannot parse wkb : {}", WKBWriter.toHex(wkb));
+        }
+        return new JtsMultiPolygonToMultiPolygonConverter().convert(geometry);
+    }
+
+    @Override
+    public byte[] convert(final MultiPolygon multiPolygon)
+    {
+        final Geometry geometry = new JtsMultiPolygonToMultiPolygonConverter().backwardConvert(multiPolygon);
+        final byte[] wkb = new WKBWriter().write(geometry);
+        return wkb;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
@@ -1,13 +1,14 @@
 package org.openstreetmap.atlas.geography.converters;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKBReader;
-import com.vividsolutions.jts.io.WKBWriter;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.converters.jts.JtsMultiPolygonToMultiPolygonConverter;
 import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBReader;
+import com.vividsolutions.jts.io.WKBWriter;
 
 /**
  * Converter class for conversion between Wkb byte array and {@link MultiPolygon}
@@ -35,7 +36,8 @@ public class WkbMultiPolygonConverter implements TwoWayConverter<MultiPolygon, b
     @Override
     public byte[] convert(final MultiPolygon multiPolygon)
     {
-        final Geometry geometry = new JtsMultiPolygonToMultiPolygonConverter().backwardConvert(multiPolygon);
+        final Geometry geometry = new JtsMultiPolygonToMultiPolygonConverter()
+                .backwardConvert(multiPolygon);
         final byte[] wkb = new WKBWriter().write(geometry);
         return wkb;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverter.java
@@ -17,14 +17,15 @@ import com.vividsolutions.jts.io.WKBWriter;
  */
 public class WkbMultiPolygonConverter implements TwoWayConverter<MultiPolygon, byte[]>
 {
+    private static final WKBReader WKB_READER = new WKBReader();
+
     @Override
     public MultiPolygon backwardConvert(final byte[] wkb)
     {
         com.vividsolutions.jts.geom.MultiPolygon geometry = null;
-        final WKBReader myReader = new WKBReader();
         try
         {
-            geometry = (com.vividsolutions.jts.geom.MultiPolygon) myReader.read(wkb);
+            geometry = (com.vividsolutions.jts.geom.MultiPolygon) WKB_READER.read(wkb);
         }
         catch (final ParseException | ClassCastException e)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
@@ -439,7 +439,8 @@ public class GeoJsonBuilder
     }
 
     /**
-     * Creates multipolygons where first polygon assumed to be outer ring and the rest are inner.
+     * Creates multipolygon from {@link Iterable} of {@link Polygon}s where first polygon is assumed
+     * to be the outer ring and the rest are inner.
      * 
      * @param polygons
      *            an iterable of polygons where the first is assumed to be the outer polygon in a

--- a/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
@@ -53,14 +54,15 @@ public class GeoJsonBuilder
         }
     }
 
-    public static final String FEATURES = "features";
-    public static final String GEOMETRY = "geometry";
     public static final String COORDINATES = "coordinates";
-    public static final String TYPE = "type";
     public static final String FEATURE = "Feature";
+    public static final String FEATURES = "features";
     public static final String FEATURE_COLLECTION = "FeatureCollection";
-    public static final String GEOMETRY_COLLECTION = "GeometryCollection";
     public static final String GEOMETRIES = "geometries";
+    public static final String GEOMETRY = "geometry";
+    public static final String GEOMETRY_COLLECTION = "GeometryCollection";
+    public static final String PROPERTIES = "properties";
+    public static final String TYPE = "type";
     private static final Logger logger = LoggerFactory.getLogger(GeoJsonBuilder.class);
     private final int logFrequency;
 
@@ -229,6 +231,36 @@ public class GeoJsonBuilder
     public GeoJsonObject create(final PolyLine polyLine)
     {
         return this.create(polyLine, GeoJsonType.LINESTRING);
+    }
+
+    /**
+     * Creates a GeoJson FeatureCollection containing a list of GeoJsonObject Features
+     *
+     * @param objects
+     *            the features
+     * @return a GeoJson FeatureCollection
+     */
+    public GeoJsonObject createFeatureCollection(final Iterable<GeoJsonObject> objects)
+    {
+        final JsonObject result = new JsonObject();
+        result.addProperty(TYPE, FEATURE_COLLECTION);
+        final JsonArray features = new JsonArray();
+        int counter = 0;
+        for (final GeoJsonObject object : objects)
+        {
+            if (this.logFrequency > 0 && ++counter % this.logFrequency == 0)
+            {
+                logger.info("Processed {} features.", counter);
+            }
+            if (!Optional.ofNullable(object.jsonObject().get(TYPE))
+                    .filter(jsonObject -> jsonObject.getAsString().equals(FEATURE)).isPresent())
+            {
+                throw new CoreException("Illegal GeoJson Type for Feature collection");
+            }
+            features.add(object.jsonObject());
+        }
+        result.add(FEATURES, features);
+        return new GeoJsonObject(result);
     }
 
     /**
@@ -403,6 +435,45 @@ public class GeoJsonBuilder
         geometry.addProperty(TYPE, GeoJsonType.MULTI_POLYGON.getType());
         geometry.add(COORDINATES, coordinates);
         result.add(GEOMETRY, geometry);
+        return new GeoJsonObject(result);
+    }
+
+    /**
+     * Creates multipolygons where first polygon assumed to be outer ring and the rest are inner.
+     * 
+     * @param polygons
+     *            an iterable of polygons where the first is assumed to be the outer polygon in a
+     *            multipolygon
+     * @return a MultiPolygon geojson feature with one polygon that geometrically represents a
+     *         single outer Atlas Multipolygon
+     */
+    public GeoJsonObject createOneOuterMultiPolygon(final Iterable<Polygon> polygons)
+    {
+        // Create the coordinates for each polygon
+        final List<GeoJsonObject> objects = new ArrayList<>();
+        for (final Polygon polygon : polygons)
+        {
+            objects.add(this.create(polygon, GeoJsonType.MULTI_POLYGON));
+        }
+
+        final JsonObject result = new JsonObject();
+        result.addProperty(TYPE, FEATURE);
+        final JsonArray coordinates = new JsonArray();
+
+        // Add the coordinates back for the entire object
+        for (final GeoJsonObject object : objects)
+        {
+            coordinates
+                    .add(object.jsonObject().getAsJsonObject(GEOMETRY).getAsJsonArray(COORDINATES));
+        }
+
+        final JsonArray newCoordinates = new JsonArray();
+        newCoordinates.add(coordinates);
+        final JsonObject geometry = new JsonObject();
+        geometry.addProperty(TYPE, GeoJsonType.MULTI_POLYGON.getType());
+        geometry.add(COORDINATES, newCoordinates);
+        result.add(GEOMETRY, geometry);
+        result.add(PROPERTIES, new JsonObject());
         return new GeoJsonObject(result);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -3,18 +3,29 @@ package org.openstreetmap.atlas.utilities.filters;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import org.openstreetmap.atlas.geography.Located;
+import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.LineItem;
+import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.converters.MultiPolygonStringConverter;
 import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbMultiPolygonConverter;
 import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.geography.converters.WktMultiPolygonConverter;
 import org.openstreetmap.atlas.geography.converters.WktPolygonConverter;
 import org.openstreetmap.atlas.geography.index.QuadTree;
 import org.openstreetmap.atlas.streaming.readers.GeoJsonReader;
@@ -28,37 +39,197 @@ import org.slf4j.LoggerFactory;
 import com.vividsolutions.jts.io.WKBReader;
 
 /**
- * Configurable {@link AtlasEntity} filter that passes through anything that intersects with include
- * polygons or anything that doesn't intersect with exclude polygons. Exclude polygons are looked at
- * only if no include polygons exist. Include takes precedence and polygons intersecting with
- * previously read polygons are dropped with a warning.
+ * Configurable {@link AtlasEntity} filter that passes through anything that intersects with
+ * includePolygons polygons or anything that doesn't intersect with exclude polygons. Exclude
+ * polygons are looked at only if no includePolygons polygons exist. Include takes precedence and
+ * polygons intersecting with previously read polygons are dropped with a warning.
  * 
  * @author jklamer
  */
-public class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serializable
+public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serializable
 {
-
+    public static final String EXCLUDED_MULTIPOLYGONS_KEY = "filter.multipolygons.exclude";
     public static final String EXCLUDED_POLYGONS_KEY = "filter.polygons.exclude";
+    public static final String INCLUDED_MULTIPOLYGONS_KEY = "filter.multipolygons.include";
     public static final String INCLUDED_POLYGONS_KEY = "filter.polygons.include";
+    private static final MultiPolygonStringConverter MULTI_POLYGON_STRING_CONVERTER = new MultiPolygonStringConverter();
     private static final PolygonStringConverter POLYGON_STRING_CONVERTER = new PolygonStringConverter();
-    private static final List<String> POLYGON_STRING_FORMATS = Arrays.asList("atlas", "geojson",
-            "wkt", "wkb");
+    private static final WkbMultiPolygonConverter WKB_MULTI_POLYGON_CONVERTER = new WkbMultiPolygonConverter();
     private static final WkbPolygonConverter WKB_POLYGON_CONVERTER = new WkbPolygonConverter();
+    private static final WktMultiPolygonConverter WKT_MULTI_POLYGON_CONVERTER = new WktMultiPolygonConverter();
     private static final WktPolygonConverter WKT_POLYGON_CONVERTER = new WktPolygonConverter();
     private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
-    private static final long serialVersionUID = -3474748398986569205L;
-    private List<Polygon> exclude = new ArrayList<>();
-    private List<Polygon> include = new ArrayList<>();
+    public static final IntersectionDeciding DEFAULT_INTERSECTION_DECIDING = new IntersectionDeciding()
+    {
+        @Override
+        public boolean multiPolygonAndEntity(final MultiPolygon multiPolygon,
+                final AtlasEntity entity)
+        {
+            if (entity instanceof LineItem)
+            {
+                return multiPolygon.overlaps(((LineItem) entity).asPolyLine());
+            }
+            if (entity instanceof LocationItem)
+            {
+                return multiPolygon
+                        .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+            }
+            if (entity instanceof Area)
+            {
+                return multiPolygon.overlaps(((Area) entity).asPolygon());
+            }
+            if (entity instanceof Relation)
+            {
+                return ((Relation) entity).members().stream().map(RelationMember::getEntity)
+                        .anyMatch(relationEntity -> this.multiPolygonAndEntity(multiPolygon,
+                                relationEntity));
+            }
+            else
+            {
+                logger.warn("Unknown AtlasEntity Implementation {}", entity);
+                return false;
+            }
+        }
 
-    private static StringConverter<Optional<List<Polygon>>> getConverterForFormat(
+        @Override
+        public boolean polygonAndEntity(final Polygon polygon, final AtlasEntity entity)
+        {
+            return entity.intersects(polygon);
+        }
+    };
+    private static final long serialVersionUID = -3474748398986569205L;
+    private List<MultiPolygon> excludeMultiPolygons = new ArrayList<>();
+    private List<Polygon> excludePolygons = new ArrayList<>();
+    private Type filterType;
+    private List<MultiPolygon> includeMultiPolygons = new ArrayList<>();
+    private List<Polygon> includePolygons = new ArrayList<>();
+    private IntersectionDeciding intersectionDeciding;
+
+    public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration)
+    {
+        return forConfiguration(configuration, DEFAULT_INTERSECTION_DECIDING);
+    }
+
+    public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration,
+            final IntersectionDeciding intersectionDeciding)
+    {
+        return forConfigurationValues(configuration.get(INCLUDED_POLYGONS_KEY).value(),
+                configuration.get(INCLUDED_MULTIPOLYGONS_KEY).value(),
+                configuration.get(EXCLUDED_POLYGONS_KEY).value(),
+                configuration.get(EXCLUDED_MULTIPOLYGONS_KEY).value(), intersectionDeciding);
+    }
+
+    public static AtlasEntityPolygonsFilter forConfigurationValues(
+            final Map<String, List<String>> includePolygonMap,
+            final Map<String, List<String>> includeMultiPolygonMap,
+            final Map<String, List<String>> excludePolygonMap,
+            final Map<String, List<String>> excludeMultiPolygonMap,
+            final IntersectionDeciding intersectionDeciding)
+    {
+        final List<Polygon> includePolygons;
+        final List<Polygon> excludePolygons;
+        final List<MultiPolygon> includeMultiPolygons;
+        final List<MultiPolygon> excludeMultiPolygons;
+
+        includePolygons = includePolygonMap != null ? getPolygonsFromFormatMap(includePolygonMap)
+                : Collections.EMPTY_LIST;
+        includeMultiPolygons = includeMultiPolygonMap != null
+                ? getMultiPolygonsFromFormatMap(includeMultiPolygonMap) : Collections.EMPTY_LIST;
+        excludePolygons = excludePolygonMap != null ? getPolygonsFromFormatMap(excludePolygonMap)
+                : Collections.EMPTY_LIST;
+        excludeMultiPolygons = excludeMultiPolygonMap != null
+                ? getMultiPolygonsFromFormatMap(excludeMultiPolygonMap) : Collections.EMPTY_LIST;
+
+        if (!includePolygons.isEmpty() || !includeMultiPolygons.isEmpty())
+        {
+            return Type.INCLUDE.polygonsAndMultiPolygons(intersectionDeciding, includePolygons,
+                    includeMultiPolygons);
+        }
+        else
+        {
+            return Type.EXCLUDE.polygonsAndMultiPolygons(intersectionDeciding, excludePolygons,
+                    excludeMultiPolygons);
+        }
+    }
+
+    public static AtlasEntityPolygonsFilter forConfigurationValues(
+            final Map<String, List<String>> includePolygonMap,
+            final Map<String, List<String>> includeMultiPolygonMap,
+            final Map<String, List<String>> excludePolygonMap,
+            final Map<String, List<String>> excludeMultiPolygonMap)
+    {
+        return forConfigurationValues(includePolygonMap, includeMultiPolygonMap, excludePolygonMap,
+                excludeMultiPolygonMap, DEFAULT_INTERSECTION_DECIDING);
+    }
+
+    private static StringConverter<Optional<List<MultiPolygon>>> getMultiPolygonConverterForFormat(
             final String format)
     {
-        switch (format)
+        switch (PolygonStringFormat.getEnum(format))
         {
-            case "atlas":
+            case ATLAS:
+                return string -> Optional.of(
+                        Collections.singletonList(MULTI_POLYGON_STRING_CONVERTER.convert(string)));
+            case GEOJSON:
+                return string ->
+                {
+                    final List<MultiPolygon> multiPolygons = new ArrayList<>();
+                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
+                    while (reader.hasNext())
+                    {
+                        final PropertiesLocated propertiesLocated = reader.next();
+                        if (propertiesLocated.getItem() instanceof MultiPolygon)
+                        {
+                            multiPolygons.add((MultiPolygon) propertiesLocated.getItem());
+                        }
+                        else
+                        {
+                            logger.warn("MultiPolygon Filter does not support item {}",
+                                    propertiesLocated.toString());
+                        }
+                    }
+                    return Optional.of(multiPolygons).filter(list -> !list.isEmpty());
+                };
+            case WKB:
+                return string -> Optional.of(Collections.singletonList(
+                        WKB_MULTI_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+            case WKT:
+                return string -> Optional.of(Collections
+                        .singletonList(WKT_MULTI_POLYGON_CONVERTER.backwardConvert(string)));
+            case UNSUPPORTED:
+            default:
+                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                        Arrays.copyOf(PolygonStringFormat.values(),
+                                PolygonStringFormat.values().length - 1));
+                return string -> Optional.empty();
+        }
+    }
+
+    private static List<MultiPolygon> getMultiPolygonsFromFormatMap(
+            final Map<String, List<String>> multiPolygonLists)
+    {
+        if (multiPolygonLists.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+        return multiPolygonLists.entrySet().stream()
+                .flatMap(formatAndMultiPolygonStrings -> formatAndMultiPolygonStrings.getValue()
+                        .stream()
+                        .map(getMultiPolygonConverterForFormat(
+                                formatAndMultiPolygonStrings.getKey())::convert)
+                        .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream))
+                .collect(Collectors.toList());
+    }
+
+    private static StringConverter<Optional<List<Polygon>>> getPolygonConverterForFormat(
+            final String format)
+    {
+        switch (PolygonStringFormat.getEnum(format))
+        {
+            case ATLAS:
                 return string -> Optional
                         .of(Collections.singletonList(POLYGON_STRING_CONVERTER.convert(string)));
-            case "geojson":
+            case GEOJSON:
                 return string ->
                 {
                     final List<Polygon> polygons = new ArrayList<>();
@@ -78,57 +249,142 @@ public class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serial
                     }
                     return Optional.of(polygons).filter(list -> !list.isEmpty());
                 };
-            case "wkt":
+            case WKT:
                 return string -> Optional.of(
                         Collections.singletonList(WKT_POLYGON_CONVERTER.backwardConvert(string)));
-            case "wkb":
+            case WKB:
                 return string -> Optional.of(Collections.singletonList(
                         WKB_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+            case UNSUPPORTED:
             default:
                 logger.warn("No converter set up for {} format. Supported formats are {}", format,
-                        POLYGON_STRING_FORMATS);
+                        Arrays.copyOf(PolygonStringFormat.values(),
+                                PolygonStringFormat.values().length - 1));
                 return string -> Optional.empty();
         }
     }
 
-    private static Predicate<Polygon> notOverlapping(final QuadTree<Polygon> vettedPolygons,
-            final String polygonType)
+    private static List<Polygon> getPolygonsFromFormatMap(
+            final Map<String, List<String>> polygonLists)
+    {
+        if (polygonLists.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+        return polygonLists.entrySet().stream()
+                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream()
+                        .map(getPolygonConverterForFormat(
+                                formatAndPolygonStrings.getKey())::convert)
+                        .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns predicate that filters out MultiPolygons that overlap with any Polygons or outer
+     * MultiPolygons in the provided QuadTree. This also adds any non-intersecting MultiPolygon to
+     * the quad tree.
+     *
+     * @param vettedPolygons
+     *            non-overlapping polygons and multipolygons
+     * @param polygonType
+     *            whether this is an include or exclude Polygon
+     * @return filter for multipolygons
+     */
+    private static Predicate<MultiPolygon> notOverlappingMultipolygon(
+            final QuadTree<Located> vettedPolygons, final Type polygonType)
+    {
+        return multiPolygon ->
+        {
+            if (vettedPolygons.get(multiPolygon.bounds()).stream()
+                    .filter(located -> located instanceof Polygon).map(located -> (Polygon) located)
+                    .noneMatch(multiPolygon::overlaps)
+                    && vettedPolygons.get(multiPolygon.bounds()).stream()
+                            .filter(located -> located instanceof MultiPolygon)
+                            .map(located -> (MultiPolygon) located).map(MultiPolygon::outers)
+                            .flatMap(Set::stream).noneMatch(multiPolygon::overlaps))
+            {
+                vettedPolygons.add(multiPolygon.bounds(), multiPolygon);
+                return true;
+            }
+            else
+            {
+                logger.warn("Dropping {} MultiPolygon {}", polygonType, multiPolygon);
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Returns predicate that filters out polygons that intersect with any polygons in the provided
+     * QuadTree. This also adds any non-intersecting polygon to the quad tree.
+     *
+     * @param vettedPolygons
+     *            non-overlapping polygons and multipolygons
+     * @param polygonType
+     *            whether this is an include or exclude Polygon
+     * @return filter for polygons
+     */
+    private static Predicate<Polygon> notOverlappingPolygon(final QuadTree<Located> vettedPolygons,
+            final Type polygonType)
     {
         return polygon ->
         {
-            if (vettedPolygons.get(polygon.bounds()).stream().noneMatch(polygon::overlaps))
+            if (vettedPolygons.get(polygon.bounds()).stream()
+                    .filter(located -> located instanceof Polygon).map(located -> (Polygon) located)
+                    .noneMatch(polygon::overlaps)
+                    && vettedPolygons.get(polygon.bounds()).stream()
+                            .filter(located -> located instanceof MultiPolygon)
+                            .map(located -> (MultiPolygon) located).noneMatch(polygon::overlaps))
             {
                 vettedPolygons.add(polygon.bounds(), polygon);
                 return true;
             }
             else
             {
-                logger.warn("Dropping {} polygon {}", polygonType, polygon);
+                logger.warn("Dropping {} Polygon {}", polygonType, polygon);
                 return false;
             }
         };
     }
 
-    public AtlasEntityPolygonsFilter(final Map<String, List<String>> includePolygonMap,
-            final Map<String, List<String>> excludePolygonMap)
+    private AtlasEntityPolygonsFilter(final Type filterType, final Collection<Polygon> polygons,
+            final Collection<MultiPolygon> multiPolygons)
     {
-        final QuadTree<Polygon> vettedPolygons = new QuadTree<>();
-        if (includePolygonMap != null)
-        {
-            this.include = this.getPolygonsFromMap(includePolygonMap)
-                    .filter(notOverlapping(vettedPolygons, "include")).collect(Collectors.toList());
-        }
-        if (excludePolygonMap != null)
-        {
-            this.exclude = this.getPolygonsFromMap(excludePolygonMap)
-                    .filter(notOverlapping(vettedPolygons, "exclude")).collect(Collectors.toList());
-        }
+        this(filterType, DEFAULT_INTERSECTION_DECIDING, polygons, multiPolygons);
     }
 
-    public AtlasEntityPolygonsFilter(final Configuration configuration)
+    private AtlasEntityPolygonsFilter(final Type filterType,
+            final IntersectionDeciding intersectionDeciding, final Collection<Polygon> polygons,
+            final Collection<MultiPolygon> multiPolygons)
     {
-        this(configuration.get(INCLUDED_POLYGONS_KEY).value(),
-                configuration.get(EXCLUDED_POLYGONS_KEY).value());
+        this.filterType = filterType;
+        this.intersectionDeciding = intersectionDeciding;
+        final QuadTree<Located> vettedPolygons = new QuadTree<>();
+        if (filterType == Type.INCLUDE)
+        {
+            this.includePolygons
+                    .addAll(polygons == null ? Collections.EMPTY_SET
+                            : polygons.stream()
+                                    .filter(notOverlappingPolygon(vettedPolygons, Type.INCLUDE))
+                                    .collect(Collectors.toSet()));
+            this.includeMultiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
+                    : multiPolygons.stream()
+                            .filter(notOverlappingMultipolygon(vettedPolygons, Type.INCLUDE))
+                            .collect(Collectors.toSet()));
+        }
+        else
+        {
+            this.excludePolygons
+                    .addAll(polygons == null ? Collections.EMPTY_SET
+                            : polygons.stream()
+                                    .filter(notOverlappingPolygon(vettedPolygons, Type.EXCLUDE))
+                                    .collect(Collectors.toSet()));
+            this.excludeMultiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
+                    : multiPolygons.stream()
+                            .filter(notOverlappingMultipolygon(vettedPolygons, Type.EXCLUDE))
+                            .collect(Collectors.toSet()));
+        }
+
     }
 
     @Override
@@ -137,32 +393,129 @@ public class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serial
         return noPolygons().or(isIncluded()).or(isNotExcluded()).test(object);
     }
 
-    private Stream<Polygon> getPolygonsFromMap(final Map<String, List<String>> polygonLists)
+    private boolean excludePolygonsEmpty()
     {
-        if (polygonLists.isEmpty())
-        {
-            return Stream.empty();
-        }
-        return polygonLists.entrySet().stream()
-                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream()
-                        .map(getConverterForFormat(formatAndPolygonStrings.getKey())::convert)
-                        .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream));
+        return this.excludePolygons.isEmpty() && this.excludeMultiPolygons.isEmpty();
+    }
+
+    private boolean includePolygonsEmpty()
+    {
+        return this.includePolygons.isEmpty() && this.includeMultiPolygons.isEmpty();
     }
 
     private Predicate<AtlasEntity> isIncluded()
     {
-        return entity -> this.include.stream().anyMatch(entity::intersects);
+        return entity -> this.filterType == Type.INCLUDE
+                && (this.includePolygons.stream()
+                        .anyMatch(polygon -> this.intersectionDeciding.polygonAndEntity(polygon,
+                                entity))
+                || this.includeMultiPolygons.stream()
+                        .anyMatch(multiPolygon -> this.intersectionDeciding
+                                .multiPolygonAndEntity(multiPolygon, entity)));
     }
 
     private Predicate<AtlasEntity> isNotExcluded()
     {
-        // if there are include polygons the entity needs to be in them which is not tested here
-        return entity -> this.include.isEmpty()
-                && this.exclude.stream().noneMatch(entity::intersects);
+        return entity -> this.filterType == Type.EXCLUDE
+                && this.excludePolygons.stream()
+                        .noneMatch(polygon -> this.intersectionDeciding.polygonAndEntity(polygon,
+                                entity))
+                && this.excludeMultiPolygons.stream()
+                        .noneMatch(multiPolygon -> this.intersectionDeciding
+                                .multiPolygonAndEntity(multiPolygon, entity));
     }
 
     private Predicate<AtlasEntity> noPolygons()
     {
-        return entity -> this.include.isEmpty() && this.exclude.isEmpty();
+        return entity -> this.includePolygonsEmpty() && this.excludePolygonsEmpty();
+    }
+
+    public interface IntersectionDeciding
+    {
+        boolean multiPolygonAndEntity(final MultiPolygon multiPolygon, final AtlasEntity entity);
+
+        boolean polygonAndEntity(final Polygon polygon, final AtlasEntity entity);
+    }
+
+    public enum Type
+    {
+        INCLUDE,
+        EXCLUDE;
+
+        public AtlasEntityPolygonsFilter multiPolygons(final Collection<MultiPolygon> multiPolygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, null, multiPolygons);
+        }
+
+        public AtlasEntityPolygonsFilter multiPolygons(
+                final IntersectionDeciding intersectionDeciding,
+                final Collection<MultiPolygon> multiPolygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, intersectionDeciding, null, multiPolygons);
+        }
+
+        public AtlasEntityPolygonsFilter polygons(final Collection<Polygon> polygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, polygons, null);
+        }
+
+        public AtlasEntityPolygonsFilter polygons(final IntersectionDeciding intersectionDeciding,
+                final Collection<Polygon> polygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, intersectionDeciding, polygons, null);
+        }
+
+        public AtlasEntityPolygonsFilter polygonsAndMultiPolygons(
+                final Collection<Polygon> polygons, final Collection<MultiPolygon> multiPolygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, polygons, multiPolygons);
+        }
+
+        public AtlasEntityPolygonsFilter polygonsAndMultiPolygons(
+                final IntersectionDeciding intersectionDeciding, final Collection<Polygon> polygons,
+                final Collection<MultiPolygon> multiPolygons)
+        {
+            return new AtlasEntityPolygonsFilter(this, intersectionDeciding, polygons,
+                    multiPolygons);
+        }
+    }
+
+    private enum PolygonStringFormat
+    {
+        ATLAS("atlas"),
+        GEOJSON("geojson"),
+        WKT("wkt"),
+        WKB("wkb"),
+        UNSUPPORTED("UNSUPPORTED");
+
+        private String format;
+
+        public static PolygonStringFormat getEnum(final String format)
+        {
+            for (final PolygonStringFormat polygonStringFormat : values())
+            {
+                if (polygonStringFormat.getFormat().equalsIgnoreCase(format))
+                {
+                    return polygonStringFormat;
+                }
+            }
+            return PolygonStringFormat.UNSUPPORTED;
+        }
+
+        PolygonStringFormat(final String format)
+        {
+            this.format = format;
+        }
+
+        public String getFormat()
+        {
+            return this.format;
+        }
+
+        @Override
+        public String toString()
+        {
+            return getFormat();
+        }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.utilities.filters;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -14,28 +13,12 @@ import java.util.stream.Collectors;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
-import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
-import org.openstreetmap.atlas.geography.atlas.items.LineItem;
-import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
-import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
-import org.openstreetmap.atlas.geography.converters.MultiPolygonStringConverter;
-import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
-import org.openstreetmap.atlas.geography.converters.WkbMultiPolygonConverter;
-import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
-import org.openstreetmap.atlas.geography.converters.WktMultiPolygonConverter;
-import org.openstreetmap.atlas.geography.converters.WktPolygonConverter;
+import org.openstreetmap.atlas.geography.converters.PolygonStringFormat;
 import org.openstreetmap.atlas.geography.index.QuadTree;
-import org.openstreetmap.atlas.streaming.readers.GeoJsonReader;
-import org.openstreetmap.atlas.streaming.readers.json.serializers.PropertiesLocated;
-import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
-import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.vividsolutions.jts.io.WKBReader;
 
 /**
  * Configurable {@link AtlasEntity} filter that passes through anything that intersects with
@@ -52,56 +35,15 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
     public static final String INCLUDED_MULTIPOLYGONS_KEY = "filter.multipolygons.include";
     public static final String INCLUDED_POLYGONS_KEY = "filter.polygons.include";
     private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
-    public static final IntersectionPolicy DEFAULT_INTERSECTION_POLICY = new IntersectionPolicy()
-    {
-        @Override
-        public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
-                final AtlasEntity entity)
-        {
-            if (entity instanceof LineItem)
-            {
-                return multiPolygon.overlaps(((LineItem) entity).asPolyLine());
-            }
-            if (entity instanceof LocationItem)
-            {
-                return multiPolygon
-                        .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
-            }
-            if (entity instanceof Area)
-            {
-                return multiPolygon.overlaps(((Area) entity).asPolygon());
-            }
-            if (entity instanceof Relation)
-            {
-                return ((Relation) entity).members().stream().map(RelationMember::getEntity)
-                        .anyMatch(relationEntity -> this
-                                .multiPolygonEntityIntersecting(multiPolygon, relationEntity));
-            }
-            else
-            {
-                logger.warn("Unknown AtlasEntity Implementation {}",
-                        entity.getClass().getSimpleName());
-                return false;
-            }
-        }
-
-        @Override
-        public boolean polygonEntityIntersecting(final Polygon polygon, final AtlasEntity entity)
-        {
-            return entity.intersects(polygon);
-        }
-    };
     private static final long serialVersionUID = -3474748398986569205L;
-    private List<MultiPolygon> excludeMultiPolygons = new ArrayList<>();
-    private List<Polygon> excludePolygons = new ArrayList<>();
     private Type filterType;
-    private List<MultiPolygon> includeMultiPolygons = new ArrayList<>();
-    private List<Polygon> includePolygons = new ArrayList<>();
     private IntersectionPolicy intersectionPolicy;
+    private List<MultiPolygon> multiPolygons = new ArrayList<>();
+    private List<Polygon> polygons = new ArrayList<>();
 
     public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration)
     {
-        return forConfiguration(configuration, DEFAULT_INTERSECTION_POLICY);
+        return forConfiguration(configuration, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
     }
 
     public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration,
@@ -136,6 +78,11 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
 
         if (!includePolygons.isEmpty() || !includeMultiPolygons.isEmpty())
         {
+            if (!excludePolygons.isEmpty() || !excludeMultiPolygons.isEmpty())
+            {
+                logger.warn(
+                        "Ignoring exclude polygons and multipolygons passed through configuration");
+            }
             return Type.INCLUDE.polygonsAndMultiPolygons(intersectionPolicy, includePolygons,
                     includeMultiPolygons);
         }
@@ -153,51 +100,7 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
             final Map<String, List<String>> excludeMultiPolygonMap)
     {
         return forConfigurationValues(includePolygonMap, includeMultiPolygonMap, excludePolygonMap,
-                excludeMultiPolygonMap, DEFAULT_INTERSECTION_POLICY);
-    }
-
-    private static StringConverter<Optional<List<MultiPolygon>>> getMultiPolygonConverterForFormat(
-            final String format)
-    {
-        switch (PolygonStringFormat.getEnum(format))
-        {
-            case ATLAS:
-                return string -> Optional.of(Collections
-                        .singletonList(new MultiPolygonStringConverter().convert(string)));
-            case GEOJSON:
-                return string ->
-                {
-                    final List<MultiPolygon> multiPolygons = new ArrayList<>();
-                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
-                    while (reader.hasNext())
-                    {
-                        final PropertiesLocated propertiesLocated = reader.next();
-                        if (propertiesLocated.getItem() instanceof MultiPolygon)
-                        {
-                            multiPolygons.add((MultiPolygon) propertiesLocated.getItem());
-                        }
-                        else
-                        {
-                            logger.warn("MultiPolygon Filter does not support item {}",
-                                    propertiesLocated.toString());
-                        }
-                    }
-                    return Optional.of(multiPolygons).filter(list -> !list.isEmpty());
-                };
-            case WKB:
-                return string -> Optional
-                        .of(Collections.singletonList(new WkbMultiPolygonConverter()
-                                .backwardConvert(WKBReader.hexToBytes(string))));
-            case WKT:
-                return string -> Optional.of(Collections
-                        .singletonList(new WktMultiPolygonConverter().backwardConvert(string)));
-            case UNSUPPORTED:
-            default:
-                logger.warn("No converter set up for {} format. Supported formats are {}", format,
-                        Arrays.copyOf(PolygonStringFormat.values(),
-                                PolygonStringFormat.values().length - 1));
-                return string -> Optional.empty();
-        }
+                excludeMultiPolygonMap, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
     }
 
     private static List<MultiPolygon> getMultiPolygonsFromFormatMap(
@@ -210,53 +113,11 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         return multiPolygonLists.entrySet().stream()
                 .flatMap(formatAndMultiPolygonStrings -> formatAndMultiPolygonStrings.getValue()
                         .stream()
-                        .map(getMultiPolygonConverterForFormat(
-                                formatAndMultiPolygonStrings.getKey())::convert)
+                        .map(PolygonStringFormat
+                                .getEnumForFormat(formatAndMultiPolygonStrings.getKey())
+                                .getMultiPolygonConverter())
                         .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream))
                 .collect(Collectors.toList());
-    }
-
-    private static StringConverter<Optional<List<Polygon>>> getPolygonConverterForFormat(
-            final String format)
-    {
-        switch (PolygonStringFormat.getEnum(format))
-        {
-            case ATLAS:
-                return string -> Optional.of(
-                        Collections.singletonList(new PolygonStringConverter().convert(string)));
-            case GEOJSON:
-                return string ->
-                {
-                    final List<Polygon> polygons = new ArrayList<>();
-                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
-                    while (reader.hasNext())
-                    {
-                        final PropertiesLocated propertiesLocated = reader.next();
-                        if (propertiesLocated.getItem() instanceof Polygon)
-                        {
-                            polygons.add((Polygon) propertiesLocated.getItem());
-                        }
-                        else
-                        {
-                            logger.warn("Polygon Filter does not support item {}",
-                                    propertiesLocated.toString());
-                        }
-                    }
-                    return Optional.of(polygons).filter(list -> !list.isEmpty());
-                };
-            case WKT:
-                return string -> Optional.of(Collections
-                        .singletonList(new WktPolygonConverter().backwardConvert(string)));
-            case WKB:
-                return string -> Optional.of(Collections.singletonList(
-                        new WkbPolygonConverter().backwardConvert(WKBReader.hexToBytes(string))));
-            case UNSUPPORTED:
-            default:
-                logger.warn("No converter set up for {} format. Supported formats are {}", format,
-                        Arrays.copyOf(PolygonStringFormat.values(),
-                                PolygonStringFormat.values().length - 1));
-                return string -> Optional.empty();
-        }
     }
 
     private static List<Polygon> getPolygonsFromFormatMap(
@@ -267,10 +128,46 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
             return Collections.emptyList();
         }
         return polygonLists.entrySet().stream()
-                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream().map(
-                        getPolygonConverterForFormat(formatAndPolygonStrings.getKey())::convert)
+                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream()
+                        .map(PolygonStringFormat.getEnumForFormat(formatAndPolygonStrings.getKey())
+                                .getPolygonConverter())
                         .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream))
                 .collect(Collectors.toList());
+    }
+
+    private static Predicate<Located> locatedOverlappingPredicate(final Polygon polygon,
+            final MultiPolygon multiPolygon)
+    {
+        Predicate<Located> returnPredicate = located -> false;
+        if (polygon != null)
+        {
+            returnPredicate = returnPredicate.or(located ->
+            {
+                if (located instanceof Polygon)
+                {
+                    return polygon.overlaps((Polygon) located);
+                }
+                else
+                {
+                    return polygon.overlaps((MultiPolygon) located);
+                }
+            });
+        }
+        if (multiPolygon != null)
+        {
+            returnPredicate = returnPredicate.or(located ->
+            {
+                if (located instanceof Polygon)
+                {
+                    return multiPolygon.overlaps((Polygon) located);
+                }
+                else
+                {
+                    return multiPolygon.overlaps((MultiPolygon) located);
+                }
+            });
+        }
+        return returnPredicate;
     }
 
     /**
@@ -290,12 +187,7 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         return multiPolygon ->
         {
             if (vettedPolygons.get(multiPolygon.bounds()).stream()
-                    .filter(located -> located instanceof Polygon).map(located -> (Polygon) located)
-                    .noneMatch(multiPolygon::overlaps)
-                    && vettedPolygons.get(multiPolygon.bounds()).stream()
-                            .filter(located -> located instanceof MultiPolygon)
-                            .map(located -> (MultiPolygon) located)
-                            .noneMatch(multiPolygon::overlaps))
+                    .noneMatch(locatedOverlappingPredicate(null, multiPolygon)))
             {
                 vettedPolygons.add(multiPolygon.bounds(), multiPolygon);
                 return true;
@@ -324,11 +216,7 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         return polygon ->
         {
             if (vettedPolygons.get(polygon.bounds()).stream()
-                    .filter(located -> located instanceof Polygon).map(located -> (Polygon) located)
-                    .noneMatch(polygon::overlaps)
-                    && vettedPolygons.get(polygon.bounds()).stream()
-                            .filter(located -> located instanceof MultiPolygon)
-                            .map(located -> (MultiPolygon) located).noneMatch(polygon::overlaps))
+                    .noneMatch(locatedOverlappingPredicate(polygon, null)))
             {
                 vettedPolygons.add(polygon.bounds(), polygon);
                 return true;
@@ -344,7 +232,7 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
     private AtlasEntityPolygonsFilter(final Type filterType, final Collection<Polygon> polygons,
             final Collection<MultiPolygon> multiPolygons)
     {
-        this(filterType, DEFAULT_INTERSECTION_POLICY, polygons, multiPolygons);
+        this(filterType, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY, polygons, multiPolygons);
     }
 
     private AtlasEntityPolygonsFilter(final Type filterType,
@@ -356,20 +244,20 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         final QuadTree<Located> vettedPolygons = new QuadTree<>();
         if (filterType == Type.INCLUDE)
         {
-            this.includePolygons.addAll(polygons == null ? Collections.EMPTY_SET
+            this.polygons.addAll(polygons == null ? Collections.EMPTY_SET
                     : polygons.stream().filter(notOverlappingPolygon(vettedPolygons, Type.INCLUDE))
                             .collect(Collectors.toSet()));
-            this.includeMultiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
+            this.multiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
                     : multiPolygons.stream()
                             .filter(notOverlappingMultipolygon(vettedPolygons, Type.INCLUDE))
                             .collect(Collectors.toSet()));
         }
         else
         {
-            this.excludePolygons.addAll(polygons == null ? Collections.EMPTY_SET
+            this.polygons.addAll(polygons == null ? Collections.EMPTY_SET
                     : polygons.stream().filter(notOverlappingPolygon(vettedPolygons, Type.EXCLUDE))
                             .collect(Collectors.toSet()));
-            this.excludeMultiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
+            this.multiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
                     : multiPolygons.stream()
                             .filter(notOverlappingMultipolygon(vettedPolygons, Type.EXCLUDE))
                             .collect(Collectors.toSet()));
@@ -382,51 +270,27 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         return noPolygons().or(isIncluded()).or(isNotExcluded()).test(object);
     }
 
-    private boolean excludePolygonsEmpty()
-    {
-        return this.excludePolygons.isEmpty() && this.excludeMultiPolygons.isEmpty();
-    }
-
-    private boolean includePolygonsEmpty()
-    {
-        return this.includePolygons.isEmpty() && this.includeMultiPolygons.isEmpty();
-    }
-
     private Predicate<AtlasEntity> isIncluded()
     {
-        return entity -> this.filterType == Type.INCLUDE && (this.includePolygons.stream().anyMatch(
+        return entity -> this.filterType == Type.INCLUDE && (this.polygons.stream().anyMatch(
                 polygon -> this.intersectionPolicy.polygonEntityIntersecting(polygon, entity))
-                || this.includeMultiPolygons.stream()
-                        .anyMatch(multiPolygon -> this.intersectionPolicy
-                                .multiPolygonEntityIntersecting(multiPolygon, entity)));
+                || this.multiPolygons.stream().anyMatch(multiPolygon -> this.intersectionPolicy
+                        .multiPolygonEntityIntersecting(multiPolygon, entity)));
     }
 
     private Predicate<AtlasEntity> isNotExcluded()
     {
         return entity -> this.filterType == Type.EXCLUDE
-                && this.excludePolygons.stream()
+                && this.polygons.stream()
                         .noneMatch(polygon -> this.intersectionPolicy
                                 .polygonEntityIntersecting(polygon, entity))
-                && this.excludeMultiPolygons.stream()
-                        .noneMatch(multiPolygon -> this.intersectionPolicy
-                                .multiPolygonEntityIntersecting(multiPolygon, entity));
+                && this.multiPolygons.stream().noneMatch(multiPolygon -> this.intersectionPolicy
+                        .multiPolygonEntityIntersecting(multiPolygon, entity));
     }
 
     private Predicate<AtlasEntity> noPolygons()
     {
-        return entity -> this.includePolygonsEmpty() && this.excludePolygonsEmpty();
-    }
-
-    /**
-     * Interface to be implemented if custom intersection logic is required. The
-     * {@link AtlasEntityPolygonsFilter#DEFAULT_INTERSECTION_POLICY} is that an entity is said to
-     * intersect when any part of the entity overlaps with any area of the Polygon or MultiPolygon.
-     */
-    public interface IntersectionPolicy extends Serializable
-    {
-        boolean multiPolygonEntityIntersecting(MultiPolygon multiPolygon, AtlasEntity entity);
-
-        boolean polygonEntityIntersecting(Polygon polygon, AtlasEntity entity);
+        return entity -> this.polygons.isEmpty() && this.multiPolygons.isEmpty();
     }
 
     /**
@@ -471,48 +335,6 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
                 final Collection<MultiPolygon> multiPolygons)
         {
             return new AtlasEntityPolygonsFilter(this, intersectionPolicy, polygons, multiPolygons);
-        }
-    }
-
-    /**
-     * The enum for supported Polygon and Multipolygon string formats
-     */
-    private enum PolygonStringFormat
-    {
-        ATLAS("atlas"),
-        GEOJSON("geojson"),
-        WKT("wkt"),
-        WKB("wkb"),
-        UNSUPPORTED("UNSUPPORTED");
-
-        private String format;
-
-        public static PolygonStringFormat getEnum(final String format)
-        {
-            for (final PolygonStringFormat polygonStringFormat : values())
-            {
-                if (polygonStringFormat.getFormat().equalsIgnoreCase(format))
-                {
-                    return polygonStringFormat;
-                }
-            }
-            return PolygonStringFormat.UNSUPPORTED;
-        }
-
-        PolygonStringFormat(final String format)
-        {
-            this.format = format;
-        }
-
-        public String getFormat()
-        {
-            return this.format;
-        }
-
-        @Override
-        public String toString()
-        {
-            return getFormat();
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -1,0 +1,168 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.geography.converters.WktPolygonConverter;
+import org.openstreetmap.atlas.geography.index.QuadTree;
+import org.openstreetmap.atlas.streaming.readers.GeoJsonReader;
+import org.openstreetmap.atlas.streaming.readers.json.serializers.PropertiesLocated;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.io.WKBReader;
+
+/**
+ * Configurable {@link AtlasEntity} filter that passes through anything that intersects with include
+ * polygons or anything that doesn't intersect with exclude polygons. Exclude polygons are looked at
+ * only if no include polygons exist. Include takes precedence and polygons intersecting with
+ * previously read polygons are dropped with a warning.
+ * 
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, Serializable
+{
+
+    public static final String EXCLUDED_POLYGONS_KEY = "filter.polygons.exclude";
+    public static final String INCLUDED_POLYGONS_KEY = "filter.polygons.include";
+    private static final PolygonStringConverter POLYGON_STRING_CONVERTER = new PolygonStringConverter();
+    private static final List<String> POLYGON_STRING_FORMATS = Arrays.asList("atlas", "geojson",
+            "wkt", "wkb");
+    private static final WkbPolygonConverter WKB_POLYGON_CONVERTER = new WkbPolygonConverter();
+    private static final WktPolygonConverter WKT_POLYGON_CONVERTER = new WktPolygonConverter();
+    private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
+    private static final long serialVersionUID = -3474748398986569205L;
+    private List<Polygon> exclude = new ArrayList<>();
+    private List<Polygon> include = new ArrayList<>();
+
+    private static StringConverter<Optional<List<Polygon>>> getConverterForFormat(
+            final String format)
+    {
+        switch (format)
+        {
+            case "atlas":
+                return string -> Optional
+                        .of(Collections.singletonList(POLYGON_STRING_CONVERTER.convert(string)));
+            case "geojson":
+                return string ->
+                {
+                    final List<Polygon> polygons = new ArrayList<>();
+                    final GeoJsonReader reader = new GeoJsonReader(new StringResource(string));
+                    while (reader.hasNext())
+                    {
+                        final PropertiesLocated propertiesLocated = reader.next();
+                        if (propertiesLocated.getItem() instanceof Polygon)
+                        {
+                            polygons.add((Polygon) propertiesLocated.getItem());
+                        }
+                        else
+                        {
+                            logger.warn("Polygon Filter does not support item {}",
+                                    propertiesLocated.toString());
+                        }
+                    }
+                    return Optional.of(polygons).filter(list -> !list.isEmpty());
+                };
+            case "wkt":
+                return string -> Optional.of(
+                        Collections.singletonList(WKT_POLYGON_CONVERTER.backwardConvert(string)));
+            case "wkb":
+                return string -> Optional.of(Collections.singletonList(
+                        WKB_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+            default:
+                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                        POLYGON_STRING_FORMATS);
+                return string -> Optional.empty();
+        }
+    }
+
+    private static Predicate<Polygon> notOverlapping(final QuadTree<Polygon> vettedPolygons,
+            final String polygonType)
+    {
+        return polygon ->
+        {
+            if (vettedPolygons.get(polygon.bounds()).stream().noneMatch(polygon::overlaps))
+            {
+                vettedPolygons.add(polygon.bounds(), polygon);
+                return true;
+            }
+            else
+            {
+                logger.warn("Dropping {} polygon {}", polygonType, polygon);
+                return false;
+            }
+        };
+    }
+
+    public AtlasEntityPolygonsFilter(final Map<String, List<String>> includePolygonMap,
+            final Map<String, List<String>> excludePolygonMap)
+    {
+        final QuadTree<Polygon> vettedPolygons = new QuadTree<>();
+        if (includePolygonMap != null)
+        {
+            this.include = this.getPolygonsFromMap(includePolygonMap)
+                    .filter(notOverlapping(vettedPolygons, "include")).collect(Collectors.toList());
+        }
+        if (excludePolygonMap != null)
+        {
+            this.exclude = this.getPolygonsFromMap(excludePolygonMap)
+                    .filter(notOverlapping(vettedPolygons, "exclude")).collect(Collectors.toList());
+        }
+    }
+
+    public AtlasEntityPolygonsFilter(final Configuration configuration)
+    {
+        this(configuration.get(INCLUDED_POLYGONS_KEY).value(),
+                configuration.get(EXCLUDED_POLYGONS_KEY).value());
+    }
+
+    @Override
+    public boolean test(final AtlasEntity object)
+    {
+        return noPolygons().or(isIncluded()).or(isNotExcluded()).test(object);
+    }
+
+    private Stream<Polygon> getPolygonsFromMap(final Map<String, List<String>> polygonLists)
+    {
+        if (polygonLists.isEmpty())
+        {
+            return Stream.empty();
+        }
+        return polygonLists.entrySet().stream()
+                .flatMap(formatAndPolygonStrings -> formatAndPolygonStrings.getValue().stream()
+                        .map(getConverterForFormat(formatAndPolygonStrings.getKey())::convert)
+                        .filter(Optional::isPresent).map(Optional::get).flatMap(List::stream));
+    }
+
+    private Predicate<AtlasEntity> isIncluded()
+    {
+        return entity -> this.include.stream().anyMatch(entity::intersects);
+    }
+
+    private Predicate<AtlasEntity> isNotExcluded()
+    {
+        // if there are include polygons the entity needs to be in them which is not tested here
+        return entity -> this.include.isEmpty()
+                && this.exclude.stream().noneMatch(entity::intersects);
+    }
+
+    private Predicate<AtlasEntity> noPolygons()
+    {
+        return entity -> this.include.isEmpty() && this.exclude.isEmpty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -52,12 +52,6 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
     public static final String EXCLUDED_POLYGONS_KEY = "filter.polygons.exclude";
     public static final String INCLUDED_MULTIPOLYGONS_KEY = "filter.multipolygons.include";
     public static final String INCLUDED_POLYGONS_KEY = "filter.polygons.include";
-    private static final MultiPolygonStringConverter MULTI_POLYGON_STRING_CONVERTER = new MultiPolygonStringConverter();
-    private static final PolygonStringConverter POLYGON_STRING_CONVERTER = new PolygonStringConverter();
-    private static final WkbMultiPolygonConverter WKB_MULTI_POLYGON_CONVERTER = new WkbMultiPolygonConverter();
-    private static final WkbPolygonConverter WKB_POLYGON_CONVERTER = new WkbPolygonConverter();
-    private static final WktMultiPolygonConverter WKT_MULTI_POLYGON_CONVERTER = new WktMultiPolygonConverter();
-    private static final WktPolygonConverter WKT_POLYGON_CONVERTER = new WktPolygonConverter();
     private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
     public static final IntersectionDeciding DEFAULT_INTERSECTION_DECIDING = new IntersectionDeciding()
     {
@@ -168,8 +162,8 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         switch (PolygonStringFormat.getEnum(format))
         {
             case ATLAS:
-                return string -> Optional.of(
-                        Collections.singletonList(MULTI_POLYGON_STRING_CONVERTER.convert(string)));
+                return string -> Optional.of(Collections
+                        .singletonList(new MultiPolygonStringConverter().convert(string)));
             case GEOJSON:
                 return string ->
                 {
@@ -191,11 +185,12 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
                     return Optional.of(multiPolygons).filter(list -> !list.isEmpty());
                 };
             case WKB:
-                return string -> Optional.of(Collections.singletonList(
-                        WKB_MULTI_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+                return string -> Optional
+                        .of(Collections.singletonList(new WkbMultiPolygonConverter()
+                                .backwardConvert(WKBReader.hexToBytes(string))));
             case WKT:
                 return string -> Optional.of(Collections
-                        .singletonList(WKT_MULTI_POLYGON_CONVERTER.backwardConvert(string)));
+                        .singletonList(new WktMultiPolygonConverter().backwardConvert(string)));
             case UNSUPPORTED:
             default:
                 logger.warn("No converter set up for {} format. Supported formats are {}", format,
@@ -227,8 +222,8 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         switch (PolygonStringFormat.getEnum(format))
         {
             case ATLAS:
-                return string -> Optional
-                        .of(Collections.singletonList(POLYGON_STRING_CONVERTER.convert(string)));
+                return string -> Optional.of(
+                        Collections.singletonList(new PolygonStringConverter().convert(string)));
             case GEOJSON:
                 return string ->
                 {
@@ -250,11 +245,11 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
                     return Optional.of(polygons).filter(list -> !list.isEmpty());
                 };
             case WKT:
-                return string -> Optional.of(
-                        Collections.singletonList(WKT_POLYGON_CONVERTER.backwardConvert(string)));
+                return string -> Optional.of(Collections
+                        .singletonList(new WktPolygonConverter().backwardConvert(string)));
             case WKB:
                 return string -> Optional.of(Collections.singletonList(
-                        WKB_POLYGON_CONVERTER.backwardConvert(WKBReader.hexToBytes(string))));
+                        new WkbPolygonConverter().backwardConvert(WKBReader.hexToBytes(string))));
             case UNSUPPORTED:
             default:
                 logger.warn("No converter set up for {} format. Supported formats are {}", format,
@@ -427,7 +422,7 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
      * {@link AtlasEntityPolygonsFilter#DEFAULT_INTERSECTION_DECIDING} is that an entity is said to
      * intersect when any part of the entity overlaps with any area of the Polygon or MultiPolygon.
      */
-    public interface IntersectionDeciding
+    public interface IntersectionDeciding extends Serializable
     {
         boolean multiPolygonEntityIntersecting(MultiPolygon multiPolygon, AtlasEntity entity);
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
@@ -1,0 +1,72 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import java.io.Serializable;
+
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.LineItem;
+import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+
+/**
+ * Interface to be implemented if custom intersection logic is required.
+ *
+ * @author jklamer
+ */
+public interface IntersectionPolicy extends Serializable
+{
+
+    /**
+     * A case by case common sense implementation.
+     */
+    IntersectionPolicy DEFAULT_INTERSECTION_POLICY = new IntersectionPolicy()
+    {
+        @Override
+        public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
+                final AtlasEntity entity)
+        {
+            if (entity instanceof LineItem)
+            {
+                return multiPolygon.overlaps(((LineItem) entity).asPolyLine());
+            }
+            if (entity instanceof LocationItem)
+            {
+                return multiPolygon
+                        .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+            }
+            if (entity instanceof Area)
+            {
+                return multiPolygon.overlaps(((Area) entity).asPolygon());
+            }
+            if (entity instanceof Relation)
+            {
+                return ((Relation) entity).members().stream().map(RelationMember::getEntity)
+                        .anyMatch(relationEntity -> this
+                                .multiPolygonEntityIntersecting(multiPolygon, relationEntity));
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean polygonEntityIntersecting(final Polygon polygon, final AtlasEntity entity)
+        {
+            return entity.intersects(polygon);
+        }
+    };
+
+    default boolean multiPolygonEntityIntersecting(MultiPolygon multiPolygon, AtlasEntity entity)
+    {
+        return false;
+    };
+
+    default boolean polygonEntityIntersecting(Polygon polygon, AtlasEntity entity)
+    {
+        return false;
+    };
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -81,6 +81,25 @@ public class MultiPolygonTest
     }
 
     @Test
+    public void testOverlap()
+    {
+        final MultiPolygon multiPolygon1 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((0 50, 50 50, 50 0, 0 0, 0 50)," + "(5 45, 45 45, 45 5, 5 5, 5 45)))");
+        final MultiPolygon multiPolygon2 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((10 35, 35 35, 35 10, 10 10, 10 35),"
+                        + "(15 30, 30 30, 30 15, 15 15, 15 30)))");
+        final MultiPolygon multiPolygon3 = MultiPolygon
+                .wkt("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),"
+                        + "((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),"
+                        + "(30 20, 20 15, 20 25, 30 20)))");
+
+        Assert.assertFalse(multiPolygon1.overlaps(multiPolygon2));
+        Assert.assertFalse(multiPolygon2.overlaps(multiPolygon1));
+        Assert.assertTrue(multiPolygon2.overlaps(multiPolygon3));
+        Assert.assertTrue(multiPolygon3.overlaps(multiPolygon2));
+    }
+
+    @Test
     public void testSerialization() throws ClassNotFoundException
     {
         final MultiPolygon map = new MultiPolygon(MultiMapTest.getMultiMap());

--- a/src/test/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/converters/WkbMultiPolygonConverterTest.java
@@ -1,0 +1,24 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+
+/**
+ * Test for {@link WkbMultiPolygonConverter}
+ *
+ * @author jklamer
+ */
+public class WkbMultiPolygonConverterTest
+{
+    private static WkbMultiPolygonConverter converter = new WkbMultiPolygonConverter();
+
+    @Test
+    public void testConversion()
+    {
+        final MultiPolygon multiPolygonA = MultiPolygon.TEST_MULTI_POLYGON;
+        final byte[] wkb = converter.convert(multiPolygonA);
+        final MultiPolygon multiPolygonB = converter.backwardConvert(wkb);
+        Assert.assertEquals(multiPolygonA, multiPolygonB);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -1,0 +1,193 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+
+import com.vividsolutions.jts.io.WKBWriter;
+
+/**
+ * Tests for {@link AtlasEntityPolygonsFilter}
+ *
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilterTest
+{
+    @Rule
+    public final AtlasEntityPolygonsFilterTestRule setup = new AtlasEntityPolygonsFilterTestRule();
+
+    /**
+     * Test Standard use cases by validating counts and asserting symmetry of include vs. exclude
+     */
+    @Test
+    public void testCounts()
+    {
+        final Atlas testCountsAtlas = this.setup.getTestCounts();
+        final String includeConfigurationFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"]}}";
+        final String excludeConfigurationFormat = "{\"filter.polygons\":{\"exclude.wkt\":[\"%s\"]}}";
+        final Polygon polygon1 = this.getPolygonWithName(testCountsAtlas, "polygon1");
+        final Polygon polygon2 = this.getPolygonWithName(testCountsAtlas, "polygon2");
+
+        final long totalPointCount = testCountsAtlas.numberOfPoints();
+        final long totalLineCount = testCountsAtlas.numberOfLines();
+        final long totalAreaCount = testCountsAtlas.numberOfAreas();
+        final long totalRelationCount = testCountsAtlas.numberOfRelations();
+        final AtlasEntityPolygonsFilter includePolygon1 = this
+                .constructFilter(includeConfigurationFormat, polygon1.toWkt());
+        final AtlasEntityPolygonsFilter includePolygon2 = this
+                .constructFilter(includeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter includePolygon1And2 = this.constructFilter(
+                includeConfigurationFormat,
+                String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
+        final AtlasEntityPolygonsFilter excludePolygon1 = this
+                .constructFilter(excludeConfigurationFormat, polygon1.toWkt());
+        final AtlasEntityPolygonsFilter excludePolygon2 = this
+                .constructFilter(excludeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter excludePolygon1And2 = this.constructFilter(
+                excludeConfigurationFormat,
+                String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
+
+        // testing polygon1
+        this.assertCounts(testCountsAtlas, includePolygon1, 2L, 3L, 1L, 0L);
+        this.assertCounts(testCountsAtlas, excludePolygon1, totalPointCount - 2L,
+                totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+        this.assertCounts(testCountsAtlas, includePolygon1.negate(), totalPointCount - 2L,
+                totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+
+        // testing polygon2
+        this.assertCounts(testCountsAtlas, includePolygon2, 0L, 2L, 1L, 1L);
+        this.assertCounts(testCountsAtlas, excludePolygon2, totalPointCount, totalLineCount - 2L,
+                totalAreaCount - 1L, totalRelationCount - 1L);
+        this.assertCounts(testCountsAtlas, excludePolygon2.negate(), 0L, 2L, 1L, 1L);
+
+        // testing tandem filter
+        this.assertCounts(testCountsAtlas, includePolygon1And2, totalPointCount - 1L,
+                totalLineCount - 2L, totalAreaCount, totalRelationCount);
+        this.assertCounts(testCountsAtlas, excludePolygon1And2, 1L, 2L, 0L, 0L);
+        this.assertCounts(testCountsAtlas, includePolygon1And2.negate(), 1L, 2L, 0L, 0L);
+
+    }
+
+    /**
+     * Tests every input form supported by the filter
+     */
+    @Test
+    public void testForms()
+    {
+        final Atlas testFormsAtlas = this.setup.getTestForm();
+        final String wktConfigurationStringFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"]}}";
+        final String wkbConfigurationStringFormat = "{\"filter.polygons\":{\"include.wkb\":[\"%s\"]}}";
+        final String atlasConfigurationStringFormat = "{\"filter.polygons\":{\"include.atlas\":[\"%s\"]}}";
+        final String geojsonConfigurationStringFormat = "{\"filter.polygons\":{\"include.geojson\":[\"%s\"]}}";
+        final Polygon includeBoundary = this.getPolygonWithName(testFormsAtlas, "include");
+
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(wktConfigurationStringFormat, includeBoundary.toWkt()), 2, 2,
+                2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(wkbConfigurationStringFormat,
+                        WKBWriter.toHex(new WkbPolygonConverter().convert(includeBoundary))),
+                2, 2, 2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(atlasConfigurationStringFormat,
+                        new PolygonStringConverter().backwardConvert(includeBoundary)),
+                2, 2, 2, 0);
+        this.assertCounts(this.setup.getTestForm(),
+                this.constructFilter(geojsonConfigurationStringFormat,
+                        includeBoundary.asGeoJson().toString().replaceAll("\"", "\\\\\"")),
+                2, 2, 2, 0);
+    }
+
+    /**
+     * Tests every arrangement of 1 include and 1 exclude polygon. Each situation the exclude
+     * polygon is either dropped for overlapping or ignored because of the include dominance of the
+     * filter. Each situation designed to have same count result.
+     */
+    @Test
+    public void testIncludeDominant()
+    {
+        final int numberOfCases = 4;
+        final Atlas includeExcludeArrangements = this.setup.getIncludeExcludeArrangements();
+        final String configurationStringFormat = "{\"filter.polygons\":{\"include.wkt\":[\"%s\"],\"exclude.wkt\":[\"%s\"]}}";
+        final Polygon includePolygon = this.getPolygonWithName(includeExcludeArrangements,
+                "include");
+
+        for (int caseNum = 1; caseNum <= numberOfCases; caseNum++)
+        {
+            final String caseString = String.format("case_%d", caseNum);
+            final String excludePolygonName = "exclude_".concat(caseString);
+            final Polygon excludePolygon = this.getPolygonWithName(includeExcludeArrangements,
+                    excludePolygonName);
+            final AtlasEntityPolygonsFilter filter = this.constructFilter(configurationStringFormat,
+                    includePolygon.toWkt(), excludePolygon.toWkt());
+
+            Assert.assertEquals(2L, StreamSupport
+                    .stream(includeExcludeArrangements
+                            .lines(line -> line.getTag("name")
+                                    .filter(value -> value.contains(caseString)).isPresent())
+                            .spliterator(), false)
+                    .filter(filter).map(line -> line.getTag("name")).filter(Optional::isPresent)
+                    .map(Optional::get).peek(name -> Assert.assertTrue(name.contains("included")))
+                    .count());
+
+            Assert.assertEquals(1L, StreamSupport
+                    .stream(includeExcludeArrangements
+                            .lines(line -> line.getTag("name")
+                                    .filter(value -> value.contains(caseString)).isPresent())
+                            .spliterator(), false)
+                    .filter(filter.negate()).map(line -> line.getTag("name"))
+                    .filter(Optional::isPresent).map(Optional::get)
+                    .peek(name -> Assert.assertTrue(name.contains("excluded"))).count());
+        }
+    }
+
+    private void assertCounts(final Atlas atlas, final Predicate<AtlasEntity> filter,
+            final long expectedPointCount, final long expectedLineCount,
+            final long expectedAreaCount, final long expectedRelationCount)
+    {
+        if (expectedPointCount >= 0)
+        {
+            Assert.assertEquals(expectedPointCount, Iterables.size(atlas.points(filter::test)));
+        }
+        if (expectedLineCount >= 0)
+        {
+            Assert.assertEquals(expectedLineCount, Iterables.size(atlas.lines(filter::test)));
+        }
+        if (expectedAreaCount >= 0)
+        {
+            Assert.assertEquals(expectedAreaCount, Iterables.size(atlas.areas(filter::test)));
+        }
+        if (expectedRelationCount >= 0)
+        {
+            Assert.assertEquals(expectedRelationCount,
+                    Iterables.size(atlas.relations(filter::test)));
+        }
+    }
+
+    private AtlasEntityPolygonsFilter constructFilter(final String format,
+            final Object... polygonStrings)
+    {
+        return new AtlasEntityPolygonsFilter(new StandardConfiguration(
+                new StringResource(String.format(format, polygonStrings))));
+    }
+
+    private Polygon getPolygonWithName(final Atlas atlas, final String name)
+    {
+        return StreamSupport
+                .stream(atlas.areas(area -> area.getTag("name")
+                        .filter(string -> string.equals(name)).isPresent()).spliterator(), false)
+                .findFirst().get().asPolygon();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.utilities.filters;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
@@ -7,14 +9,24 @@ import java.util.stream.StreamSupport;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.LineItem;
+import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.converters.MultiPolygonStringConverter;
 import org.openstreetmap.atlas.geography.converters.PolygonStringConverter;
+import org.openstreetmap.atlas.geography.converters.WkbMultiPolygonConverter;
 import org.openstreetmap.atlas.geography.converters.WkbPolygonConverter;
+import org.openstreetmap.atlas.geography.converters.WktMultiPolygonConverter;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
 
 import com.vividsolutions.jts.io.WKBWriter;
 
@@ -45,17 +57,17 @@ public class AtlasEntityPolygonsFilterTest
         final long totalAreaCount = testCountsAtlas.numberOfAreas();
         final long totalRelationCount = testCountsAtlas.numberOfRelations();
         final AtlasEntityPolygonsFilter includePolygon1 = this
-                .constructFilter(includeConfigurationFormat, polygon1.toWkt());
+                .constructConfiguredFilter(includeConfigurationFormat, polygon1.toWkt());
         final AtlasEntityPolygonsFilter includePolygon2 = this
-                .constructFilter(includeConfigurationFormat, polygon2.toWkt());
-        final AtlasEntityPolygonsFilter includePolygon1And2 = this.constructFilter(
+                .constructConfiguredFilter(includeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter includePolygon1And2 = this.constructConfiguredFilter(
                 includeConfigurationFormat,
                 String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
         final AtlasEntityPolygonsFilter excludePolygon1 = this
-                .constructFilter(excludeConfigurationFormat, polygon1.toWkt());
+                .constructConfiguredFilter(excludeConfigurationFormat, polygon1.toWkt());
         final AtlasEntityPolygonsFilter excludePolygon2 = this
-                .constructFilter(excludeConfigurationFormat, polygon2.toWkt());
-        final AtlasEntityPolygonsFilter excludePolygon1And2 = this.constructFilter(
+                .constructConfiguredFilter(excludeConfigurationFormat, polygon2.toWkt());
+        final AtlasEntityPolygonsFilter excludePolygon1And2 = this.constructConfiguredFilter(
                 excludeConfigurationFormat,
                 String.join("\",\"", polygon1.toWkt(), polygon2.toWkt()));
 
@@ -77,10 +89,22 @@ public class AtlasEntityPolygonsFilterTest
                 totalLineCount - 2L, totalAreaCount, totalRelationCount);
         this.assertCounts(testCountsAtlas, excludePolygon1And2, 1L, 2L, 0L, 0L);
         this.assertCounts(testCountsAtlas, includePolygon1And2.negate(), 1L, 2L, 0L, 0L);
+
+        // testing simple filter construction
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(Collections.singleton(polygon1)),
+                2L, 3L, 1L, 0L);
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.EXCLUDE.polygons(Collections.singleton(polygon1)),
+                totalPointCount - 2L, totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(Arrays.asList(polygon1, polygon2)),
+                totalPointCount - 1L, totalLineCount - 2L, totalAreaCount, totalRelationCount);
+
     }
 
     /**
-     * Tests every input form supported by the filter
+     * Tests every polygon input form supported by the filter
      */
     @Test
     public void testForms()
@@ -92,27 +116,26 @@ public class AtlasEntityPolygonsFilterTest
         final String geojsonConfigurationStringFormat = "{\"filter.polygons\":{\"include.geojson\":[\"%s\"]}}";
         final Polygon includeBoundary = this.getPolygonWithName(testFormsAtlas, "include");
 
+        this.assertCounts(this.setup.getTestForm(), this.constructConfiguredFilter(
+                wktConfigurationStringFormat, includeBoundary.toWkt()), 2, 2, 2, 0);
         this.assertCounts(this.setup.getTestForm(),
-                this.constructFilter(wktConfigurationStringFormat, includeBoundary.toWkt()), 2, 2,
-                2, 0);
-        this.assertCounts(this.setup.getTestForm(),
-                this.constructFilter(wkbConfigurationStringFormat,
+                this.constructConfiguredFilter(wkbConfigurationStringFormat,
                         WKBWriter.toHex(new WkbPolygonConverter().convert(includeBoundary))),
                 2, 2, 2, 0);
         this.assertCounts(this.setup.getTestForm(),
-                this.constructFilter(atlasConfigurationStringFormat,
+                this.constructConfiguredFilter(atlasConfigurationStringFormat,
                         new PolygonStringConverter().backwardConvert(includeBoundary)),
                 2, 2, 2, 0);
         this.assertCounts(this.setup.getTestForm(),
-                this.constructFilter(geojsonConfigurationStringFormat,
+                this.constructConfiguredFilter(geojsonConfigurationStringFormat,
                         includeBoundary.asGeoJson().toString().replaceAll("\"", "\\\\\"")),
                 2, 2, 2, 0);
     }
 
     /**
-     * Tests every arrangement of 1 include and 1 exclude polygon. Each situation the exclude
-     * polygon is either dropped for overlapping or ignored because of the include dominance of the
-     * filter. Each situation designed to have same count result.
+     * Tests every arrangement of 1 include and 1 exclude polygon in a configuration. Each situation
+     * the include dominance of the configured filter means that exclude polygon is ignored. Each
+     * situation designed to have same count result.
      */
     @Test
     public void testIncludeDominant()
@@ -129,8 +152,8 @@ public class AtlasEntityPolygonsFilterTest
             final String excludePolygonName = "exclude_".concat(caseString);
             final Polygon excludePolygon = this.getPolygonWithName(includeExcludeArrangements,
                     excludePolygonName);
-            final AtlasEntityPolygonsFilter filter = this.constructFilter(configurationStringFormat,
-                    includePolygon.toWkt(), excludePolygon.toWkt());
+            final AtlasEntityPolygonsFilter filter = this.constructConfiguredFilter(
+                    configurationStringFormat, includePolygon.toWkt(), excludePolygon.toWkt());
 
             Assert.assertEquals(2L, StreamSupport
                     .stream(includeExcludeArrangements
@@ -150,6 +173,228 @@ public class AtlasEntityPolygonsFilterTest
                     .filter(Optional::isPresent).map(Optional::get)
                     .peek(name -> Assert.assertTrue(name.contains("excluded"))).count());
         }
+    }
+
+    @Test
+    public void testIntersectionDeciding()
+    {
+
+        final Atlas testCountsAtlas = this.setup.getTestCounts();
+        final Polygon polygon1 = this.getPolygonWithName(testCountsAtlas, "polygon1");
+        final Polygon polygon2 = this.getPolygonWithName(testCountsAtlas, "polygon2");
+        final long totalPointCount = testCountsAtlas.numberOfPoints();
+        final long totalLineCount = testCountsAtlas.numberOfLines();
+        final long totalAreaCount = testCountsAtlas.numberOfAreas();
+        final long totalRelationCount = testCountsAtlas.numberOfRelations();
+        final AtlasEntityPolygonsFilter.IntersectionDeciding dudIntersectionDeciding = new AtlasEntityPolygonsFilter.IntersectionDeciding()
+        {
+            @Override
+            public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
+                    final AtlasEntity entity)
+            {
+                return false;
+            }
+
+            @Override
+            public boolean polygonEntityIntersecting(final Polygon polygon,
+                    final AtlasEntity entity)
+            {
+                return false;
+            }
+        };
+        final AtlasEntityPolygonsFilter.IntersectionDeciding fullGeometricEnclosing = new AtlasEntityPolygonsFilter.IntersectionDeciding()
+        {
+            @Override
+            public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
+                    final AtlasEntity entity)
+            {
+
+                if (entity instanceof LineItem)
+                {
+                    return multiPolygon
+                            .fullyGeometricallyEncloses(((LineItem) entity).asPolyLine());
+                }
+                if (entity instanceof LocationItem)
+                {
+                    return multiPolygon
+                            .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+                }
+                if (entity instanceof Area)
+                {
+                    return multiPolygon.fullyGeometricallyEncloses(((Area) entity).asPolygon());
+                }
+                if (entity instanceof Relation)
+                {
+                    return ((Relation) entity).members().stream().map(RelationMember::getEntity)
+                            .anyMatch(relationEntity -> this
+                                    .multiPolygonEntityIntersecting(multiPolygon, relationEntity));
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            @Override
+            public boolean polygonEntityIntersecting(final Polygon polygon,
+                    final AtlasEntity entity)
+            {
+
+                if (entity instanceof LineItem)
+                {
+                    return polygon.fullyGeometricallyEncloses(((LineItem) entity).asPolyLine());
+                }
+                if (entity instanceof LocationItem)
+                {
+                    return polygon
+                            .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+                }
+                if (entity instanceof Area)
+                {
+                    return polygon.fullyGeometricallyEncloses(((Area) entity).asPolygon());
+                }
+                if (entity instanceof Relation)
+                {
+                    return ((Relation) entity).members().stream().map(RelationMember::getEntity)
+                            .anyMatch(relationEntity -> this.polygonEntityIntersecting(polygon,
+                                    relationEntity));
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        };
+
+        // Test all three decision makers on the first polygon
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
+                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_DECIDING,
+                        Collections.singleton(polygon1)),
+                2L, 3L, 1L, 0L);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
+                dudIntersectionDeciding, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(fullGeometricEnclosing, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
+
+        // Test all three decision makers on two polygon filter
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
+                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_DECIDING,
+                        Arrays.asList(polygon1, polygon2)),
+                totalPointCount - 1L, totalLineCount - 2L, totalAreaCount, totalRelationCount);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(dudIntersectionDeciding, Arrays.asList(polygon1, polygon2)), 0, 0, 0, 0);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(fullGeometricEnclosing, Arrays.asList(polygon1, polygon2)), 2, 1, 0, 0);
+    }
+
+    /**
+     * Test Multipolygon Functionality
+     */
+    @Test
+    public void testMultiPolygon()
+    {
+
+        final Atlas testMultiPolygonFilterAtlas = this.setup.getMultiPolygons();
+        final long totalPointCount = testMultiPolygonFilterAtlas.numberOfPoints();
+        final long totalLineCount = testMultiPolygonFilterAtlas.numberOfLines();
+        final long totalAreaCount = testMultiPolygonFilterAtlas.numberOfAreas();
+        final long totalRelationCount = testMultiPolygonFilterAtlas.numberOfRelations();
+        final Polygon multiPolygon1Outer1 = this.getPolygonWithName(testMultiPolygonFilterAtlas,
+                "multipolygon1-outer1");
+        final Polygon multiPolygon1Inner1 = this.getPolygonWithName(testMultiPolygonFilterAtlas,
+                "multipolygon1-inner1");
+        final Polygon multiPolygon1Inner2 = this.getPolygonWithName(testMultiPolygonFilterAtlas,
+                "multipolygon1-inner2");
+        final Polygon multiPolygon2Outer1 = this.getPolygonWithName(testMultiPolygonFilterAtlas,
+                "multipolygon2-outer1");
+        final Polygon multiPolygon2Inner1 = this.getPolygonWithName(testMultiPolygonFilterAtlas,
+                "multipolygon2-inner1");
+        final MultiMap<Polygon, Polygon> multiPolygonMap1 = new MultiMap<>();
+        multiPolygonMap1.add(multiPolygon1Outer1, multiPolygon1Inner1);
+        multiPolygonMap1.add(multiPolygon1Outer1, multiPolygon1Inner2);
+        final MultiMap<Polygon, Polygon> multiPolygonMap2 = new MultiMap<>();
+        multiPolygonMap2.add(multiPolygon2Outer1, multiPolygon2Inner1);
+        final MultiPolygon multiPolygon1 = new MultiPolygon(multiPolygonMap1);
+        final MultiPolygon multiPolygon2 = new MultiPolygon(multiPolygonMap2);
+        final Polygon polygon1 = this.getPolygonWithName(testMultiPolygonFilterAtlas, "polygon1");
+
+        // Multipolygon 1 and 2 include counts
+        this.assertCounts(testMultiPolygonFilterAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .multiPolygons(Collections.singleton(multiPolygon1)), 3, 1, 5, 1);
+        this.assertCounts(testMultiPolygonFilterAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .multiPolygons(Collections.singleton(multiPolygon2)), 2, 1, 3, 1);
+
+        // Multipolygon 1 and 2 exclude counts
+        this.assertCounts(testMultiPolygonFilterAtlas,
+                AtlasEntityPolygonsFilter.Type.EXCLUDE
+                        .multiPolygons(Collections.singleton(multiPolygon1)),
+                totalPointCount - 3, totalLineCount - 1, totalAreaCount - 5,
+                totalRelationCount - 1);
+        this.assertCounts(testMultiPolygonFilterAtlas,
+                AtlasEntityPolygonsFilter.Type.EXCLUDE
+                        .multiPolygons(Collections.singleton(multiPolygon2)),
+                totalPointCount - 2, totalLineCount - 1, totalAreaCount - 3,
+                totalRelationCount - 1);
+
+        // Merged MultiPolygon include is sum of above (except relation is the same between the two)
+        this.assertCounts(testMultiPolygonFilterAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .multiPolygons(Arrays.asList(multiPolygon1, multiPolygon2)), 3 + 2, 1 + 1, 5 + 3,
+                1);
+        this.assertCounts(testMultiPolygonFilterAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE
+                        .multiPolygons(Collections.singleton(multiPolygon1.merge(multiPolygon2))),
+                3 + 2, 1 + 1, 5 + 3, 1);
+
+        // both polygons and multipolygons
+        this.assertCounts(testMultiPolygonFilterAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygonsAndMultiPolygons(
+                        Collections.singleton(polygon1),
+                        Arrays.asList(multiPolygon1, multiPolygon2)),
+                totalPointCount - 2, totalLineCount - 2, totalAreaCount - 1, totalRelationCount);
+
+    }
+
+    /**
+     * Tests the various forms of configurable multipolygons
+     */
+    @Test
+    public void testMultiPolygonForms()
+    {
+        final Atlas testMultiPolygonFormsAtlas = this.setup.getMultiPolygons();
+        final Polygon outerPolygon = this.getPolygonWithName(testMultiPolygonFormsAtlas,
+                "multipolygon1-outer1");
+        final Polygon innerPolygon1 = this.getPolygonWithName(testMultiPolygonFormsAtlas,
+                "multipolygon1-inner1");
+        final Polygon innerPolygon2 = this.getPolygonWithName(testMultiPolygonFormsAtlas,
+                "multipolygon1-inner2");
+        final MultiMap<Polygon, Polygon> multiPolygonMap = new MultiMap<>();
+        multiPolygonMap.add(outerPolygon, innerPolygon1);
+        multiPolygonMap.add(outerPolygon, innerPolygon2);
+        final MultiPolygon multiPolygon1 = new MultiPolygon(multiPolygonMap);
+
+        final String wktConfigurationStringFormat = "{\"filter.multipolygons\":{\"include.wkt\":[\"%s\"]}}";
+        final String wkbConfigurationStringFormat = "{\"filter.multipolygons\":{\"include.wkb\":[\"%s\"]}}";
+        final String atlasConfigurationStringFormat = "{\"filter.multipolygons\":{\"include.atlas\":[\"%s\"]}}";
+        final String geojsonConfigurationStringFormat = "{\"filter.multipolygons\":{\"include.geojson\":[\"%s\"]}}";
+
+        this.assertCounts(testMultiPolygonFormsAtlas,
+                this.constructConfiguredFilter(wkbConfigurationStringFormat,
+                        WKBWriter.toHex(new WkbMultiPolygonConverter().convert(multiPolygon1))),
+                3, 1, -1, -1);
+        this.assertCounts(testMultiPolygonFormsAtlas,
+                this.constructConfiguredFilter(wktConfigurationStringFormat,
+                        new WktMultiPolygonConverter().convert(multiPolygon1)),
+                3, 1, -1, -1);
+        this.assertCounts(testMultiPolygonFormsAtlas,
+                this.constructConfiguredFilter(atlasConfigurationStringFormat,
+                        new MultiPolygonStringConverter().backwardConvert(multiPolygon1)),
+                3, 1, -1, -1);
+        this.assertCounts(testMultiPolygonFormsAtlas,
+                this.constructConfiguredFilter(geojsonConfigurationStringFormat, multiPolygon1
+                        .asGeoJsonFeatureCollection().toString().replaceAll("\"", "\\\\\"")),
+                3, 1, -1, -1);
     }
 
     private void assertCounts(final Atlas atlas, final Predicate<AtlasEntity> filter,
@@ -175,7 +420,7 @@ public class AtlasEntityPolygonsFilterTest
         }
     }
 
-    private AtlasEntityPolygonsFilter constructFilter(final String format,
+    private AtlasEntityPolygonsFilter constructConfiguredFilter(final String format,
             final Object... polygonStrings)
     {
         return AtlasEntityPolygonsFilter.forConfiguration(new StandardConfiguration(

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -77,7 +77,6 @@ public class AtlasEntityPolygonsFilterTest
                 totalLineCount - 2L, totalAreaCount, totalRelationCount);
         this.assertCounts(testCountsAtlas, excludePolygon1And2, 1L, 2L, 0L, 0L);
         this.assertCounts(testCountsAtlas, includePolygon1And2.negate(), 1L, 2L, 0L, 0L);
-
     }
 
     /**
@@ -124,9 +123,9 @@ public class AtlasEntityPolygonsFilterTest
         final Polygon includePolygon = this.getPolygonWithName(includeExcludeArrangements,
                 "include");
 
-        for (int caseNum = 1; caseNum <= numberOfCases; caseNum++)
+        for (int caseNumber = 1; caseNumber <= numberOfCases; caseNumber++)
         {
-            final String caseString = String.format("case_%d", caseNum);
+            final String caseString = String.format("case_%d", caseNumber);
             final String excludePolygonName = "exclude_".concat(caseString);
             final Polygon excludePolygon = this.getPolygonWithName(includeExcludeArrangements,
                     excludePolygonName);
@@ -179,7 +178,7 @@ public class AtlasEntityPolygonsFilterTest
     private AtlasEntityPolygonsFilter constructFilter(final String format,
             final Object... polygonStrings)
     {
-        return new AtlasEntityPolygonsFilter(new StandardConfiguration(
+        return AtlasEntityPolygonsFilter.forConfiguration(new StandardConfiguration(
                 new StringResource(String.format(format, polygonStrings))));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -38,8 +38,7 @@ import com.vividsolutions.jts.io.WKBWriter;
  */
 public class AtlasEntityPolygonsFilterTest
 {
-
-    private static final AtlasEntityPolygonsFilter.IntersectionDeciding FULL_GEOMETRIC_ENCLOSING = new AtlasEntityPolygonsFilter.IntersectionDeciding()
+    private static final AtlasEntityPolygonsFilter.IntersectionPolicy FULL_GEOMETRIC_ENCLOSING = new AtlasEntityPolygonsFilter.IntersectionPolicy()
     {
         @Override
         public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
@@ -238,7 +237,7 @@ public class AtlasEntityPolygonsFilterTest
     }
 
     @Test
-    public void testIntersectionDeciding()
+    public void testIntersectionPolicy()
     {
 
         final Atlas testCountsAtlas = this.setup.getTestCounts();
@@ -248,7 +247,7 @@ public class AtlasEntityPolygonsFilterTest
         final long totalLineCount = testCountsAtlas.numberOfLines();
         final long totalAreaCount = testCountsAtlas.numberOfAreas();
         final long totalRelationCount = testCountsAtlas.numberOfRelations();
-        final AtlasEntityPolygonsFilter.IntersectionDeciding dudIntersectionDeciding = new AtlasEntityPolygonsFilter.IntersectionDeciding()
+        final AtlasEntityPolygonsFilter.IntersectionPolicy dudIntersectionPolicy = new AtlasEntityPolygonsFilter.IntersectionPolicy()
         {
             @Override
             public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
@@ -265,25 +264,25 @@ public class AtlasEntityPolygonsFilterTest
             }
         };
 
-        // Test all three decision makers on the first polygon
+        // Test all three policies on the first polygon
         this.assertCounts(testCountsAtlas,
                 AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_DECIDING,
+                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_POLICY,
                         Collections.singleton(polygon1)),
                 2L, 3L, 1L, 0L);
-        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                dudIntersectionDeciding, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(dudIntersectionPolicy, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
                 FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
 
         // Test all three decision makers on two polygon filter
         this.assertCounts(testCountsAtlas,
                 AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_DECIDING,
+                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_POLICY,
                         Arrays.asList(polygon1, polygon2)),
                 totalPointCount - 1L, totalLineCount - 2L, totalAreaCount, totalRelationCount);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
-                .polygons(dudIntersectionDeciding, Arrays.asList(polygon1, polygon2)), 0, 0, 0, 0);
+                .polygons(dudIntersectionPolicy, Arrays.asList(polygon1, polygon2)), 0, 0, 0, 0);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(FULL_GEOMETRIC_ENCLOSING, Arrays.asList(polygon1, polygon2)), 2, 1, 0, 0);
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.utilities.filters;
 
+import static org.openstreetmap.atlas.utilities.filters.IntersectionPolicy.DEFAULT_INTERSECTION_POLICY;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -38,7 +40,7 @@ import com.vividsolutions.jts.io.WKBWriter;
  */
 public class AtlasEntityPolygonsFilterTest
 {
-    private static final AtlasEntityPolygonsFilter.IntersectionPolicy FULL_GEOMETRIC_ENCLOSING = new AtlasEntityPolygonsFilter.IntersectionPolicy()
+    private static final IntersectionPolicy FULL_GEOMETRIC_ENCLOSING = new IntersectionPolicy()
     {
         @Override
         public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
@@ -247,7 +249,7 @@ public class AtlasEntityPolygonsFilterTest
         final long totalLineCount = testCountsAtlas.numberOfLines();
         final long totalAreaCount = testCountsAtlas.numberOfAreas();
         final long totalRelationCount = testCountsAtlas.numberOfRelations();
-        final AtlasEntityPolygonsFilter.IntersectionPolicy dudIntersectionPolicy = new AtlasEntityPolygonsFilter.IntersectionPolicy()
+        final IntersectionPolicy dudIntersectionPolicy = new IntersectionPolicy()
         {
             @Override
             public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
@@ -265,10 +267,9 @@ public class AtlasEntityPolygonsFilterTest
         };
 
         // Test all three policies on the first polygon
-        this.assertCounts(testCountsAtlas,
-                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_POLICY,
-                        Collections.singleton(polygon1)),
+        this.assertCounts(
+                testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                        .polygons(DEFAULT_INTERSECTION_POLICY, Collections.singleton(polygon1)),
                 2L, 3L, 1L, 0L);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(dudIntersectionPolicy, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
@@ -277,8 +278,7 @@ public class AtlasEntityPolygonsFilterTest
 
         // Test all three decision makers on two polygon filter
         this.assertCounts(testCountsAtlas,
-                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                        AtlasEntityPolygonsFilter.DEFAULT_INTERSECTION_POLICY,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(DEFAULT_INTERSECTION_POLICY,
                         Arrays.asList(polygon1, polygon2)),
                 totalPointCount - 1L, totalLineCount - 2L, totalAreaCount, totalRelationCount);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
@@ -400,6 +400,40 @@ public class AtlasEntityPolygonsFilterTest
                 this.constructConfiguredFilter(geojsonConfigurationStringFormat, multiPolygon1
                         .asGeoJsonFeatureCollection().toString().replaceAll("\"", "\\\\\"")),
                 3, 1, -1, -1);
+    }
+
+    @Test
+    public void testOverlappingPolygons()
+    {
+        final Atlas testOverlappingPolygonsAtlas = this.setup.getOverlappingPolygons();
+        final Polygon polygon1 = this.getPolygonWithName(testOverlappingPolygonsAtlas, "polygon1");
+        final Polygon polygon2 = this.getPolygonWithName(testOverlappingPolygonsAtlas, "polygon2");
+        final Polygon polygon3 = this.getPolygonWithName(testOverlappingPolygonsAtlas, "polygon3");
+        final Polygon polygon4 = this.getPolygonWithName(testOverlappingPolygonsAtlas, "polygon4");
+        final Polygon polygon5 = this.getPolygonWithName(testOverlappingPolygonsAtlas, "polygon5");
+        final MultiMap<Polygon, Polygon> multiPolygonMap1 = new MultiMap<>();
+        final MultiMap<Polygon, Polygon> multiPolygonMap2 = new MultiMap<>();
+        multiPolygonMap1.add(polygon3, polygon4);
+        multiPolygonMap2.add(polygon5, polygon2);
+
+        final MultiPolygon multiPolygon1 = new MultiPolygon(multiPolygonMap1);
+        final MultiPolygon multiPolygon2 = new MultiPolygon(multiPolygonMap2);
+
+        // Test overlapping polygons
+        this.assertCounts(testOverlappingPolygonsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(Arrays.asList(polygon1, polygon2, polygon3)), 2, 4, -1, -1);
+        this.assertCounts(testOverlappingPolygonsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .polygons(Arrays.asList(polygon2, polygon1, polygon3)), 4, 5, -1, -1);
+        this.assertCounts(testOverlappingPolygonsAtlas,
+                AtlasEntityPolygonsFilter.Type.INCLUDE.polygonsAndMultiPolygons(
+                        Arrays.asList(polygon1, polygon2), Collections.singleton(multiPolygon1)),
+                2, 4, -1, -1);
+
+        // Test overlapping multipolygons
+        this.assertCounts(testOverlappingPolygonsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .multiPolygons(Arrays.asList(multiPolygon1, multiPolygon2)), 0, 3, -1, -1);
+        this.assertCounts(testOverlappingPolygonsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .multiPolygons(Arrays.asList(multiPolygon2, multiPolygon1)), 1, 6, -1, -1);
     }
 
     private void assertCounts(final Atlas atlas, final Predicate<AtlasEntity> filter,

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
@@ -13,6 +13,8 @@ public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
 {
     @TestAtlas(loadFromJosmOsmResource = "includeExcludePolygonArrangements.osm")
     private Atlas includeExcludeArrangements;
+    @TestAtlas(loadFromJosmOsmResource = "multiPolygons.osm")
+    private Atlas multiPolygons;
     @TestAtlas(loadFromJosmOsmResource = "testCounts.osm")
     private Atlas testCounts;
     @TestAtlas(loadFromJosmOsmResource = "testForms.osm")
@@ -21,6 +23,11 @@ public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
     public Atlas getIncludeExcludeArrangements()
     {
         return this.includeExcludeArrangements;
+    }
+
+    public Atlas getMultiPolygons()
+    {
+        return this.multiPolygons;
     }
 
     public Atlas getTestCounts()

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
@@ -1,0 +1,35 @@
+package org.openstreetmap.atlas.utilities.filters;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * Test Rule for {@link AtlasEntityPolygonsFilterTest}
+ *
+ * @author jklamer
+ */
+public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "includeExcludePolygonArrangements.osm")
+    private Atlas includeExcludeArrangements;
+    @TestAtlas(loadFromJosmOsmResource = "testCounts.osm")
+    private Atlas testCounts;
+    @TestAtlas(loadFromJosmOsmResource = "testForms.osm")
+    private Atlas testForm;
+
+    public Atlas getIncludeExcludeArrangements()
+    {
+        return this.includeExcludeArrangements;
+    }
+
+    public Atlas getTestCounts()
+    {
+        return this.testCounts;
+    }
+
+    public Atlas getTestForm()
+    {
+        return this.testForm;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTestRule.java
@@ -15,6 +15,8 @@ public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
     private Atlas includeExcludeArrangements;
     @TestAtlas(loadFromJosmOsmResource = "multiPolygons.osm")
     private Atlas multiPolygons;
+    @TestAtlas(loadFromJosmOsmResource = "overlappingPolygons.osm")
+    private Atlas overlappingPolygons;
     @TestAtlas(loadFromJosmOsmResource = "testCounts.osm")
     private Atlas testCounts;
     @TestAtlas(loadFromJosmOsmResource = "testForms.osm")
@@ -28,6 +30,11 @@ public class AtlasEntityPolygonsFilterTestRule extends CoreTestRule
     public Atlas getMultiPolygons()
     {
         return this.multiPolygons;
+    }
+
+    public Atlas getOverlappingPolygons()
+    {
+        return this.overlappingPolygons;
     }
 
     public Atlas getTestCounts()

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/includeExcludePolygonArrangements.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/includeExcludePolygonArrangements.osm
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-38986' action='modify' lat='26.97532157261' lon='-45.28701816559' />
+  <node id='-38988' action='modify' lat='26.97470963111' lon='-45.17200504303' />
+  <node id='-38990' action='modify' lat='26.87491874122' lon='-45.17440830231' />
+  <node id='-38992' action='modify' lat='26.87614370399' lon='-45.29045139313' />
+  <node id='-38994' action='modify' lat='26.95910399899' lon='-45.21869693756' />
+  <node id='-38996' action='modify' lat='26.95910399899' lon='-45.19363437653' />
+  <node id='-38998' action='modify' lat='26.93706883755' lon='-45.19397769928' />
+  <node id='-39000' action='modify' lat='26.93676276331' lon='-45.21869693756' />
+  <node id='-39002' action='modify' lat='26.88808639533' lon='-45.30864749908' />
+  <node id='-39004' action='modify' lat='26.88533050164' lon='-45.12874637604' />
+  <node id='-39006' action='modify' lat='26.78116977658' lon='-45.13114963531' />
+  <node id='-39008' action='modify' lat='26.78392820597' lon='-45.31585727692' />
+  <node id='-39010' action='modify' lat='26.98266461115' lon='-45.38589511871' />
+  <node id='-39012' action='modify' lat='26.98235866077' lon='-45.33439670563' />
+  <node id='-39014' action='modify' lat='26.93278372258' lon='-45.33508335114' />
+  <node id='-39016' action='modify' lat='26.93339589183' lon='-45.38658176422' />
+  <node id='-39018' action='modify' lat='27.05178835252' lon='-45.426407547' />
+  <node id='-39020' action='modify' lat='27.05056529863' lon='-45.0487525177' />
+  <node id='-39022' action='modify' lat='26.69286497728' lon='-45.04463264465' />
+  <node id='-39024' action='modify' lat='26.70513367403' lon='-45.44563362122' />
+  <node id='-39026' action='modify' lat='26.95436052931' lon='-45.23019807816' />
+  <node id='-39028' action='modify' lat='26.95436052931' lon='-45.20891206741' />
+  <node id='-39030' action='modify' lat='26.94808680378' lon='-45.24942415237' />
+  <node id='-39032' action='modify' lat='26.94823982563' lon='-45.23019807816' />
+  <node id='-39034' action='modify' lat='26.94833588924' lon='-45.16047971726' />
+  <node id='-39036' action='modify' lat='26.94848891076' lon='-45.14588850021' />
+  <node id='-39038' action='modify' lat='26.90462034578' lon='-45.26744876862' />
+  <node id='-39040' action='modify' lat='26.89237320746' lon='-45.26744876862' />
+  <node id='-39042' action='modify' lat='26.89145461855' lon='-45.257149086' />
+  <node id='-39044' action='modify' lat='26.87116721019' lon='-45.257149086' />
+  <node id='-39046' action='modify' lat='26.86955921994' lon='-45.26916521072' />
+  <node id='-39048' action='modify' lat='26.850110237' lon='-45.26950853348' />
+  <node id='-39050' action='modify' lat='26.96124607654' lon='-45.27774845123' />
+  <node id='-39052' action='modify' lat='26.96430611665' lon='-45.34469638824' />
+  <node id='-39054' action='modify' lat='26.9523714901' lon='-45.27362857819' />
+  <node id='-39056' action='modify' lat='26.95267752196' lon='-45.28427158356' />
+  <node id='-39058' action='modify' lat='26.97623947862' lon='-45.30590091705' />
+  <node id='-39060' action='modify' lat='26.97654544563' lon='-45.32203708649' />
+  <node id='-39062' action='modify' lat='26.9572679001' lon='-45.25680576324' />
+  <node id='-39064' action='modify' lat='26.96644809526' lon='-45.25680576324' />
+  <node id='-39066' action='modify' lat='26.96736607362' lon='-45.24616275787' />
+  <node id='-39068' action='modify' lat='27.0001024073' lon='-45.24547611237' />
+  <node id='-39070' action='modify' lat='26.99979650435' lon='-45.26195560455' />
+  <node id='-39072' action='modify' lat='27.02579528372' lon='-45.26195560455' />
+  <way id='-39074' action='modify'>
+    <nd ref='-38986' />
+    <nd ref='-38988' />
+    <nd ref='-38990' />
+    <nd ref='-38992' />
+    <nd ref='-38986' />
+    <tag k='name' v='include' />
+  </way>
+  <way id='-39076' action='modify'>
+    <nd ref='-38994' />
+    <nd ref='-38996' />
+    <nd ref='-38998' />
+    <nd ref='-39000' />
+    <nd ref='-38994' />
+    <tag k='name' v='exclude_case_1' />
+  </way>
+  <way id='-39078' action='modify'>
+    <nd ref='-39002' />
+    <nd ref='-39004' />
+    <nd ref='-39006' />
+    <nd ref='-39008' />
+    <nd ref='-39002' />
+    <tag k='name' v='exclude_case_2' />
+  </way>
+  <way id='-39080' action='modify'>
+    <nd ref='-39010' />
+    <nd ref='-39012' />
+    <nd ref='-39014' />
+    <nd ref='-39016' />
+    <nd ref='-39010' />
+    <tag k='name' v='exclude_case_3' />
+  </way>
+  <way id='-39082' action='modify'>
+    <nd ref='-39018' />
+    <nd ref='-39020' />
+    <nd ref='-39022' />
+    <nd ref='-39024' />
+    <nd ref='-39018' />
+    <tag k='name' v='exclude_case_4' />
+  </way>
+  <way id='-39084' action='modify'>
+    <nd ref='-39026' />
+    <nd ref='-39028' />
+    <tag k='name' v='case_1_included' />
+  </way>
+  <way id='-39086' action='modify'>
+    <nd ref='-39030' />
+    <nd ref='-39032' />
+    <tag k='name' v='case_1_included' />
+  </way>
+  <way id='-39088' action='modify'>
+    <nd ref='-39034' />
+    <nd ref='-39036' />
+    <tag k='name' v='case_1_excluded' />
+  </way>
+  <way id='-39090' action='modify'>
+    <nd ref='-39038' />
+    <nd ref='-39040' />
+    <tag k='name' v='case_2_included' />
+  </way>
+  <way id='-39092' action='modify'>
+    <nd ref='-39042' />
+    <nd ref='-39044' />
+    <tag k='name' v='case_2_included' />
+  </way>
+  <way id='-39094' action='modify'>
+    <nd ref='-39046' />
+    <nd ref='-39048' />
+    <tag k='name' v='case_2_excluded' />
+  </way>
+  <way id='-39096' action='modify'>
+    <nd ref='-39050' />
+    <nd ref='-39052' />
+    <tag k='name' v='case_3_included' />
+  </way>
+  <way id='-39098' action='modify'>
+    <nd ref='-39054' />
+    <nd ref='-39056' />
+    <tag k='name' v='case_3_included' />
+  </way>
+  <way id='-39100' action='modify'>
+    <nd ref='-39058' />
+    <nd ref='-39060' />
+    <tag k='name' v='case_3_excluded' />
+  </way>
+  <way id='-39102' action='modify'>
+    <nd ref='-39062' />
+    <nd ref='-39064' />
+    <tag k='name' v='case_4_included' />
+  </way>
+  <way id='-39104' action='modify'>
+    <nd ref='-39066' />
+    <nd ref='-39068' />
+    <tag k='name' v='case_4_included' />
+  </way>
+  <way id='-39106' action='modify'>
+    <nd ref='-39070' />
+    <nd ref='-39072' />
+    <tag k='name' v='case_4_excluded' />
+  </way>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/multiPolygons.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/multiPolygons.osm
@@ -1,0 +1,241 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-39906' action='modify' lat='34.27750317356' lon='-33.60906618118' />
+  <node id='-39909' action='modify' lat='34.27750317356' lon='-33.58554857254' />
+  <node id='-39913' action='modify' lat='34.25877726571' lon='-33.58486192703' />
+  <node id='-39915' action='modify' lat='34.25920290083' lon='-33.60975282669' />
+  <node id='-39919' action='modify' lat='34.28232583805' lon='-33.53920000076' />
+  <node id='-39920' action='modify' lat='34.28190031996' lon='-33.50709932327' />
+  <node id='-39922' action='modify' lat='34.24175009505' lon='-33.5069276619' />
+  <node id='-39924' action='modify' lat='34.24231772291' lon='-33.55190294266' />
+  <node id='-39926' action='modify' lat='34.28190031996' lon='-33.55052965164' />
+  <node id='-39930' action='modify' lat='34.26104722387' lon='-33.54520806313' />
+  <node id='-39931' action='modify' lat='34.26083441124' lon='-33.53035935402' />
+  <node id='-39933' action='modify' lat='34.2477808744' lon='-33.53061684608' />
+  <node id='-39935' action='modify' lat='34.24820656516' lon='-33.54529389381' />
+  <node id='-39939' action='modify' lat='34.27757402618' lon='-33.52769860268' />
+  <node id='-39940' action='modify' lat='34.26402654409' lon='-33.52821358681' />
+  <node id='-39942' action='modify' lat='34.263813739' lon='-33.51284989357' />
+  <node id='-39944' action='modify' lat='34.27771587308' lon='-33.51267823219' />
+  <node id='-39948' action='modify' lat='34.22826795032' lon='-33.61301456451' />
+  <node id='-39949' action='modify' lat='34.22628090452' lon='-33.58417545319' />
+  <node id='-39951' action='modify' lat='34.21975170967' lon='-33.57524906158' />
+  <node id='-39953' action='modify' lat='34.20839538286' lon='-33.57421909332' />
+  <node id='-39955' action='modify' lat='34.1953337151' lon='-33.58486209869' />
+  <node id='-39957' action='modify' lat='34.18539413402' lon='-33.62159763336' />
+  <node id='-39959' action='modify' lat='34.19817338024' lon='-33.65181003571' />
+  <node id='-39961' action='modify' lat='34.21577716939' lon='-33.68476902008' />
+  <node id='-39963' action='modify' lat='34.2004450435' lon='-33.69541202545' />
+  <node id='-39965' action='modify' lat='34.181986008' lon='-33.68476902008' />
+  <node id='-39967' action='modify' lat='34.17090864758' lon='-33.66073642731' />
+  <node id='-39969' action='modify' lat='34.16522738588' lon='-33.69712863922' />
+  <node id='-39971' action='modify' lat='34.18738214395' lon='-33.71704135895' />
+  <node id='-39973' action='modify' lat='34.22997109513' lon='-33.68648563385' />
+  <node id='-39975' action='modify' lat='34.22968724005' lon='-33.67446933746' />
+  <node id='-39977' action='modify' lat='34.22315830926' lon='-33.65627323151' />
+  <node id='-39979' action='modify' lat='34.21492545779' lon='-33.64837680817' />
+  <node id='-39981' action='modify' lat='34.21492545779' lon='-33.63327060699' />
+  <node id='-39983' action='modify' lat='34.22684863668' lon='-33.63018070221' />
+  <node id='-39985' action='modify' lat='34.23394496572' lon='-33.62571750641' />
+  <node id='-39987' action='modify' lat='34.23422880644' lon='-33.61713443756' />
+  <node id='-39989' action='modify' lat='34.23053880241' lon='-33.61507450104' />
+  <node id='-39993' action='modify' lat='34.21776446297' lon='-33.5989383316' />
+  <node id='-39994' action='modify' lat='34.21180244161' lon='-33.62228427887' />
+  <node id='-39996' action='modify' lat='34.20328453649' lon='-33.62262760162' />
+  <node id='-39998' action='modify' lat='34.2004450435' lon='-33.60992465973' />
+  <node id='-40000' action='modify' lat='34.20356848053' lon='-33.59687839508' />
+  <node id='-40002' action='modify' lat='34.20953108441' lon='-33.58863864899' />
+  <node id='-40004' action='modify' lat='34.21322200876' lon='-33.58760868073' />
+  <node id='-40019' action='modify' lat='34.27665208639' lon='-33.5448648262'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40020' action='modify' lat='34.26927563672' lon='-33.53920000076'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40021' action='modify' lat='34.27253837697' lon='-33.51842897415'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40022' action='modify' lat='34.2548045674' lon='-33.53851335526'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40023' action='modify' lat='34.25210870099' lon='-33.51757066727'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40024' action='modify' lat='34.27168723955' lon='-33.6037446785'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40025' action='modify' lat='34.26941749763' lon='-33.59241502762'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40026' action='modify' lat='34.26402661502' lon='-33.60134141922'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40031' action='modify' lat='34.25792598901' lon='-33.53576677322' />
+  <node id='-40032' action='modify' lat='34.25125735681' lon='-33.5359384346' />
+  <node id='-40034' action='modify' lat='34.25806786906' lon='-33.54194658279' />
+  <node id='-40035' action='modify' lat='34.25210870099' lon='-33.54228990555' />
+  <node id='-40037' action='modify' lat='34.27324765158' lon='-33.52357881546' />
+  <node id='-40038' action='modify' lat='34.26728955893' lon='-33.52357881546' />
+  <node id='-40040' action='modify' lat='34.2675732872' lon='-33.51980226517' />
+  <node id='-40042' action='modify' lat='34.27310579714' lon='-33.52066057205' />
+  <node id='-40045' action='modify' lat='34.25707470369' lon='-33.52151887894' />
+  <node id='-40046' action='modify' lat='34.25707470369' lon='-33.51396577835' />
+  <node id='-40048' action='modify' lat='34.26133104413' lon='-33.51602571487' />
+  <node id='-40050' action='modify' lat='34.26076354452' lon='-33.52306383133' />
+  <node id='-40054' action='modify' lat='34.27126166761' lon='-33.54280488968' />
+  <node id='-40055' action='modify' lat='34.26601276987' lon='-33.54125993729' />
+  <node id='-40057' action='modify' lat='34.26743142319' lon='-33.5337068367' />
+  <node id='-40059' action='modify' lat='34.27282208753' lon='-33.53628175735' />
+  <node id='-40062' action='modify' lat='34.24586531032' lon='-33.52272050858' />
+  <node id='-40063' action='modify' lat='34.24629101076' lon='-33.51448076248' />
+  <node id='-40065' action='modify' lat='34.24969653678' lon='-33.51259248734' />
+  <node id='-40067' action='modify' lat='34.26743156505' lon='-33.6034015274' />
+  <node id='-40068' action='modify' lat='34.26374301666' lon='-33.59310184479' />
+  <node id='-40071' action='modify' lat='34.20754359665' lon='-33.64940677643' />
+  <node id='-40072' action='modify' lat='34.19675355962' lon='-33.62983737946' />
+  <node id='-40074' action='modify' lat='34.19419782226' lon='-33.60958133698' />
+  <node id='-40076' action='modify' lat='34.20328453649' lon='-33.58623538971' />
+  <node id='-40078' action='modify' lat='34.21890003825' lon='-33.5855487442' />
+  <node id='-40080' action='modify' lat='34.22173890951' lon='-33.61438785553' />
+  <node id='-40082' action='modify' lat='34.20811145508' lon='-33.63464389801' />
+  <node id='-40161' action='modify' lat='34.21833225252' lon='-33.66485630035' />
+  <node id='-40162' action='modify' lat='34.21265418477' lon='-33.66725955963' />
+  <node id='-40164' action='modify' lat='34.21066677066' lon='-33.6600497818' />
+  <node id='-40166' action='modify' lat='34.21606107134' lon='-33.65764652252' />
+  <node id='-40170' action='modify' lat='34.21066677066' lon='-33.64563022614'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-40171' action='modify' lat='34.20640786832' lon='-33.63979373932'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <way id='-39910' action='modify'>
+    <nd ref='-39906' />
+    <nd ref='-39909' />
+    <nd ref='-39913' />
+    <nd ref='-39915' />
+    <nd ref='-39906' />
+    <tag k='name' v='polygon1' />
+  </way>
+  <way id='-39921' action='modify'>
+    <nd ref='-39919' />
+    <nd ref='-39920' />
+    <nd ref='-39922' />
+    <nd ref='-39924' />
+    <nd ref='-39926' />
+    <nd ref='-39919' />
+    <tag k='name' v='multipolygon1-outer1' />
+  </way>
+  <way id='-39932' action='modify'>
+    <nd ref='-39930' />
+    <nd ref='-39931' />
+    <nd ref='-39933' />
+    <nd ref='-39935' />
+    <nd ref='-39930' />
+    <tag k='name' v='multipolygon1-inner1' />
+  </way>
+  <way id='-39941' action='modify'>
+    <nd ref='-39939' />
+    <nd ref='-39940' />
+    <nd ref='-39942' />
+    <nd ref='-39944' />
+    <nd ref='-39939' />
+    <tag k='name' v='multipolygon1-inner2' />
+  </way>
+  <way id='-39950' action='modify'>
+    <nd ref='-39948' />
+    <nd ref='-39949' />
+    <nd ref='-39951' />
+    <nd ref='-39953' />
+    <nd ref='-39955' />
+    <nd ref='-39957' />
+    <nd ref='-39959' />
+    <nd ref='-39961' />
+    <nd ref='-39963' />
+    <nd ref='-39965' />
+    <nd ref='-39967' />
+    <nd ref='-39969' />
+    <nd ref='-39971' />
+    <nd ref='-39973' />
+    <nd ref='-39975' />
+    <nd ref='-39977' />
+    <nd ref='-39979' />
+    <nd ref='-39981' />
+    <nd ref='-39983' />
+    <nd ref='-39985' />
+    <nd ref='-39987' />
+    <nd ref='-39989' />
+    <nd ref='-39948' />
+    <tag k='name' v='multipolygon2-outer1' />
+  </way>
+  <way id='-39995' action='modify'>
+    <nd ref='-39993' />
+    <nd ref='-39994' />
+    <nd ref='-39996' />
+    <nd ref='-39998' />
+    <nd ref='-40000' />
+    <nd ref='-40002' />
+    <nd ref='-40004' />
+    <nd ref='-39993' />
+    <tag k='name' v='multipolygon2-inner1' />
+  </way>
+  <way id='-40033' action='modify'>
+    <nd ref='-40031' />
+    <nd ref='-40032' />
+  </way>
+  <way id='-40036' action='modify'>
+    <nd ref='-40034' />
+    <nd ref='-40035' />
+  </way>
+  <way id='-40039' action='modify'>
+    <nd ref='-40037' />
+    <nd ref='-40038' />
+    <nd ref='-40040' />
+    <nd ref='-40042' />
+    <nd ref='-40037' />
+  </way>
+  <way id='-40047' action='modify'>
+    <nd ref='-40045' />
+    <nd ref='-40046' />
+    <nd ref='-40048' />
+    <nd ref='-40050' />
+    <nd ref='-40045' />
+  </way>
+  <way id='-40056' action='modify'>
+    <nd ref='-40054' />
+    <nd ref='-40055' />
+    <nd ref='-40057' />
+    <nd ref='-40059' />
+    <nd ref='-40054' />
+  </way>
+  <way id='-40064' action='modify'>
+    <nd ref='-40062' />
+    <nd ref='-40063' />
+    <nd ref='-40065' />
+  </way>
+  <way id='-40069' action='modify'>
+    <nd ref='-40067' />
+    <nd ref='-40068' />
+  </way>
+  <way id='-40073' action='modify'>
+    <nd ref='-40071' />
+    <nd ref='-40072' />
+    <nd ref='-40074' />
+    <nd ref='-40076' />
+    <nd ref='-40078' />
+    <nd ref='-40080' />
+    <nd ref='-40082' />
+  </way>
+  <way id='-40163' action='modify'>
+    <nd ref='-40161' />
+    <nd ref='-40162' />
+    <nd ref='-40164' />
+    <nd ref='-40166' />
+    <nd ref='-40161' />
+  </way>
+  <relation id='-40242' action='modify'>
+    <member type='node' ref='-40025' role='memeber1' />
+    <member type='way' ref='-40163' role='memeber2' />
+    <member type='way' ref='-40064' role='memeber3' />
+    <tag k='name' v='relation1' />
+  </relation>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/overlappingPolygons.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/overlappingPolygons.osm
@@ -1,0 +1,172 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-38988' action='modify' lat='47.59521189372' lon='-122.2439576414' />
+  <node id='-38991' action='modify' lat='47.59945226292' lon='-122.24000505415' />
+  <node id='-38995' action='modify' lat='47.59775615648' lon='-122.26255276778' />
+  <node id='-38997' action='modify' lat='47.59212226548' lon='-122.26416973529' />
+  <node id='-38999' action='modify' lat='47.58830541404' lon='-122.26093580027' />
+  <node id='-39001' action='modify' lat='47.58691189097' lon='-122.2499763538' />
+  <node id='-39003' action='modify' lat='47.58721483393' lon='-122.23793892899' />
+  <node id='-39005' action='modify' lat='47.5899412416' lon='-122.23533381467' />
+  <node id='-39007' action='modify' lat='47.5925463429' lon='-122.24189151624' />
+  <node id='-39009' action='modify' lat='47.59327332477' lon='-122.24674241878' />
+  <node id='-39011' action='modify' lat='47.59454551874' lon='-122.24575427197' />
+  <node id='-39015' action='modify' lat='47.59393971595' lon='-122.24225084236' />
+  <node id='-39016' action='modify' lat='47.59248576062' lon='-122.23820842358' />
+  <node id='-39018' action='modify' lat='47.59315216183' lon='-122.23281853187' />
+  <node id='-39020' action='modify' lat='47.59612057319' lon='-122.2341660048' />
+  <node id='-39022' action='modify' lat='47.59636288505' lon='-122.23937623345' />
+  <node id='-39024' action='modify' lat='47.59490899705' lon='-122.2420711793' />
+  <node id='-39027' action='modify' lat='47.6033894409' lon='-122.215840373' />
+  <node id='-39028' action='modify' lat='47.60187517675' lon='-122.2329083634' />
+  <node id='-39030' action='modify' lat='47.59933111428' lon='-122.23739993982' />
+  <node id='-39032' action='modify' lat='47.59515131453' lon='-122.23757960288' />
+  <node id='-39034' action='modify' lat='47.58794188986' lon='-122.2294049338' />
+  <node id='-39036' action='modify' lat='47.58594246174' lon='-122.21763700357' />
+  <node id='-39038' action='modify' lat='47.58757836316' lon='-122.20973182907' />
+  <node id='-39040' action='modify' lat='47.59085001259' lon='-122.20721654628' />
+  <node id='-39042' action='modify' lat='47.5966657733' lon='-122.20730637781' />
+  <node id='-39044' action='modify' lat='47.59957341128' lon='-122.20838435615' />
+  <node id='-39046' action='modify' lat='47.60266259958' lon='-122.21386407938' />
+  <node id='-39091' action='modify' lat='47.59442435875' lon='-122.23964572803'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-39092' action='modify' lat='47.5947878379' lon='-122.23488465703'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-39093' action='modify' lat='47.59369739286' lon='-122.23829825511' />
+  <node id='-39094' action='modify' lat='47.59393971595' lon='-122.23470499397' />
+  <node id='-39117' action='modify' lat='47.59484841751' lon='-122.2566238869' />
+  <node id='-39118' action='modify' lat='47.59127410033' lon='-122.25653405538' />
+  <node id='-39120' action='modify' lat='47.59115293275' lon='-122.2506051745' />
+  <node id='-39122' action='modify' lat='47.59424261822' lon='-122.2499763538' />
+  <node id='-39124' action='modify' lat='47.59551478863' lon='-122.25338995188' />
+  <node id='-39126' action='modify' lat='47.59581768179' lon='-122.25680354996' />
+  <node id='-39150' action='modify' lat='47.59857529659' lon='-122.22208270128'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-39151' action='modify' lat='47.5917904272' lon='-122.221184386'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-39152' action='modify' lat='47.59154809416' lon='-122.21435718984'>
+    <tag k='name' v='aPoint' />
+  </node>
+  <node id='-39153' action='modify' lat='47.59869644698' lon='-122.22917939203' />
+  <node id='-39154' action='modify' lat='47.59693973891' lon='-122.21606398888' />
+  <node id='-39170' action='modify' lat='47.57955120639' lon='-122.26556116103' />
+  <node id='-39171' action='modify' lat='47.57930881669' lon='-122.23268282163' />
+  <node id='-39173' action='modify' lat='47.58427758132' lon='-122.19872650389' />
+  <node id='-39175' action='modify' lat='47.59700031603' lon='-122.19297728608' />
+  <node id='-39177' action='modify' lat='47.60711571161' lon='-122.20717066756' />
+  <node id='-39179' action='modify' lat='47.60814531286' lon='-122.23349130539' />
+  <node id='-39181' action='modify' lat='47.60402678628' lon='-122.25999160627' />
+  <node id='-39183' action='modify' lat='47.59893874691' lon='-122.27220869414' />
+  <node id='-39185' action='modify' lat='47.58603471447' lon='-122.27454431387' />
+  <node id='-39187' action='modify' lat='47.58106611661' lon='-122.26897475911' />
+  <node id='-39190' action='modify' lat='47.59445601652' lon='-122.20007397682' />
+  <node id='-39191' action='modify' lat='47.60305767407' lon='-122.20744016215' />
+  <node id='-39193' action='modify' lat='47.60487474473' lon='-122.22504714172' />
+  <node id='-39194' action='modify' lat='47.60408735519' lon='-122.24148631142' />
+  <node id='-39251' action='modify' lat='47.58930390424' lon='-122.25199937315' />
+  <node id='-39252' action='modify' lat='47.58930390424' lon='-122.24659528743' />
+  <node id='-39254' action='modify' lat='47.59162686922' lon='-122.24707037189' />
+  <node id='-39256' action='modify' lat='47.59002483544' lon='-122.24344785288' />
+  <node id='-39258' action='modify' lat='47.59122636537' lon='-122.25936318227' />
+  <node id='-39259' action='modify' lat='47.59539145556' lon='-122.26043212231' />
+  <node id='-39261' action='modify' lat='47.59659286228' lon='-122.24671405854' />
+  <node id='-39262' action='modify' lat='47.59715350931' lon='-122.2555625066' />
+  <way id='-38992' action='modify'>
+    <nd ref='-38988' />
+    <nd ref='-38991' />
+    <nd ref='-38995' />
+    <nd ref='-38997' />
+    <nd ref='-38999' />
+    <nd ref='-39001' />
+    <nd ref='-39003' />
+    <nd ref='-39005' />
+    <nd ref='-39007' />
+    <nd ref='-39009' />
+    <nd ref='-39011' />
+    <nd ref='-38988' />
+    <tag k='name' v='polygon3' />
+  </way>
+  <way id='-39017' action='modify'>
+    <nd ref='-39015' />
+    <nd ref='-39016' />
+    <nd ref='-39018' />
+    <nd ref='-39020' />
+    <nd ref='-39022' />
+    <nd ref='-39024' />
+    <nd ref='-39015' />
+    <tag k='name' v='polygon1' />
+  </way>
+  <way id='-39029' action='modify'>
+    <nd ref='-39027' />
+    <nd ref='-39028' />
+    <nd ref='-39030' />
+    <nd ref='-39032' />
+    <nd ref='-39034' />
+    <nd ref='-39036' />
+    <nd ref='-39038' />
+    <nd ref='-39040' />
+    <nd ref='-39042' />
+    <nd ref='-39044' />
+    <nd ref='-39046' />
+    <nd ref='-39027' />
+    <tag k='name' v='polygon2' />
+  </way>
+  <way id='-39095' action='modify'>
+    <nd ref='-39093' />
+    <nd ref='-39094' />
+  </way>
+  <way id='-39119' action='modify'>
+    <nd ref='-39117' />
+    <nd ref='-39118' />
+    <nd ref='-39120' />
+    <nd ref='-39122' />
+    <nd ref='-39124' />
+    <nd ref='-39126' />
+    <nd ref='-39117' />
+    <tag k='name' v='polygon4' />
+  </way>
+  <way id='-39155' action='modify'>
+    <nd ref='-39153' />
+    <nd ref='-39154' />
+  </way>
+  <way id='-39172' action='modify'>
+    <nd ref='-39170' />
+    <nd ref='-39171' />
+    <nd ref='-39173' />
+    <nd ref='-39175' />
+    <nd ref='-39177' />
+    <nd ref='-39179' />
+    <nd ref='-39181' />
+    <nd ref='-39183' />
+    <nd ref='-39185' />
+    <nd ref='-39187' />
+    <nd ref='-39170' />
+    <tag k='name' v='polygon5' />
+  </way>
+  <way id='-39192' action='modify'>
+    <nd ref='-39190' />
+    <nd ref='-39191' />
+  </way>
+  <way id='-39195' action='modify'>
+    <nd ref='-39193' />
+    <nd ref='-39194' />
+  </way>
+  <way id='-39253' action='modify'>
+    <nd ref='-39251' />
+    <nd ref='-39252' />
+    <nd ref='-39254' />
+    <nd ref='-39256' />
+  </way>
+  <way id='-39260' action='modify'>
+    <nd ref='-39258' />
+    <nd ref='-39259' />
+  </way>
+  <way id='-39263' action='modify'>
+    <nd ref='-39261' />
+    <nd ref='-39262' />
+  </way>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/testCounts.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/testCounts.osm
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-39463' action='modify' lat='22.51657258543' lon='-81.15236564257' />
+  <node id='-39464' action='modify' lat='22.52022381399' lon='-81.11409741146' />
+  <node id='-39466' action='modify' lat='22.50727811384' lon='-81.07870378927' />
+  <node id='-39468' action='modify' lat='22.47092409354' lon='-81.0769071587' />
+  <node id='-39470' action='modify' lat='22.44933956686' lon='-81.11194145478' />
+  <node id='-39472' action='modify' lat='22.44817722775' lon='-81.17320655716' />
+  <node id='-39474' action='modify' lat='22.47407847354' lon='-81.19710174372' />
+  <node id='-39476' action='modify' lat='22.50910386294' lon='-81.19243050424' />
+  <node id='-39478' action='modify' lat='22.52885360709' lon='-81.15775553427' />
+  <node id='-39482' action='modify' lat='22.45564973583' lon='-81.34783958738' />
+  <node id='-39483' action='modify' lat='22.50213318921' lon='-81.30400180151' />
+  <node id='-39485' action='modify' lat='22.53466231595' lon='-81.25225884115' />
+  <node id='-39487' action='modify' lat='22.52204988998' lon='-81.21560757756' />
+  <node id='-39489' action='modify' lat='22.57249268064' lon='-81.17967496619' />
+  <node id='-39491' action='modify' lat='22.41380196055' lon='-81.18758085934' />
+  <node id='-39492' action='modify' lat='22.46428422097' lon='-81.14302442125' />
+  <node id='-39494' action='modify' lat='22.37925089053' lon='-81.02804006489' />
+  <node id='-39496' action='modify' lat='22.48951746297' lon='-81.16170830118' />
+  <node id='-39497' action='modify' lat='22.48785745705' lon='-81.12290108091' />
+  <node id='-39530' action='modify' lat='22.50279679349' lon='-81.17392538905'>
+    <tag k='name' v='point1' />
+  </node>
+  <node id='-39531' action='modify' lat='22.49648927042' lon='-81.10313814466'>
+    <tag k='name' v='point2' />
+  </node>
+  <node id='-39532' action='modify' lat='22.34003765932' lon='-81.20195318524' />
+  <node id='-39533' action='modify' lat='22.29217009178' lon='-81.34783958738' />
+  <node id='-39535' action='modify' lat='22.24495129088' lon='-81.27022514683' />
+  <node id='-39537' action='modify' lat='22.24495129088' lon='-81.05534813087' />
+  <node id='-39539' action='modify' lat='22.26490484086' lon='-81.00360517051' />
+  <node id='-39541' action='modify' lat='22.32408362748' lon='-81.09056209001' />
+  <node id='-39543' action='modify' lat='22.33006660327' lon='-81.16602057387' />
+  <node id='-39546' action='modify' lat='22.4682682159' lon='-81.16817653056' />
+  <node id='-39547' action='modify' lat='22.42310203991' lon='-81.25800805897' />
+  <node id='-39549' action='modify' lat='22.31830515826' lon='-81.26819371853' />
+  <node id='-39552' action='modify' lat='22.28352558777' lon='-81.23860444883' />
+  <node id='-39625' action='modify' lat='22.332726286' lon='-81.00648049807' />
+  <node id='-39626' action='modify' lat='22.33139678335' lon='-80.87137387933' />
+  <node id='-39628' action='modify' lat='22.19172859815' lon='-80.88143501052' />
+  <node id='-39630' action='modify' lat='22.20104414329' lon='-81.01941623816' />
+  <node id='-39768' action='modify' lat='22.38757524055' lon='-81.40228557444'>
+    <tag k='name' v='point3' />
+  </node>
+  <way id='-39465' action='modify'>
+    <nd ref='-39463' />
+    <nd ref='-39464' />
+    <nd ref='-39466' />
+    <nd ref='-39468' />
+    <nd ref='-39470' />
+    <nd ref='-39472' />
+    <nd ref='-39474' />
+    <nd ref='-39476' />
+    <nd ref='-39478' />
+    <nd ref='-39463' />
+    <tag k='name' v='polygon1' />
+  </way>
+  <way id='-39484' action='modify'>
+    <nd ref='-39482' />
+    <nd ref='-39483' />
+    <nd ref='-39485' />
+    <nd ref='-39487' />
+    <nd ref='-39489' />
+  </way>
+  <way id='-39493' action='modify'>
+    <nd ref='-39491' />
+    <nd ref='-39492' />
+    <nd ref='-39494' />
+  </way>
+  <way id='-39498' action='modify'>
+    <nd ref='-39496' />
+    <nd ref='-39497' />
+  </way>
+  <way id='-39534' action='modify'>
+    <nd ref='-39532' />
+    <nd ref='-39549' />
+    <nd ref='-39533' />
+    <nd ref='-39535' />
+    <nd ref='-39537' />
+    <nd ref='-39539' />
+    <nd ref='-39541' />
+    <nd ref='-39543' />
+    <nd ref='-39532' />
+    <tag k='name' v='polygon2' />
+  </way>
+  <way id='-39548' action='modify'>
+    <nd ref='-39546' />
+    <nd ref='-39547' />
+    <nd ref='-39549' />
+    <nd ref='-39552' />
+  </way>
+  <way id='-39627' action='modify'>
+    <nd ref='-39625' />
+    <nd ref='-39626' />
+    <nd ref='-39628' />
+  </way>
+  <way id='-39631' action='modify'>
+    <nd ref='-39630' />
+    <nd ref='-39625' />
+  </way>
+  <relation id='-39636' action='modify'>
+    <member type='way' ref='-39631' role='barrier' />
+    <member type='way' ref='-39627' role='barrier' />
+    <tag k='name' v='relation1' />
+  </relation>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/utilities/filters/testForms.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/filters/testForms.osm
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-39232' action='modify' lat='22.47789683741' lon='-81.11176179172' />
+  <node id='-39233' action='modify' lat='22.47806285085' lon='-81.06864265809' />
+  <node id='-39235' action='modify' lat='22.50860593376' lon='-81.06702569057' />
+  <node id='-39237' action='modify' lat='22.50727811384' lon='-81.11122280255' />
+  <node id='-39252' action='modify' lat='22.49350122996' lon='-81.10259897583' />
+  <node id='-39253' action='modify' lat='22.49798301747' lon='-81.08984289879' />
+  <node id='-39255' action='modify' lat='22.4886872965' lon='-81.09487346438' />
+  <node id='-39256' action='modify' lat='22.49433120156' lon='-81.08193772429' />
+  <node id='-39258' action='modify' lat='22.48769128936' lon='-81.08283603958'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39259' action='modify' lat='22.49964290192' lon='-81.10008369303'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39260' action='modify' lat='22.50254756879' lon='-81.10583282102' />
+  <node id='-39261' action='modify' lat='22.50296252808' lon='-81.07457144913' />
+  <node id='-39263' action='modify' lat='22.48320908553' lon='-81.07627824817' />
+  <node id='-39265' action='modify' lat='22.48337509259' lon='-81.10915658757' />
+  <node id='-39286' action='modify' lat='22.51790023309' lon='-81.11562445761' />
+  <node id='-39287' action='modify' lat='22.51980882353' lon='-81.0896631459' />
+  <node id='-39289' action='modify' lat='22.51524475905' lon='-81.08696820005' />
+  <node id='-39290' action='modify' lat='22.52196632882' lon='-81.07016970424' />
+  <node id='-39292' action='modify' lat='22.5008877192' lon='-81.12308047447'>
+    <tag k='name' v='hey' />
+  </node>
+  <node id='-39299' action='modify' lat='22.46893173352' lon='-81.06262385585' />
+  <node id='-39300' action='modify' lat='22.46926378168' lon='-81.04977794729' />
+  <node id='-39302' action='modify' lat='22.46303774628' lon='-81.05346103995' />
+  <node id='-39304' action='modify' lat='22.46278869905' lon='-81.06603745393' />
+  <way id='-39234' action='modify'>
+    <nd ref='-39232' />
+    <nd ref='-39233' />
+    <nd ref='-39235' />
+    <nd ref='-39237' />
+    <nd ref='-39232' />
+    <tag k='name' v='include' />
+  </way>
+  <way id='-39254' action='modify'>
+    <nd ref='-39252' />
+    <nd ref='-39253' />
+  </way>
+  <way id='-39257' action='modify'>
+    <nd ref='-39255' />
+    <nd ref='-39256' />
+  </way>
+  <way id='-39262' action='modify'>
+    <nd ref='-39260' />
+    <nd ref='-39261' />
+    <nd ref='-39263' />
+    <nd ref='-39265' />
+    <nd ref='-39260' />
+  </way>
+  <way id='-39288' action='modify'>
+    <nd ref='-39286' />
+    <nd ref='-39287' />
+  </way>
+  <way id='-39291' action='modify'>
+    <nd ref='-39289' />
+    <nd ref='-39290' />
+  </way>
+  <way id='-39301' action='modify'>
+    <nd ref='-39299' />
+    <nd ref='-39300' />
+    <nd ref='-39302' />
+    <nd ref='-39304' />
+    <nd ref='-39299' />
+  </way>
+</osm>


### PR DESCRIPTION
This PR contains a configurable AtlasEntity filter based on either include or exclude ```Polygon```s or ```MultiPolygon```s. The filter is either an include or exclude filter. If this filter is constructed using a configuration then it will use whatever type ```Polygon```s/```MultiPolygon```s are present. If both include and exclude ```Polygon```s/```MultiPolygon```s are presents then only the includes are considered.  If there are no filter ```Polygon```s in the configuration then every entity is passed through. ```Polygon```s/```MultiPolygon```s are not allowed to overlap and they are dropped with a warning as they are read in if they overlap with any previously read ```Polygon```/```MultiPolygon```. 

The intersection logic can also be configured by implementing ``` IntersectionPolicy``` which allows you to decide what is intersection between ```AtlasEntities```  and ```Polygon```s and ```MultiPolygon```s.
The supported configuration ```Polygon```/```MultiPolygon``` string formats are
<li>Atlas's native format</li>
<li>wkt</li>
<li>wkb</li>
<li>geojson*</li>

*This is the only format where more that one polygon/multipolygon per string is permitted

Example Configurations:
```
{
    "filter.polygons":{
        "include.wkt":["POLYGON ((-81.1523656 22.5165725, -81.1140974 22.5202238, -81.0787037 22.5072781, -81.0769071 22.470924, -81.1119414 22.4493395, -81.1732065 22.4481772, -81.1971017 22.4740784, -81.1924305 22.5091038, -81.1577555 22.5288536, -81.1523656 22.5165725))"]
    }
}

```

```
{
    "filter.polygons":{
        "exclude.geojson":["{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-81.1523656,22.5165725],[-81.1140974,22.5202238],[-81.0787037,22.5072781],[-81.0769071,22.470924],[-81.1119414,22.4493395],[-81.1732065,22.4481772],[-81.1971017,22.4740784],[-81.1924305,22.5091038],[-81.1577555,22.5288536]]]},\"properties\":{}}]}"]
    }
}
```

Example Static constructions:
```
AtlasEntityPolygonsFilter.Type.INCLUDE.multiPolygons(Collections.singleton(multiPolygon1)
AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(Arrays.asList(polygon1, polygon2)
AtlasEntityPolygonsFilter.Type.INCLUDE.polygonsAndMultiPolygons(Collections.singleton(polygon1),Arrays.asList(multiPolygon1, multiPolygon2)
AtlasEntityPolygonsFilter.Type.EXCLUDE.polygons(Collections.singleton(polygon1))
```


***Bonus***
<li>Added WkbMultiPolygonConverter</li>
<li>Added MultiPolygon::overlaps(MultiPolygon) function</li>
<li>Added functions so that MultiPolygons can be output as valid geojson**</li> 
**More to be done here