### PR TITLE
Return results if there is a full overlap in slicing process

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1106,27 +1107,27 @@ public class CountryBoundaryMap implements Serializable
 
         Geometry target = geometry;
         final List<Geometry> results = new ArrayList<>();
-        List<Polygon> polygons = this.query(target.getEnvelopeInternal());
+        List<Polygon> candidates = this.query(target.getEnvelopeInternal());
 
         // Performance improvement, if only one polygon returned no need to do any further
         // evaluation.
-        if (isSameCountry(polygons))
+        if (isSameCountry(candidates))
         {
-            final String countryCode = getGeometryProperty(polygons.get(0), ISOCountryTag.KEY);
+            final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             addResult(target, results);
             return results;
         }
 
         // Remove duplicates
-        polygons = polygons.stream().distinct().collect(Collectors.toList());
+        candidates = candidates.stream().distinct().collect(Collectors.toList());
 
         // Avoid slicing across too many polygons for performance reasons
-        if (polygons.size() > this.getPolygonSliceLimit())
+        if (candidates.size() > this.getPolygonSliceLimit())
         {
             RuntimeCounter.waySkipped(identifier);
             logger.warn("Skipping slicing way {} due to too many intersecting polygons [{}]",
-                    identifier, polygons.size());
+                    identifier, candidates.size());
             return null;
         }
 
@@ -1135,33 +1136,34 @@ public class CountryBoundaryMap implements Serializable
         boolean isWarned = false;
         final Time time = Time.now();
 
