### PR TITLE
Fix NPE in CountryBoundaryMap when country code is missing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -1064,9 +1064,12 @@ public class CountryBoundaryMap implements Serializable
         for (final String countryCode : countries)
         {
             final List<CountryBoundary> boundaries = this.countryBoundary(countryCode);
-            for (final CountryBoundary boundary : boundaries)
+            if (boundaries != null)
             {
-                multiPolygon = multiPolygon.concatenate(boundary.getBoundary());
+                for (final CountryBoundary boundary : boundaries)
+                {
+                    multiPolygon = multiPolygon.concatenate(boundary.getBoundary());
+                }
             }
         }
         final com.vividsolutions.jts.geom.MultiPolygon area = JTS_MULTI_POLYGON_TO_MULTI_POLYGON_CONVERTER

--- a/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMapTest.java
@@ -238,6 +238,20 @@ public class CountryBoundaryMapTest
         }
     }
 
+    @Test(expected = CoreException.class)
+    public void testGridIndexReconstructionWithMissingCountryCode()
+    {
+        final CountryBoundaryMap map = CountryBoundaryMap.fromPlainText(new InputStreamResource(
+                CountryBoundaryMapTest.class.getResourceAsStream("HTI_DOM_osm_boundaries.txt.gz"))
+                        .withDecompressor(Decompressor.GZIP));
+        Assert.assertFalse(map.hasGridIndex());
+
+        final Set<String> countries = new HashSet<>(
+                Arrays.asList("HTI", "DOM", /* Not there on purpose */"CIV"));
+        // This is expected to throw a CoreException listing the missing country, versus a NPE.
+        map.initializeGridIndex(countries);
+    }
+
     @Test
     public void testIndexBuildWithMultipleThreads()
     {


### PR DESCRIPTION
When a country code is listed but missing from the serialized `CountryBoundaryMap` this type of NPE is occuring:

```
Caused by: java.lang.NullPointerException
	at org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap.initializeGridIndex(CountryBoundaryMap.java:1066)
```

This PR fixes it by swapping to the expected `CoreException` listing the missing country code.