### PR TITLE
GeometricSurface Interface added + Utilities

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/GeometricSurface.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/GeometricSurface.java
@@ -1,0 +1,38 @@
+package org.openstreetmap.atlas.geography;
+
+import org.openstreetmap.atlas.utilities.scalars.Surface;
+
+/**
+ * An interface for all geometric surface objects
+ *
+ * @author jklamer
+ */
+public interface GeometricSurface extends Located
+{
+    boolean fullyGeometricallyEncloses(Location location);
+
+    boolean fullyGeometricallyEncloses(PolyLine polyLine);
+
+    boolean fullyGeometricallyEncloses(Segment segment);
+
+    boolean fullyGeometricallyEncloses(MultiPolygon multiPolygon);
+
+    boolean overlaps(PolyLine polyLine);
+
+    boolean overlaps(MultiPolygon multiPolygon);
+
+    /**
+     * @return The {@link Surface} of this {@link GeometricSurface}. Not valid if the
+     *         {@link GeometricSurface} self-intersects, and/or overlaps itself
+     * @see "http://www.mathopenref.com/coordpolygonarea2.html"
+     */
+    Surface surface();
+
+    /**
+     * @return The approximate {@link Surface} of this {@link GeometricSurface} if it were projected
+     *         onto the Earth. Not valid if the {@link GeometricSurface} self-intersects, and/or
+     *         overlaps itself. Uses "Some Algorithms for Polygons on a Sphere" paper as reference.
+     * @see "https://trs.jpl.nasa.gov/bitstream/handle/2014/41271/07-0286.pdf"
+     */
+    Surface surfaceOnSphere();
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/GeometricSurface.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/GeometricSurface.java
@@ -13,8 +13,6 @@ public interface GeometricSurface extends Located
 
     boolean fullyGeometricallyEncloses(PolyLine polyLine);
 
-    boolean fullyGeometricallyEncloses(Segment segment);
-
     boolean fullyGeometricallyEncloses(MultiPolygon multiPolygon);
 
     boolean overlaps(PolyLine polyLine);

--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
@@ -17,7 +17,7 @@ import org.openstreetmap.atlas.geography.converters.WktMultiPolygonConverter;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.LocationIterableProperties;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonObject;
-import org.openstreetmap.atlas.geography.index.QuadTree;
+import org.openstreetmap.atlas.geography.index.RTree;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.streaming.writers.JsonWriter;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -31,7 +31,7 @@ import org.openstreetmap.atlas.utilities.scalars.Surface;
  *
  * @author matthieun
  */
-public class MultiPolygon implements Iterable<Polygon>, GeometricSurface, Located, Serializable
+public class MultiPolygon implements Iterable<Polygon>, GeometricSurface, Serializable
 {
     private static final long serialVersionUID = 4198234682870043547L;
     private static final int SIMPLE_STRING_LENGTH = 200;
@@ -245,7 +245,7 @@ public class MultiPolygon implements Iterable<Polygon>, GeometricSurface, Locate
     @Override
     public boolean fullyGeometricallyEncloses(final MultiPolygon that)
     {
-        final QuadTree<Polygon> thisOuters = QuadTree.forLocated(this.outers());
+        final RTree<Polygon> thisOuters = RTree.forLocated(this.outers());
         // each outer of that must fit within one of this' outer/inner groups
         for (final Polygon thatOuter : that.outers())
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolygon.java
@@ -9,7 +9,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.clipping.Clip;
 import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
@@ -242,26 +241,30 @@ public class MultiPolygon implements Iterable<Polygon>, GeometricSurface, Locate
     }
 
     /**
-     * Tests to see if entire surface of the provided {@link MultiPolygon} lies within this {@link MultiPolygon}
-     * @param that the provided {@link MultiPolygon} to test
+     * Tests to see if entire surface of the provided {@link MultiPolygon} lies within this
+     * {@link MultiPolygon}
+     * 
+     * @param that
+     *            the provided {@link MultiPolygon} to test
      * @return true if the conditions are met, false otherwise
      */
     @Override
     public boolean fullyGeometricallyEncloses(final MultiPolygon that)
     {
         final QuadTree<Polygon> thisOuters = QuadTree.forLocated(this.outers());
-        //each outer of that must fit within one of this' outer/inner groups
-        for (Polygon thatOuter : that.outers())
+        // each outer of that must fit within one of this' outer/inner groups
+        for (final Polygon thatOuter : that.outers())
         {
             boolean cleared = false;
-            for(Polygon thisOuter : thisOuters.get(thatOuter.bounds(), thatOuter::overlaps))
+            for (final Polygon thisOuter : thisOuters.get(thatOuter.bounds(), thatOuter::overlaps))
             {
-                if(thisOuter.fullyGeometricallyEncloses(thatOuter))
+                if (thisOuter.fullyGeometricallyEncloses(thatOuter))
                 {
-                    cleared = this.getOuterToInners().get(thisOuter).stream().noneMatch(that::overlaps);
+                    cleared = this.getOuterToInners().get(thisOuter).stream()
+                            .noneMatch(that::overlaps);
                 }
             }
-            if(!cleared)
+            if (!cleared)
             {
                 return false;
             }
@@ -272,7 +275,9 @@ public class MultiPolygon implements Iterable<Polygon>, GeometricSurface, Locate
     @Override
     public boolean fullyGeometricallyEncloses(final Segment segment)
     {
-        final Set<Location> intersections = Iterables.stream(this).flatMap(polygon -> Iterables.stream(polygon.intersections(segment))).collectToSet();
+        final Set<Location> intersections = Iterables.stream(this)
+                .flatMap(polygon -> Iterables.stream(polygon.intersections(segment)))
+                .collectToSet();
         for (final Location intersection : intersections)
         {
             if (!intersection.equals(segment.start()) && !intersection.equals(segment.end()))

--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -33,7 +33,7 @@ import com.vividsolutions.jts.triangulate.ConformingDelaunayTriangulationBuilder
  *
  * @author matthieun
  */
-public class Polygon extends PolyLine
+public class Polygon extends PolyLine implements GeometricSurface
 {
     public static final Polygon SILICON_VALLEY = new Polygon(Location.TEST_3, Location.TEST_7,
             Location.TEST_4, Location.TEST_1, Location.TEST_5);
@@ -174,6 +174,7 @@ public class Polygon extends PolyLine
      *            The {@link Location} to test
      * @return True if the {@link Polygon} contains the {@link Location}
      */
+    @Override
     public boolean fullyGeometricallyEncloses(final Location location)
     {
         // if this value overflows, use JTS to correctly calculate covers
@@ -190,6 +191,12 @@ public class Polygon extends PolyLine
         }
     }
 
+    @Override
+    public boolean fullyGeometricallyEncloses(final MultiPolygon multiPolygon)
+    {
+        return multiPolygon.outers().stream().allMatch(this::fullyGeometricallyEncloses);
+    }
+
     /**
      * Tests if this {@link Polygon} fully encloses (geometrically contains) a {@link PolyLine}.
      * Note: this will return false for the case when the {@link Polygon} and given {@link PolyLine}
@@ -200,6 +207,7 @@ public class Polygon extends PolyLine
      * @return True if this {@link Polygon} wraps (geometrically contains) the provided
      *         {@link PolyLine}
      */
+    @Override
     public boolean fullyGeometricallyEncloses(final PolyLine polyLine)
     {
         final List<Segment> segments = polyLine.segments();
@@ -481,6 +489,7 @@ public class Polygon extends PolyLine
      *         overlaps itself
      * @see "http://www.mathopenref.com/coordpolygonarea2.html"
      */
+    @Override
     public Surface surface()
     {
         long dm7Squared = 0L;
@@ -507,6 +516,7 @@ public class Polygon extends PolyLine
      *         for Polygons on a Sphere" paper as reference.
      * @see "https://trs.jpl.nasa.gov/bitstream/handle/2014/41271/07-0286.pdf"
      */
+    @Override
     public Surface surfaceOnSphere()
     {
         double dm7 = 0L;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.Map;
 
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -62,9 +63,9 @@ public abstract class Area extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final Polygon polygon)
+    public boolean intersects(final GeometricSurface geometricSurface)
     {
-        return polygon.overlaps(asPolygon());
+        return geometricSurface.overlaps(asPolygon());
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
@@ -63,9 +63,9 @@ public abstract class Area extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final GeometricSurface geometricSurface)
+    public boolean intersects(final GeometricSurface surface)
     {
-        return geometricSurface.overlaps(asPolygon());
+        return surface.overlaps(asPolygon());
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openstreetmap.atlas.geography.GeometricSurface;
-import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.LocationIterableProperties;
@@ -127,10 +126,10 @@ public abstract class AtlasEntity implements AtlasObject
     }
 
     /**
-     * Return true if the entity intersects the geometricSurface. If it is a {@link LocationItem}, the
-     * polygon fully encloses it. For a {@link LineItem} the geometricSurface overlaps it. For an
-     * {@link Area} the geometricSurface overlaps it. For a relation, at least one member of the relation
-     * returns true to this method.
+     * Return true if the entity intersects the geometricSurface. If it is a {@link LocationItem},
+     * the polygon fully encloses it. For a {@link LineItem} the geometricSurface overlaps it. For
+     * an {@link Area} the geometricSurface overlaps it. For a relation, at least one member of the
+     * relation returns true to this method.
      *
      * @param geometricSurface
      *            The {@link GeometricSurface} to test

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
@@ -126,16 +127,16 @@ public abstract class AtlasEntity implements AtlasObject
     }
 
     /**
-     * Return true if the entity intersects the polygon. If it is a {@link LocationItem}, the
-     * polygon fully encloses it. For a {@link LineItem} the polygon overlaps it. For an
-     * {@link Area} the polygon overlaps it. For a relation, at least one member of the relation
+     * Return true if the entity intersects the geometricSurface. If it is a {@link LocationItem}, the
+     * polygon fully encloses it. For a {@link LineItem} the geometricSurface overlaps it. For an
+     * {@link Area} the geometricSurface overlaps it. For a relation, at least one member of the relation
      * returns true to this method.
      *
-     * @param polygon
-     *            The polygon to test
+     * @param geometricSurface
+     *            The {@link GeometricSurface} to test
      * @return True if it intersects
      */
-    public abstract boolean intersects(Polygon polygon);
+    public abstract boolean intersects(GeometricSurface geometricSurface);
 
     /**
      * @return If available, the {@link Time} at which the entity was last edited.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -131,11 +131,11 @@ public abstract class AtlasEntity implements AtlasObject
      * an {@link Area} the geometricSurface overlaps it. For a relation, at least one member of the
      * relation returns true to this method.
      *
-     * @param geometricSurface
+     * @param surface
      *            The {@link GeometricSurface} to test
      * @return True if it intersects
      */
-    public abstract boolean intersects(GeometricSurface geometricSurface);
+    public abstract boolean intersects(GeometricSurface surface);
 
     /**
      * @return If available, the {@link Time} at which the entity was last edited.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
@@ -7,7 +7,6 @@ import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
-import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
@@ -47,9 +47,9 @@ public abstract class LineItem extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final GeometricSurface geometricSurface)
+    public boolean intersects(final GeometricSurface surface)
     {
-        return geometricSurface.overlaps(asPolyLine());
+        return surface.overlaps(asPolyLine());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.items;
 import java.util.Map;
 import java.util.Optional;
 
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
@@ -47,9 +48,9 @@ public abstract class LineItem extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final Polygon polygon)
+    public boolean intersects(final GeometricSurface geometricSurface)
     {
-        return polygon.overlaps(asPolyLine());
+        return geometricSurface.overlaps(asPolyLine());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.Map;
 
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -43,9 +44,9 @@ public abstract class LocationItem extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final Polygon polygon)
+    public boolean intersects(final GeometricSurface geometricSurface)
     {
-        return polygon.fullyGeometricallyEncloses(getLocation());
+        return geometricSurface.fullyGeometricallyEncloses(getLocation());
     }
 
     public SnappedLocation snapTo(final Area other)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
@@ -43,9 +43,9 @@ public abstract class LocationItem extends AtlasItem
     }
 
     @Override
-    public boolean intersects(final GeometricSurface geometricSurface)
+    public boolean intersects(final GeometricSurface surface)
     {
-        return geometricSurface.fullyGeometricallyEncloses(getLocation());
+        return surface.fullyGeometricallyEncloses(getLocation());
     }
 
     public SnappedLocation snapTo(final Area other)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LocationItem.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.Snapper.SnappedLocation;
 import org.openstreetmap.atlas.geography.atlas.Atlas;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -128,9 +128,9 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
     }
 
     @Override
-    public boolean intersects(final GeometricSurface geometricSurface)
+    public boolean intersects(final GeometricSurface surface)
     {
-        return intersectsInternal(geometricSurface, new LinkedHashSet<>());
+        return intersectsInternal(surface, new LinkedHashSet<>());
     }
 
     public boolean isMultiPolygon()
@@ -248,13 +248,13 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
      * {@link PackedAtlas} but could happen when two {@link Atlas} are combined into a
      * {@link MultiAtlas}.
      *
-     * @param geometricSurface
-     *            The geometricSurface to check for
+     * @param surface
+     *            The {@link GeometricSurface} to check for
      * @param parentRelationIdentifiers
      *            The identifiers of the parent relations that have already been visited.
      * @return True if the relation intersects the geometricSurface
      */
-    protected boolean intersectsInternal(final GeometricSurface geometricSurface,
+    protected boolean intersectsInternal(final GeometricSurface surface,
             final Set<Long> parentRelationIdentifiers)
     {
         for (final RelationMember member : this)
@@ -270,14 +270,13 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
                 else
                 {
                     parentRelationIdentifiers.add(identifier);
-                    if (((Relation) entity).intersectsInternal(geometricSurface,
-                            parentRelationIdentifiers))
+                    if (((Relation) entity).intersectsInternal(surface, parentRelationIdentifiers))
                     {
                         return true;
                     }
                 }
             }
-            else if (entity.intersects(geometricSurface))
+            else if (entity.intersects(surface))
             {
                 return true;
             }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
-import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
@@ -128,9 +128,9 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
     }
 
     @Override
-    public boolean intersects(final Polygon polygon)
+    public boolean intersects(final GeometricSurface geometricSurface)
     {
-        return intersectsInternal(polygon, new LinkedHashSet<>());
+        return intersectsInternal(geometricSurface, new LinkedHashSet<>());
     }
 
     public boolean isMultiPolygon()
@@ -248,13 +248,13 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
      * {@link PackedAtlas} but could happen when two {@link Atlas} are combined into a
      * {@link MultiAtlas}.
      *
-     * @param polygon
-     *            The polygon to check for
+     * @param geometricSurface
+     *            The geometricSurface to check for
      * @param parentRelationIdentifiers
      *            The identifiers of the parent relations that have already been visited.
-     * @return True if the relation intersects the polygon
+     * @return True if the relation intersects the geometricSurface
      */
-    protected boolean intersectsInternal(final Polygon polygon,
+    protected boolean intersectsInternal(final GeometricSurface geometricSurface,
             final Set<Long> parentRelationIdentifiers)
     {
         for (final RelationMember member : this)
@@ -270,13 +270,14 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
                 else
                 {
                     parentRelationIdentifiers.add(identifier);
-                    if (((Relation) entity).intersectsInternal(polygon, parentRelationIdentifiers))
+                    if (((Relation) entity).intersectsInternal(geometricSurface,
+                            parentRelationIdentifiers))
                     {
                         return true;
                     }
                 }
             }
-            else if (entity.intersects(polygon))
+            else if (entity.intersects(geometricSurface))
             {
                 return true;
             }

--- a/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
@@ -1,12 +1,15 @@
 package org.openstreetmap.atlas.geography.index;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 
 import com.vividsolutions.jts.index.quadtree.Quadtree;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 
 /**
  * A JTS Quadtree wrapper.
@@ -32,6 +35,13 @@ public class QuadTree<T> implements JtsSpatialIndex<T>
     private static final long serialVersionUID = 7515245245282264428L;
     private final Quadtree tree = new Quadtree();
     private Rectangle bound;
+
+    public static <K extends Located> QuadTree<K> forLocated(Collection<K> locatedCollection)
+    {
+        final QuadTree<K> toReturn= new QuadTree<>();
+        locatedCollection.forEach(located -> toReturn.add(located.bounds(), located));
+        return toReturn;
+    }
 
     @Override
     public void add(final Rectangle bound, final T item)

--- a/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.index;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -9,7 +10,6 @@ import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 
 import com.vividsolutions.jts.index.quadtree.Quadtree;
-import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 
 /**
  * A JTS Quadtree wrapper.
@@ -36,10 +36,18 @@ public class QuadTree<T> implements JtsSpatialIndex<T>
     private final Quadtree tree = new Quadtree();
     private Rectangle bound;
 
-    public static <K extends Located> QuadTree<K> forLocated(Collection<K> locatedCollection)
+    public static <K extends Located> QuadTree<K> forLocated(final Collection<K> locatedCollection)
     {
-        final QuadTree<K> toReturn= new QuadTree<>();
+        final QuadTree<K> toReturn = new QuadTree<>();
         locatedCollection.forEach(located -> toReturn.add(located.bounds(), located));
+        return toReturn;
+    }
+
+    public static <K> QuadTree<K> forCollection(final Collection<K> collection,
+            final Function<K, Rectangle> transform)
+    {
+        final QuadTree<K> toReturn = new QuadTree<>();
+        collection.forEach(item -> toReturn.add(transform.apply(item), item));
         return toReturn;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/index/QuadTree.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.geography.index;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -36,18 +35,18 @@ public class QuadTree<T> implements JtsSpatialIndex<T>
     private final Quadtree tree = new Quadtree();
     private Rectangle bound;
 
-    public static <K extends Located> QuadTree<K> forLocated(final Collection<K> locatedCollection)
+    public static <K extends Located> QuadTree<K> forLocated(final Iterable<K> locatedIterable)
     {
         final QuadTree<K> toReturn = new QuadTree<>();
-        locatedCollection.forEach(located -> toReturn.add(located.bounds(), located));
+        locatedIterable.forEach(located -> toReturn.add(located.bounds(), located));
         return toReturn;
     }
 
-    public static <K> QuadTree<K> forCollection(final Collection<K> collection,
+    public static <K> QuadTree<K> forCollection(final Iterable<K> iterable,
             final Function<K, Rectangle> transform)
     {
         final QuadTree<K> toReturn = new QuadTree<>();
-        collection.forEach(item -> toReturn.add(transform.apply(item), item));
+        iterable.forEach(item -> toReturn.add(transform.apply(item), item));
         return toReturn;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/index/RTree.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/index/RTree.java
@@ -1,9 +1,11 @@
 package org.openstreetmap.atlas.geography.index;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 
 import com.vividsolutions.jts.index.strtree.STRtree;
@@ -27,6 +29,21 @@ public class RTree<T> implements JtsSpatialIndex<T>
     private static final long serialVersionUID = -3672714932238885163L;
     private final STRtree tree;
     private Rectangle bound;
+
+    public static <K extends Located> RTree<K> forLocated(final Iterable<K> locatedIterable)
+    {
+        final RTree<K> toReturn = new RTree<>();
+        locatedIterable.forEach(located -> toReturn.add(located.bounds(), located));
+        return toReturn;
+    }
+
+    public static <K> RTree<K> forCollection(final Iterable<K> iterable,
+            final Function<K, Rectangle> transform)
+    {
+        final RTree<K> toReturn = new RTree<>();
+        iterable.forEach(item -> toReturn.add(transform.apply(item), item));
+        return toReturn;
+    }
 
     public RTree()
     {

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.GeometricSurface;
-import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -38,14 +37,17 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
     private static final Logger logger = LoggerFactory.getLogger(AtlasEntityPolygonsFilter.class);
     private static final long serialVersionUID = -3474748398986569205L;
     private Type filterType;
-    private IntersectionPolicy intersectionPolicy;
-    private List<MultiPolygon> multiPolygons = new ArrayList<>();
-    private List<Polygon> polygons = new ArrayList<>();
     private List<GeometricSurface> geometricSurfaces = new ArrayList<>();
+    private IntersectionPolicy intersectionPolicy;
 
-    public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration)
+    public static Collection<GeometricSurface> createSurfaceCollection(
+            final Collection<? extends GeometricSurface> collection1,
+            final Collection<? extends GeometricSurface> collection2)
     {
-        return forConfiguration(configuration, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
+        final ArrayList<GeometricSurface> returnCollection = new ArrayList<>();
+        returnCollection.addAll(collection1);
+        returnCollection.addAll(collection2);
+        return returnCollection;
     }
 
     public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration,
@@ -55,6 +57,21 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
                 configuration.get(INCLUDED_MULTIPOLYGONS_KEY).value(),
                 configuration.get(EXCLUDED_POLYGONS_KEY).value(),
                 configuration.get(EXCLUDED_MULTIPOLYGONS_KEY).value(), intersectionPolicy);
+    }
+
+    public static AtlasEntityPolygonsFilter forConfiguration(final Configuration configuration)
+    {
+        return forConfiguration(configuration, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
+    }
+
+    public static AtlasEntityPolygonsFilter forConfigurationValues(
+            final Map<String, List<String>> includePolygonMap,
+            final Map<String, List<String>> includeMultiPolygonMap,
+            final Map<String, List<String>> excludePolygonMap,
+            final Map<String, List<String>> excludeMultiPolygonMap)
+    {
+        return forConfigurationValues(includePolygonMap, includeMultiPolygonMap, excludePolygonMap,
+                excludeMultiPolygonMap, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
     }
 
     public static AtlasEntityPolygonsFilter forConfigurationValues(
@@ -95,16 +112,6 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         }
     }
 
-    public static AtlasEntityPolygonsFilter forConfigurationValues(
-            final Map<String, List<String>> includePolygonMap,
-            final Map<String, List<String>> includeMultiPolygonMap,
-            final Map<String, List<String>> excludePolygonMap,
-            final Map<String, List<String>> excludeMultiPolygonMap)
-    {
-        return forConfigurationValues(includePolygonMap, includeMultiPolygonMap, excludePolygonMap,
-                excludeMultiPolygonMap, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY);
-    }
-
     private static List<MultiPolygon> getMultiPolygonsFromFormatMap(
             final Map<String, List<String>> multiPolygonLists)
     {
@@ -137,175 +144,83 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
                 .collect(Collectors.toList());
     }
 
-    private static Predicate<Located> locatedOverlappingPredicate(final Polygon polygon,
-            final MultiPolygon multiPolygon)
-    {
-        Predicate<Located> returnPredicate = located -> false;
-        if (polygon != null)
-        {
-            returnPredicate = returnPredicate.or(located ->
-            {
-                if (located instanceof Polygon)
-                {
-                    return polygon.overlaps((Polygon) located);
-                }
-                else
-                {
-                    return polygon.overlaps((MultiPolygon) located);
-                }
-            });
-        }
-        if (multiPolygon != null)
-        {
-            returnPredicate = returnPredicate.or(located ->
-            {
-                if (located instanceof Polygon)
-                {
-                    return multiPolygon.overlaps((Polygon) located);
-                }
-                else
-                {
-                    return multiPolygon.overlaps((MultiPolygon) located);
-                }
-            });
-        }
-        return returnPredicate;
-    }
-
-    /**
-     * Returns predicate that filters out MultiPolygons that overlap with any Polygons or outer
-     * MultiPolygons in the provided QuadTree. This also adds any non-intersecting MultiPolygon to
-     * the quad tree.
-     *
-     * @param vettedPolygons
-     *            non-overlapping polygons and multipolygons
-     * @param polygonType
-     *            whether this is an include or exclude Polygon
-     * @return filter for multipolygons
-     */
-    private static Predicate<MultiPolygon> notOverlappingMultipolygon(
-            final QuadTree<Located> vettedPolygons, final Type polygonType)
-    {
-        return multiPolygon ->
-        {
-            if (vettedPolygons.get(multiPolygon.bounds()).stream()
-                    .noneMatch(locatedOverlappingPredicate(null, multiPolygon)))
-            {
-                vettedPolygons.add(multiPolygon.bounds(), multiPolygon);
-                return true;
-            }
-            else
-            {
-                logger.warn("Dropping {} MultiPolygon {}", polygonType, multiPolygon);
-                return false;
-            }
-        };
-    }
-
-    /**
-     * Returns predicate that filters out polygons that intersect with any polygons in the provided
-     * QuadTree. This also adds any non-intersecting polygon to the quad tree.
-     *
-     * @param vettedPolygons
-     *            non-overlapping polygons and multipolygons
-     * @param polygonType
-     *            whether this is an include or exclude Polygon
-     * @return filter for polygons
-     */
-    private static Predicate<Polygon> notOverlappingPolygon(final QuadTree<Located> vettedPolygons,
-            final Type polygonType)
-    {
-        return polygon ->
-        {
-            if (vettedPolygons.get(polygon.bounds()).stream()
-                    .noneMatch(locatedOverlappingPredicate(polygon, null)))
-            {
-                vettedPolygons.add(polygon.bounds(), polygon);
-                return true;
-            }
-            else
-            {
-                logger.warn("Dropping {} Polygon {}", polygonType, polygon);
-                return false;
-            }
-        };
-    }
-
-
-    private static Predicate<GeometricSurface> noOverlappingSurfaces(final Type polygonType)
+    private static Predicate<GeometricSurface> notOverlappingSurfaces(final Type polygonType)
     {
         final QuadTree<GeometricSurface> vettedSurfaces = new QuadTree<>();
         return geometricSurface ->
         {
-            if(vettedSurfaces.get(geometricSurface.bounds()).stream().noneMatch())
+            if (vettedSurfaces.get(geometricSurface.bounds()).stream()
+                    .noneMatch(surfaceOverlappingPredicate(geometricSurface)))
             {
                 vettedSurfaces.add(geometricSurface.bounds(), geometricSurface);
+                return true;
             }
-        }
-
+            else
+            {
+                logger.warn("Dropping {} GeometricSurface {}", polygonType, geometricSurface);
+                return false;
+            }
+        };
     }
 
-    private <T extends GeometricSurface> AtlasEntityPolygonsFilter(final Type filterType, final Collection<T> geometricSurfaces)
+    private static Predicate<GeometricSurface> surfaceOverlappingPredicate(
+            final GeometricSurface geometricSurface)
+    {
+        if (geometricSurface instanceof MultiPolygon)
+        {
+            return surface -> surface.overlaps((MultiPolygon) geometricSurface);
+        }
+        else if (geometricSurface instanceof Polygon)
+        {
+            return surface -> surface.overlaps((Polygon) geometricSurface);
+        }
+        else
+        {
+            logger.warn("Unrecognized GeometricSurface {}", geometricSurface);
+            return surface -> false;
+        }
+    }
+
+    private AtlasEntityPolygonsFilter(final Type filterType,
+            final Collection<? extends GeometricSurface> geometricSurfaces)
     {
         this(filterType, IntersectionPolicy.DEFAULT_INTERSECTION_POLICY, geometricSurfaces);
     }
 
-    private <T extends GeometricSurface> AtlasEntityPolygonsFilter(final Type filterType,
-            final IntersectionPolicy intersectionPolicy, final Collection<T> geometricSurfaces)
+    private AtlasEntityPolygonsFilter(final Type filterType,
+            final IntersectionPolicy intersectionPolicy,
+            final Collection<? extends GeometricSurface> geometricSurfaces)
     {
         this.filterType = filterType;
         this.intersectionPolicy = intersectionPolicy;
-        this.geometricSurfaces.addAll(geometricSurfaces == null ? Collections.EMPTY_SET : geometricSurfaces.stream().filter(noOverlappingSurfaces(this.filterType)).collect(
-                Collectors.toSet()));
-//        if (filterType == Type.INCLUDE)
-//        {
-//            this.polygons.addAll(polygons == null ? Collections.EMPTY_SET
-//                    : polygons.stream().filter(notOverlappingPolygon(vettedPolygons, Type.INCLUDE))
-//                            .collect(Collectors.toSet()));
-//            this.multiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
-//                    : multiPolygons.stream()
-//                            .filter(notOverlappingMultipolygon(vettedPolygons, Type.INCLUDE))
-//                            .collect(Collectors.toSet()));
-//        }
-//        else
-//        {
-//            this.polygons.addAll(polygons == null ? Collections.EMPTY_SET
-//                    : polygons.stream().filter(notOverlappingPolygon(vettedPolygons, Type.EXCLUDE))
-//                            .collect(Collectors.toSet()));
-//            this.multiPolygons.addAll(multiPolygons == null ? Collections.EMPTY_SET
-//                    : multiPolygons.stream()
-//                            .filter(notOverlappingMultipolygon(vettedPolygons, Type.EXCLUDE))
-//                            .collect(Collectors.toSet()));
-//        }
+        this.geometricSurfaces.addAll(geometricSurfaces == null ? Collections.EMPTY_SET
+                : geometricSurfaces.stream().filter(notOverlappingSurfaces(this.filterType))
+                        .collect(Collectors.toSet()));
     }
 
     @Override
     public boolean test(final AtlasEntity object)
     {
-        return noPolygons().or(isIncluded()).or(isNotExcluded()).test(object);
+        return noSurfaces().or(isIncluded()).or(isNotExcluded()).test(object);
     }
 
     private Predicate<AtlasEntity> isIncluded()
     {
-        return entity -> this.filterType == Type.INCLUDE && (this.polygons.stream().anyMatch(
-                polygon -> this.intersectionPolicy.polygonEntityIntersecting(polygon, entity))
-                || this.multiPolygons.stream().anyMatch(multiPolygon -> this.intersectionPolicy
-                        .multiPolygonEntityIntersecting(multiPolygon, entity)));
+        return entity -> this.filterType == Type.INCLUDE && (this.geometricSurfaces.stream()
+                .anyMatch(geometricSurface -> this.intersectionPolicy
+                        .geometricSurfaceEntityIntersecting(geometricSurface, entity)));
     }
 
     private Predicate<AtlasEntity> isNotExcluded()
     {
-        return entity -> this.filterType == Type.EXCLUDE
-                && this.polygons.stream()
-                        .noneMatch(polygon -> this.intersectionPolicy
-                                .polygonEntityIntersecting(polygon, entity))
-                && this.multiPolygons.stream().noneMatch(multiPolygon -> this.intersectionPolicy
-                        .multiPolygonEntityIntersecting(multiPolygon, entity));
+        return entity -> this.filterType == Type.EXCLUDE && this.geometricSurfaces.stream()
+                .noneMatch(geometricSurface -> this.intersectionPolicy
+                        .geometricSurfaceEntityIntersecting(geometricSurface, entity));
     }
 
-    private Predicate<AtlasEntity> noPolygons()
+    private Predicate<AtlasEntity> noSurfaces()
     {
-        return entity -> this.polygons.isEmpty() && this.multiPolygons.isEmpty();
+        return entity -> this.geometricSurfaces.isEmpty();
     }
 
     /**
@@ -317,6 +232,20 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         INCLUDE,
         EXCLUDE;
 
+        public AtlasEntityPolygonsFilter geometricSurfaces(
+                final IntersectionPolicy intersectionPolicy,
+                final Collection<GeometricSurface> geometricSurfaces)
+        {
+            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, geometricSurfaces);
+        }
+
+        public AtlasEntityPolygonsFilter geometricSurfaces(
+                final Collection<GeometricSurface> geometricSurfaces)
+        {
+            return new AtlasEntityPolygonsFilter(this,
+                    IntersectionPolicy.DEFAULT_INTERSECTION_POLICY, geometricSurfaces);
+        }
+
         public AtlasEntityPolygonsFilter multiPolygons(final Collection<MultiPolygon> multiPolygons)
         {
             return new AtlasEntityPolygonsFilter(this, multiPolygons);
@@ -325,31 +254,33 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         public AtlasEntityPolygonsFilter multiPolygons(final IntersectionPolicy intersectionPolicy,
                 final Collection<MultiPolygon> multiPolygons)
         {
-            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, null, multiPolygons);
+            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, multiPolygons);
         }
 
         public AtlasEntityPolygonsFilter polygons(final Collection<Polygon> polygons)
         {
-            return new AtlasEntityPolygonsFilter(this, polygons, null);
+            return new AtlasEntityPolygonsFilter(this, polygons);
         }
 
         public AtlasEntityPolygonsFilter polygons(final IntersectionPolicy intersectionPolicy,
                 final Collection<Polygon> polygons)
         {
-            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, polygons, null);
+            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, polygons);
         }
 
         public AtlasEntityPolygonsFilter polygonsAndMultiPolygons(
                 final Collection<Polygon> polygons, final Collection<MultiPolygon> multiPolygons)
         {
-            return new AtlasEntityPolygonsFilter(this, polygons, multiPolygons);
+            return new AtlasEntityPolygonsFilter(this,
+                    createSurfaceCollection(polygons, multiPolygons));
         }
 
         public AtlasEntityPolygonsFilter polygonsAndMultiPolygons(
                 final IntersectionPolicy intersectionPolicy, final Collection<Polygon> polygons,
                 final Collection<MultiPolygon> multiPolygons)
         {
-            return new AtlasEntityPolygonsFilter(this, intersectionPolicy, polygons, multiPolygons);
+            return new AtlasEntityPolygonsFilter(this, intersectionPolicy,
+                    createSurfaceCollection(polygons, multiPolygons));
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.utilities.filters;
 
 import java.io.Serializable;
 
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
@@ -58,15 +59,27 @@ public interface IntersectionPolicy extends Serializable
         {
             return entity.intersects(polygon);
         }
+
+        @Override
+        public boolean geometricSurfaceEntityIntersecting(
+                final GeometricSurface geometricSurface, final AtlasEntity entity)
+        {
+            return entity.intersects(geometricSurface);
+        }
     };
+
+    default boolean geometricSurfaceEntityIntersecting(GeometricSurface geometricSurface, AtlasEntity entity)
+    {
+        return false;
+    }
 
     default boolean multiPolygonEntityIntersecting(MultiPolygon multiPolygon, AtlasEntity entity)
     {
         return false;
-    };
+    }
 
     default boolean polygonEntityIntersecting(Polygon polygon, AtlasEntity entity)
     {
         return false;
-    };
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/IntersectionPolicy.java
@@ -61,14 +61,15 @@ public interface IntersectionPolicy extends Serializable
         }
 
         @Override
-        public boolean geometricSurfaceEntityIntersecting(
-                final GeometricSurface geometricSurface, final AtlasEntity entity)
+        public boolean geometricSurfaceEntityIntersecting(final GeometricSurface geometricSurface,
+                final AtlasEntity entity)
         {
             return entity.intersects(geometricSurface);
         }
     };
 
-    default boolean geometricSurfaceEntityIntersecting(GeometricSurface geometricSurface, AtlasEntity entity)
+    default boolean geometricSurfaceEntityIntersecting(GeometricSurface geometricSurface,
+            AtlasEntity entity)
     {
         return false;
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -81,6 +81,32 @@ public class MultiPolygonTest
     }
 
     @Test
+    public void testFullyGeometricallyEncloses()
+    {
+        final MultiPolygon multiPolygon1 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-10 10, 10 10, 10 -10, -10 -10, -10 10)," + "(-5 5, 5 5, 5 -5, -5 -5, -5 5)))");
+        final MultiPolygon multiPolygon2 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)," + "(-6 6, 6 6, 6 -6, -6 -6, -6 6)))");
+        final MultiPolygon multiPolygon3 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)," + "(-4 4, 4 4, 4 -4, -4 -4, -4 4)))");
+        final MultiPolygon multiPolygon4 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)))");
+        final MultiPolygon multiPolygon5 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-4 4, 4 4, 4 -4, -4 -4, -4 4)," + "(-3 3, 3 3, 3 -3, -3 -3, -3 3)))");
+        final MultiPolygon multiPolygon6 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((8 9, 9 9, 9 8, 8 8, 8 9)," + "(8.25 8.75, 8.75 8.75, 8.75 8.25, 8.25 8.25, 8.25 8.75)))");
+        final MultiPolygon multiPolygon7 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((89 90, 90 90, 90 89, 89 89, 89 90)," + "(89.25 89.75, 89.75 89.75, 89.75 89.25, 89.25 89.25, 89.25 89.75)))");
+        Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon2));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon3));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon4));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon5));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon2.merge(multiPolygon5)));
+        Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon6));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon7));
+    }
+
+    @Test
     public void testOverlap()
     {
         final MultiPolygon multiPolygon1 = MultiPolygon.wkt("MULTIPOLYGON ("

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -100,6 +100,7 @@ public class MultiPolygonTest
         final MultiPolygon multiPolygon7 = MultiPolygon
                 .wkt("MULTIPOLYGON (" + "((89 90, 90 90, 90 89, 89 89, 89 90),"
                         + "(89.25 89.75, 89.75 89.75, 89.75 89.25, 89.25 89.25, 89.25 89.75)))");
+        // Test Multipolygon enclose
         Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon2));
         Assert.assertFalse(multiPolygon2.fullyGeometricallyEncloses(multiPolygon1));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon3));
@@ -109,6 +110,15 @@ public class MultiPolygonTest
                 multiPolygon1.fullyGeometricallyEncloses(multiPolygon2.merge(multiPolygon5)));
         Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon6));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon7));
+
+        final PolyLine polyLine1 = PolyLine.wkt("LINESTRING (6 6, -6 -6)");
+        final PolyLine polyLine2 = PolyLine.wkt("LINESTRING (6 6, -6 6, -6 -6, 6 -6)");
+        final Polygon polygon1 = Polygon.wkt("POLYGON ((6 6, -6 6, -6 -6, 6 -6, 6 6))");
+
+        // Test Polyline Enclose
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(polyLine1));
+        Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(polyLine2));
+        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(polygon1));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -83,25 +83,30 @@ public class MultiPolygonTest
     @Test
     public void testFullyGeometricallyEncloses()
     {
-        final MultiPolygon multiPolygon1 = MultiPolygon.wkt("MULTIPOLYGON ("
-                + "((-10 10, 10 10, 10 -10, -10 -10, -10 10)," + "(-5 5, 5 5, 5 -5, -5 -5, -5 5)))");
+        final MultiPolygon multiPolygon1 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((-10 10, 10 10, 10 -10, -10 -10, -10 10),"
+                        + "(-5 5, 5 5, 5 -5, -5 -5, -5 5)))");
         final MultiPolygon multiPolygon2 = MultiPolygon.wkt("MULTIPOLYGON ("
                 + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)," + "(-6 6, 6 6, 6 -6, -6 -6, -6 6)))");
         final MultiPolygon multiPolygon3 = MultiPolygon.wkt("MULTIPOLYGON ("
                 + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)," + "(-4 4, 4 4, 4 -4, -4 -4, -4 4)))");
-        final MultiPolygon multiPolygon4 = MultiPolygon.wkt("MULTIPOLYGON ("
-                + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)))");
+        final MultiPolygon multiPolygon4 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((-8 8, 8 8, 8 -8, -8 -8, -8 8)))");
         final MultiPolygon multiPolygon5 = MultiPolygon.wkt("MULTIPOLYGON ("
                 + "((-4 4, 4 4, 4 -4, -4 -4, -4 4)," + "(-3 3, 3 3, 3 -3, -3 -3, -3 3)))");
-        final MultiPolygon multiPolygon6 = MultiPolygon.wkt("MULTIPOLYGON ("
-                + "((8 9, 9 9, 9 8, 8 8, 8 9)," + "(8.25 8.75, 8.75 8.75, 8.75 8.25, 8.25 8.25, 8.25 8.75)))");
-        final MultiPolygon multiPolygon7 = MultiPolygon.wkt("MULTIPOLYGON ("
-                + "((89 90, 90 90, 90 89, 89 89, 89 90)," + "(89.25 89.75, 89.75 89.75, 89.75 89.25, 89.25 89.25, 89.25 89.75)))");
+        final MultiPolygon multiPolygon6 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((8 9, 9 9, 9 8, 8 8, 8 9),"
+                        + "(8.25 8.75, 8.75 8.75, 8.75 8.25, 8.25 8.25, 8.25 8.75)))");
+        final MultiPolygon multiPolygon7 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((89 90, 90 90, 90 89, 89 89, 89 90),"
+                        + "(89.25 89.75, 89.75 89.75, 89.75 89.25, 89.25 89.25, 89.25 89.75)))");
         Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon2));
+        Assert.assertFalse(multiPolygon2.fullyGeometricallyEncloses(multiPolygon1));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon3));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon4));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon5));
-        Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon2.merge(multiPolygon5)));
+        Assert.assertFalse(
+                multiPolygon1.fullyGeometricallyEncloses(multiPolygon2.merge(multiPolygon5)));
         Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon6));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon7));
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -106,6 +106,7 @@ public class MultiPolygonTest
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon3));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon4));
         Assert.assertFalse(multiPolygon1.fullyGeometricallyEncloses(multiPolygon5));
+        Assert.assertFalse(multiPolygon5.fullyGeometricallyEncloses(multiPolygon1));
         Assert.assertFalse(
                 multiPolygon1.fullyGeometricallyEncloses(multiPolygon2.merge(multiPolygon5)));
         Assert.assertTrue(multiPolygon1.fullyGeometricallyEncloses(multiPolygon6));

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -255,6 +255,23 @@ public class PolygonTest
     }
 
     @Test
+    public void testFullyGeometricallyEnclosingMultiPolygon()
+    {
+        final MultiPolygon multiPolygon1 = MultiPolygon
+                .wkt("MULTIPOLYGON (" + "((-10 10, 10 10, 10 -10, -10 -10, -10 10),"
+                        + "(-6 6, 6 6, 6 -6, -6 -6, -6 6)))");
+        final MultiPolygon multiPolygon2 = MultiPolygon.wkt("MULTIPOLYGON ("
+                + "((-4 4, 4 4, 4 -4, -4 -4, -4 4)," + "(-3 3, 3 3, 3 -3, -3 -3, -3 3)))");
+        final Polygon polygon1 = Polygon.wkt("POLYGON " + "((-8 8, 8 8, 8 -8, -8 -8, -8 8))");
+        final Polygon polygon2 = Polygon.wkt("POLYGON " + "((-5 5, 5 5, 5 -5, -5 -5, -5 5))");
+
+        Assert.assertFalse(polygon2.fullyGeometricallyEncloses(multiPolygon1));
+        Assert.assertTrue(polygon1.fullyGeometricallyEncloses(multiPolygon2));
+        Assert.assertFalse(polygon1.fullyGeometricallyEncloses(multiPolygon1));
+        Assert.assertTrue(polygon2.fullyGeometricallyEncloses(multiPolygon2));
+    }
+
+    @Test
     public void testIntersects()
     {
         final Set<Location> intersection = this.quadrant.intersections(new Segment(Location.TEST_5,

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -11,6 +11,7 @@ import java.util.stream.StreamSupport;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -92,6 +93,35 @@ public class AtlasEntityPolygonsFilterTest
             {
                 return ((Relation) entity).members().stream().map(RelationMember::getEntity)
                         .anyMatch(relationEntity -> this.polygonEntityIntersecting(polygon,
+                                relationEntity));
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        //note this is the only one now used by the filter
+        @Override
+        public boolean geometricSurfaceEntityIntersecting(
+                final GeometricSurface geometricSurface, final AtlasEntity entity)
+        {
+            if (entity instanceof LineItem)
+            {
+                return geometricSurface.fullyGeometricallyEncloses(((LineItem) entity).asPolyLine());
+            }
+            if (entity instanceof LocationItem)
+            {
+                return geometricSurface.fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+            }
+            if (entity instanceof Area)
+            {
+                return geometricSurface.fullyGeometricallyEncloses(((Area) entity).asPolygon());
+            }
+            if (entity instanceof Relation)
+            {
+                return ((Relation) entity).members().stream().map(RelationMember::getEntity)
+                        .anyMatch(relationEntity -> this.geometricSurfaceEntityIntersecting(geometricSurface,
                                 relationEntity));
             }
             else

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -101,18 +101,20 @@ public class AtlasEntityPolygonsFilterTest
             }
         }
 
-        //note this is the only one now used by the filter
+        // note this is the only one now used by the filter
         @Override
-        public boolean geometricSurfaceEntityIntersecting(
-                final GeometricSurface geometricSurface, final AtlasEntity entity)
+        public boolean geometricSurfaceEntityIntersecting(final GeometricSurface geometricSurface,
+                final AtlasEntity entity)
         {
             if (entity instanceof LineItem)
             {
-                return geometricSurface.fullyGeometricallyEncloses(((LineItem) entity).asPolyLine());
+                return geometricSurface
+                        .fullyGeometricallyEncloses(((LineItem) entity).asPolyLine());
             }
             if (entity instanceof LocationItem)
             {
-                return geometricSurface.fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
+                return geometricSurface
+                        .fullyGeometricallyEncloses(((LocationItem) entity).getLocation());
             }
             if (entity instanceof Area)
             {
@@ -121,8 +123,8 @@ public class AtlasEntityPolygonsFilterTest
             if (entity instanceof Relation)
             {
                 return ((Relation) entity).members().stream().map(RelationMember::getEntity)
-                        .anyMatch(relationEntity -> this.geometricSurfaceEntityIntersecting(geometricSurface,
-                                relationEntity));
+                        .anyMatch(relationEntity -> this.geometricSurfaceEntityIntersecting(
+                                geometricSurface, relationEntity));
             }
             else
             {
@@ -188,8 +190,14 @@ public class AtlasEntityPolygonsFilterTest
         this.assertCounts(testCountsAtlas,
                 AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(Collections.singleton(polygon1)),
                 2L, 3L, 1L, 0L);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
+                .geometricSurfaces(Collections.singleton(polygon1)), 2L, 3L, 1L, 0L);
         this.assertCounts(testCountsAtlas,
                 AtlasEntityPolygonsFilter.Type.EXCLUDE.polygons(Collections.singleton(polygon1)),
+                totalPointCount - 2L, totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
+        this.assertCounts(testCountsAtlas,
+                AtlasEntityPolygonsFilter.Type.EXCLUDE
+                        .geometricSurfaces(Collections.singleton(polygon1)),
                 totalPointCount - 2L, totalLineCount - 3L, totalAreaCount - 1L, totalRelationCount);
         this.assertCounts(testCountsAtlas,
                 AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(Arrays.asList(polygon1, polygon2)),
@@ -281,19 +289,7 @@ public class AtlasEntityPolygonsFilterTest
         final long totalRelationCount = testCountsAtlas.numberOfRelations();
         final IntersectionPolicy dudIntersectionPolicy = new IntersectionPolicy()
         {
-            @Override
-            public boolean multiPolygonEntityIntersecting(final MultiPolygon multiPolygon,
-                    final AtlasEntity entity)
-            {
-                return false;
-            }
-
-            @Override
-            public boolean polygonEntityIntersecting(final Polygon polygon,
-                    final AtlasEntity entity)
-            {
-                return false;
-            }
+            // uses all false defaults
         };
 
         // Test all three policies on the first polygon
@@ -304,6 +300,8 @@ public class AtlasEntityPolygonsFilterTest
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(dudIntersectionPolicy, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
+                FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
+        this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.geometricSurfaces(
                 FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
 
         // Test all three decision makers on two polygon filter
@@ -316,7 +314,7 @@ public class AtlasEntityPolygonsFilterTest
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(FULL_GEOMETRIC_ENCLOSING, Arrays.asList(polygon1, polygon2)), 2, 1, 0, 0);
 
-        // Test Stabilizability
+        // Test Serializability
         this.assertCounts(testCountsAtlas,
                 new FreezeDryFunction<AtlasEntityPolygonsFilter>().apply(
                         AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(FULL_GEOMETRIC_ENCLOSING,


### PR DESCRIPTION
Adding in the GeometricSurface Interface to handle geometric surface interactions (namely Polygon and Multipolygon). Then used the interface to expand the usability of AtlasEntities and clean up the AtlasEntityPolygonFilter
Things to note:

- ```AtlasEntity::intersects(Polygon)``` ->  ```AtlaEntity::intersects(GeometricSurface)``` 

- I implemented ```MultiPolygon::fullyGeometricallyEncloses(MultiPolygon)```, ~~~```MultiPolygon::fullyGeometricallyEncloses(Segment)```~~~ , and ```MultiPolygon::surfaceOnSphere()```
- Backwards Compatible
- Some utility added in QuadTree

Some questions I have:
- Should I get ride of ```IntersectionPolicy ```  interface and replace it with a ```BiPredicate<GeometricSurface,AtlasEntity>``` ?
- Are there more functions to add to the Interface ?
- Should I allow overlapping GeometricSurfaces in AtlasEntityPolygonFilter ?