-        if (polygons.size() > MAXIMUM_EXPECTED_COUNTRIES_TO_SLICE_WITH)
+        if (candidates.size() > MAXIMUM_EXPECTED_COUNTRIES_TO_SLICE_WITH)
         {
-            logger.warn("slicing way {} with {} polygons", identifier, polygons.size());
+            logger.warn("Slicing way {} with {} polygons.", identifier, candidates.size());
             if (logger.isTraceEnabled())
             {
-                final Map<String, List<Polygon>> countries = polygons.stream().collect(Collectors
+                final Map<String, List<Polygon>> countries = candidates.stream().collect(Collectors
                         .groupingBy(polygon -> getGeometryProperty(polygon, ISOCountryTag.KEY)));
                 countries.forEach((key, value) -> logger.trace("{} : {}", key, value.size()));
             }
         }
 
-        final List<Polygon> intersected = new ArrayList<>();
-
         // Check relation of target to all polygons
-        for (final Polygon polygon : polygons)
+        final Iterator<Polygon> candidateIterator = candidates.iterator();
+        while (candidateIterator.hasNext())
         {
-            final String countryCode = getGeometryProperty(polygon, ISOCountryTag.KEY);
+            final Polygon candidate = candidateIterator.next();
+            final String countryCode = getGeometryProperty(candidate, ISOCountryTag.KEY);
             if (Strings.isNullOrEmpty(countryCode))
             {
-                logger.warn("Ignoring a polygon from slicing, because it is missing country tag.");
+                logger.warn(
+                        "Ignoring a candidate polygon from slicing, because it is missing country tag.");
                 continue;
             }
 
             final IntersectionMatrix matrix;
             try
             {
-                matrix = target.relate(polygon);
+                matrix = target.relate(candidate);
             }
             catch (final Exception e)
             {
@@ -1183,39 +1185,37 @@ public class CountryBoundaryMap implements Serializable
                 setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
                 this.addResult(target, results);
                 fullyMatched = true;
-                break;
+                return results;
             }
 
+            // No intersection, remove from candidate list
             if (!matrix.isIntersects())
             {
                 RuntimeCounter.geometryCheckedNoIntersect();
-            }
-            else
-            {
-                intersected.add(polygon);
+                candidateIterator.remove();
             }
         }
 
         // Performance: short circuit, if all intersected polygons in same country, skip cutting.
-        if (isSameCountry(intersected))
+        if (isSameCountry(candidates))
         {
-            final String countryCode = getGeometryProperty(intersected.get(0), ISOCountryTag.KEY);
+            final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             this.addResult(target, results);
             return results;
         }
 
         // Sort intersecting polygons for consistent slicing
-        Collections.sort(intersected,
+        Collections.sort(candidates,
                 (final Polygon first,
                         final Polygon second) -> getGeometryProperty(first, ISOCountryTag.KEY)
                                 .compareTo(getGeometryProperty(second, ISOCountryTag.KEY)));
 
-        // Start the cutting
-        for (final Polygon intersection : intersected)
+        // Start cut process
+        for (final Polygon candidate : candidates)
         {
             RuntimeCounter.geometryCheckedIntersect();
-            final Geometry clipped = target.intersection(intersection);
+            final Geometry clipped = target.intersection(candidate);
 
             // We don't want single point pieces
             if (clipped.getNumPoints() < 2)
@@ -1223,15 +1223,16 @@ public class CountryBoundaryMap implements Serializable
                 continue;
             }
 
-            final String countryCode = getGeometryProperty(intersection, ISOCountryTag.KEY);
+            // Add to the results
+            final String countryCode = getGeometryProperty(candidate, ISOCountryTag.KEY);
             setGeometryProperty(clipped, ISOCountryTag.KEY, countryCode);
             this.addResult(clipped, results);
 
             // Update target to be what's left after clipping
-            target = target.difference(intersection);
+            target = target.difference(candidate);
             if (target.getDimension() == 1 && target.getLength() < LINE_BUFFER
                     || target.getDimension() == 2 && target.getArea() < AREA_BUFFER
-                            && new DiscreteHausdorffDistance(target, intersection)
+                            && new DiscreteHausdorffDistance(target, candidate)
                                     .orientedDistance() < LINE_BUFFER)
             {
                 // The remaining piece is very small and we ignore it. This also helps avoid

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
@@ -140,10 +140,8 @@ public class OsmPbfLoaderTest
         {
             final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
                     // Here reduce the loading bounds to a small area around Edge 3. In this case
-                    // Node 3
-                    // is included in the country boundary but not in the loading area. It should
-                    // not
-                    // have any boundary tag.
+                    // Node 3 is included in the country boundary but not in the loading area. It
+                    // should not have any boundary tag.
                     MultiPolygon.forPolygon(SHAPEPOINT.boxAround(Distance.meters(10))),
                     AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
                             .setAdditionalCountryCodes(COUNTRY_1_NAME));

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfLoaderTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.pbf;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,6 +42,7 @@ public class OsmPbfLoaderTest
     private static final String COUNTRY_2_NAME = "COUNTRY_2";
     private static final Location SHAPEPOINT = Location.forString("37.328076,-122.031869");
     private static final Location DE_ANZA_AT_280 = Location.forString("37.334384,-122.032327");
+    private static final Location OUTSIDE_COUNTRY_1 = Location.forString("37.350987,-121.988496");
 
     private MultiPolygon countryShape1;
     private MultiPolygon countryShape2;
@@ -51,8 +53,19 @@ public class OsmPbfLoaderTest
     @Before
     public void init()
     {
-        final Polygon polygon1 = new Polygon(Location.TEST_6, Location.TEST_2, Location.TEST_5);
-        final Polygon polygon2 = new Polygon(Location.TEST_1, Location.TEST_2, Location.TEST_5);
+        final Polygon polygon1 = new Polygon(
+                Location.forString("37.330310627190194,-122.08282470703124"),
+                Location.forString("37.25014416051375,-122.04025268554688"),
+                Location.forString("37.242218476496625,-121.937255859375"),
+                Location.forString("37.28060928450999,-121.95030212402344"),
+                Location.forString("37.33310876404607,-122.02986717224121"),
+                Location.forString("37.33604328341095,-122.06462860107422"));
+        final Polygon polygon2 = new Polygon(
+                Location.forString("37.34232140492521,-122.06904888153078"),
+                Location.forString("37.33474664945566,-122.06102371215819"),
+                Location.forString("37.331308755038414,-122.0297384262085"),
+                Location.forString("37.34051308677875,-122.02124118804932"),
+                Location.forString("37.3447096829136,-122.03505992889404"));
         this.countryShape1 = MultiPolygon.forPolygon(polygon1);
         this.countryShape2 = MultiPolygon.forPolygon(polygon2);
         final Map<String, MultiPolygon> boundaries = new HashMap<>();
@@ -79,6 +92,7 @@ public class OsmPbfLoaderTest
                 Maps.stringMap("tag_key", "tag_value")));
         this.store.addNode(new AtlasPrimitiveLocationItem(10, DE_ANZA_AT_280,
                 Maps.stringMap("tag_key", "tag_value")));
+        this.store.addNode(new AtlasPrimitiveLocationItem(11, OUTSIDE_COUNTRY_1, Maps.stringMap()));
 
         // Add Edges
         this.store.addEdge(new AtlasPrimitiveLineItem(3,
@@ -89,6 +103,9 @@ public class OsmPbfLoaderTest
                 Maps.stringMap(HighwayTag.KEY, HighwayTag.MOTORWAY.name().toLowerCase())));
         this.store.addEdge(
                 new AtlasPrimitiveLineItem(8, new PolyLine(Location.TEST_7, DE_ANZA_AT_280),
+                        Maps.stringMap(HighwayTag.KEY, HighwayTag.MOTORWAY.name().toLowerCase())));
+        this.store.addEdge(
+                new AtlasPrimitiveLineItem(9, new PolyLine(DE_ANZA_AT_280, OUTSIDE_COUNTRY_1),
                         Maps.stringMap(HighwayTag.KEY, HighwayTag.MOTORWAY.name().toLowerCase())));
 
         // Add Lines
@@ -111,70 +128,84 @@ public class OsmPbfLoaderTest
      * In some cases, ways can be outside the loading area (still inside the osm PBF) and connected
      * to some other ways that are inside the loading area, but still inside the country boundary.
      * That happens at shard boundaries, which do a soft cut.
+     *
+     * @throws IOException
+     *             Exception thrown when {@link OsmosisReaderMock} fails to close
      */
     @Test
     public void testBoundaryNodesForWayOutsideLoadingAreaButInsideCountryBoundary()
+            throws IOException
     {
-        final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
-        final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
-                // Here reduce the loading bounds to a small area around Edge 3. In this case Node 3
-                // is included in the country boundary but not in the loading area. It should not
-                // have any boundary tag.
-                MultiPolygon.forPolygon(SHAPEPOINT.boxAround(Distance.meters(10))),
-                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
-                        .setAdditionalCountryCodes(COUNTRY_1_NAME));
-        final Atlas atlas = osmPbfLoader.read();
-        logger.info("{}", atlas);
-        final Edge edgeIn = atlas.edgesIntersecting(DE_ANZA_AT_280.bounds()).iterator().next();
-        final Node nodeIn = edgeIn.end();
-        Assert.assertNull(nodeIn.tag(SyntheticBoundaryNodeTag.KEY));
+        try (OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store))
+        {
+            final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
+                    // Here reduce the loading bounds to a small area around Edge 3. In this case
+                    // Node 3
+                    // is included in the country boundary but not in the loading area. It should
+                    // not
+                    // have any boundary tag.
+                    MultiPolygon.forPolygon(SHAPEPOINT.boxAround(Distance.meters(10))),
+                    AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
+                            .setAdditionalCountryCodes(COUNTRY_1_NAME));
+            final Atlas atlas = osmPbfLoader.read();
+            logger.info("{}", atlas);
+            final Edge edgeIn = atlas.edgesIntersecting(DE_ANZA_AT_280.bounds()).iterator().next();
+            final Node nodeIn = edgeIn.end();
+            Assert.assertNull(nodeIn.tag(SyntheticBoundaryNodeTag.KEY));
+        }
     }
 
     @Test
