### PR TITLE
Fix for SQL file generation OOM

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
@@ -70,13 +70,37 @@ public class SlippyTile implements Shard, Comparable<SlippyTile>
         {
             throw new CoreException("Zoom too large.");
         }
+        final Iterable<SlippyTile> result = () -> allTilesIterator(zoom, bounds);
+        final List<SlippyTile> list = Iterables.asList(result);
+        if (list.isEmpty())
+        {
+            throw new CoreException("List cannot be empty");
+        }
+        return list;
+    }
+
+    /**
+     * Iterator for all tiles within some bounds
+     *
+     * @param zoom
+     *            The zoom to consider
+     * @param bounds
+     *            The bounds to consider
+     * @return Iterator for all tiles within some bounds
+     */
+    public static Iterator<SlippyTile> allTilesIterator(final int zoom, final Rectangle bounds)
+    {
+        if (zoom > MAX_ZOOM)
+        {
+            throw new CoreException("Zoom too large.");
+        }
         final SlippyTile lowerLeft = new SlippyTile(bounds.lowerLeft(), zoom);
         final SlippyTile upperRight = new SlippyTile(bounds.upperRight(), zoom);
         final int minX = lowerLeft.getX();
         final int maxX = upperRight.getX();
         final int minY = upperRight.getY();
         final int maxY = lowerLeft.getY();
-        final Iterable<SlippyTile> result = () -> new Iterator<SlippyTile>()
+        final Iterator<SlippyTile> result = new Iterator<SlippyTile>()
         {
             private int xAxis = minX;
             private int yAxis = minY;
@@ -104,12 +128,7 @@ public class SlippyTile implements Shard, Comparable<SlippyTile>
                 return result;
             }
         };
-        final List<SlippyTile> list = Iterables.asList(result);
-        if (list.isEmpty())
-        {
-            throw new CoreException("List cannot be empty");
-        }
-        return list;
+        return result;
     }
 
     /**
@@ -235,11 +254,6 @@ public class SlippyTile implements Shard, Comparable<SlippyTile>
                     && this.getY() == that.getY();
         }
         return false;
-    }
-
-    public void freeBoundsForGC()
-    {
-        this.bounds = null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
@@ -237,6 +237,11 @@ public class SlippyTile implements Shard, Comparable<SlippyTile>
         return false;
     }
 
+    public void freeBoundsForGC()
+    {
+        this.bounds = null;
+    }
+
     @Override
     public String getName()
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/preparation/TilePrinter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/preparation/TilePrinter.java
@@ -83,6 +83,7 @@ public class TilePrinter extends Command
                     writer.write(";");
                 }
                 writer.write("\n");
+                tile.freeBoundsForGC();
             }
         }
         Streams.close(writer);

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/preparation/TilePrinter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/preparation/TilePrinter.java
@@ -56,7 +56,8 @@ public class TilePrinter extends Command
                 "CREATE TABLE sharding.counts(tile text, count integer) WITH ( OIDS=FALSE );");
         writer.writeLine("ALTER TABLE sharding.counts OWNER TO osm;");
 
-        final Iterator<SlippyTile> tileIterator = SlippyTile.allTiles(this.zoom).iterator();
+        final Iterator<SlippyTile> tileIterator = SlippyTile.allTilesIterator(this.zoom,
+                Rectangle.MAXIMUM);
         while (tileIterator.hasNext())
         {
             Streams.close(writer);
@@ -83,7 +84,6 @@ public class TilePrinter extends Command
                     writer.write(";");
                 }
                 writer.write("\n");
-                tile.freeBoundsForGC();
             }
         }
         Streams.close(writer);


### PR DESCRIPTION
This PR fixes an OOM issue in `TilePrinter`. Previously, all the tiles for a certain zoom level were calculated, and then as they were written to SQL each tile's bounds were calculated and stored. GC tried to collect these `Rectangle`s, but couldn't because they were still referenced by the tile object. The method `freeBoundsForGC` nulls the bounds and allows them to be collected, fixing the OOM.

UPDATE:

After Mert's comment I've refactored the fix. Now instead creating an `Iterable` of all slippy tiles at a certain zoom, we instead create an `Iterator` directly to only load a shard at a time. This will use even less memory than the original, while still solving the `GC overhead limit` issue. I implemented this by adding a method `allTilesIterator(final int zoom, final Rectangle bounds)` which can be called directly and is now used by `allTiles`. The method `freeBoundsForGC` has been removed.