### PR TITLE
Ensure consistency within country for slice operation

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -1221,10 +1221,17 @@ public class CountryBoundaryMap implements Serializable
         }
 
         // Sort intersecting polygons for consistent slicing
-        Collections.sort(candidates,
-                (final Polygon first,
-                        final Polygon second) -> getGeometryProperty(first, ISOCountryTag.KEY)
-                                .compareTo(getGeometryProperty(second, ISOCountryTag.KEY)));
+        Collections.sort(candidates, (final Polygon first, final Polygon second) ->
+        {
+            final int countryCodeComparison = getGeometryProperty(first, ISOCountryTag.KEY)
+                    .compareTo(getGeometryProperty(second, ISOCountryTag.KEY));
+            if (countryCodeComparison != 0)
+            {
+                return countryCodeComparison;
+            }
+
+            return first.compareTo(second);
+        });
 
         // Start cut process
         for (final Polygon candidate : candidates)
@@ -1323,11 +1330,11 @@ public class CountryBoundaryMap implements Serializable
         if (geometry instanceof GeometryCollection)
         {
             final GeometryCollection collection = (GeometryCollection) geometry;
-            geometries(collection).forEach(point ->
+            geometries(collection).forEach(part ->
             {
                 final String countryCode = getGeometryProperty(geometry, ISOCountryTag.KEY);
-                setGeometryProperty(point, ISOCountryTag.KEY, countryCode);
-                this.addResult(point, results);
+                setGeometryProperty(part, ISOCountryTag.KEY, countryCode);
+                this.addResult(part, results);
             });
         }
         else if (geometry instanceof LineString || geometry instanceof Polygon)


### PR DESCRIPTION
This PR further ensures consistency of slicing operation. If there are multiple candidates from the same country in slice operation (in addition to at least one other candidate from another country), we want to be able to process them in the same consistent order. Therefore, the sort logic is updated to first look at country codes and if country codes are the same, then sort according to polygon's first coordinates (if first coordinate matches, then second and etc).

A unit test is added called `testFeatureRightByCountryBoundary`. It slices a line right along the boundary between HTI and DOM. Slice operation always returns the piece inside DOM first. Then, pieces from HTI are returned. In the same unit test, line is reversed and sliced again and results are compared to non-reversed line slice operation.