-    public void testEmptyRelations()
+    public void testEmptyRelations() throws IOException
     {
-        final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
-        final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis, MultiPolygon.MAXIMUM,
-                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundariesAll)
-                        .setAdditionalCountryCodes(COUNTRY_1_NAME));
-        final Atlas atlas = osmPbfLoader.read();
-        logger.info("{}", atlas);
-        Assert.assertEquals(1, atlas.numberOfLines());
-        Assert.assertEquals(1, atlas.numberOfRelations());
-        final Relation relation = atlas.relations().iterator().next();
-        Assert.assertEquals(1, relation.members().size());
-        Assert.assertEquals(3, atlas.numberOfEdges());
+        try (OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store))
+        {
+            final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis, MultiPolygon.MAXIMUM,
+                    AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundariesAll)
+                            .setAdditionalCountryCodes(COUNTRY_1_NAME));
+            final Atlas atlas = osmPbfLoader.read();
+            logger.info("{}", atlas);
+            Assert.assertEquals(2, atlas.numberOfLines());
+            Assert.assertEquals(1, atlas.numberOfRelations());
+            final Relation relation = atlas.relations().iterator().next();
+            Assert.assertEquals(2, relation.members().size());
+            Assert.assertEquals(2, atlas.numberOfEdges());
+        }
     }
 
     @Test
-    public void testNoFilter()
+    public void testNoFilter() throws IOException
     {
-        final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
-        final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis, MultiPolygon.MAXIMUM,
-                AtlasLoadingOption.withNoFilter());
-        final Atlas atlas = osmPbfLoader.read();
-        logger.info("{}", atlas);
-        Assert.assertEquals(3, atlas.numberOfLines());
+        try (OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store))
+        {
+            final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis, MultiPolygon.MAXIMUM,
+                    AtlasLoadingOption.withNoFilter());
+            final Atlas atlas = osmPbfLoader.read();
+            logger.info("{}", atlas);
+            Assert.assertEquals(3, atlas.numberOfLines());
+        }
     }
 
     @Test
-    public void testOutsideWayBoundaryNodes()
+    public void testOutsideWayBoundaryNodes() throws IOException
     {
-        final OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store);
-        final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
-                this.countryBoundaries1.countryBoundary(COUNTRY_1_NAME).iterator().next()
-                        .getBoundary(),
-                AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
-                        .setAdditionalCountryCodes(COUNTRY_1_NAME));
-        final Atlas atlas = osmPbfLoader.read();
-        logger.info("{}", atlas);
-        final Edge edgeOut = atlas.edgesIntersecting(Location.CROSSING_85_17.bounds()).iterator()
-                .next();
-        final Node nodeOut = edgeOut.end();
-        Assert.assertNotNull(nodeOut.tag(SyntheticBoundaryNodeTag.KEY));
-        final Edge edgeIn = atlas.edgesIntersecting(Location.TEST_7.bounds()).iterator().next();
-        final Node nodeIn = edgeIn.end();
-        Assert.assertNull(nodeIn.tag(SyntheticBoundaryNodeTag.KEY));
-        Assert.assertEquals(2, atlas.numberOfPoints());
+        try (OsmosisReaderMock osmosis = new OsmosisReaderMock(this.store))
+        {
+            final OsmPbfLoader osmPbfLoader = new OsmPbfLoader(() -> osmosis,
+                    this.countryBoundaries1.countryBoundary(COUNTRY_1_NAME).iterator().next()
+                            .getBoundary(),
+                    AtlasLoadingOption.createOptionWithAllEnabled(this.countryBoundaries1)
+                            .setAdditionalCountryCodes(COUNTRY_1_NAME));
+            final Atlas atlas = osmPbfLoader.read();
+            logger.info("{}", atlas);
+            final Edge edgeOut = atlas.edgesIntersecting(OUTSIDE_COUNTRY_1.bounds()).iterator()
+                    .next();
+            final Node nodeOut = edgeOut.end();
+            Assert.assertNotNull(nodeOut.tag(SyntheticBoundaryNodeTag.KEY));
+            final Edge edgeIn = atlas.edgesIntersecting(Location.TEST_7.bounds()).iterator().next();
+            final Node nodeIn = edgeIn.end();
+            Assert.assertNull(nodeIn.tag(SyntheticBoundaryNodeTag.KEY));
+            Assert.assertEquals(2, atlas.numberOfPoints());
+        }
     }
 }


### PR DESCRIPTION
This PR addresses an edge case in CountryBoundaryMap’s slicing logic. When there is an overlap between country borders and a feature is fully covered by one country, then we’d detect it and assign that country’s code to the feature. However, after detecting we continue to slice the feature. Other country’s (one that is NOT fully covering feature) boundary slices the geometry and tries to assign a country code, but that fails. That assigns sliced geometries to the same country, although we can just return the full geometry and be done with the slicing process.

The actual changes is happening on line 1186 in CountryBoundaryMap file - https://github.com/osmlab/atlas/pull/95/files#diff-624909305b238ebca80c0e72370bd906L1186

Other changes are minor improvements, like removing the list that was holding intersecting candidates `intersected`, renaming variables to make things more clear. `OsmPbfLoaderTest` is updated so that we hit the scenario above. Tests are updated to avoid resource leaks.
