### PR TITLE
AtlasStatistics Unterminated CSV quoted fields Fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
@@ -76,7 +76,7 @@ public class AtlasStatistics implements Iterable<AtlasStatistics.StatisticKey>, 
         @Override
         public String toString()
         {
-            return this.tag + "," + this.type + "," + this.subType;
+            return this.tag + "," + this.type + "," + this.subType.replace("\"", "\"\"");
         }
     }
 
@@ -216,7 +216,8 @@ public class AtlasStatistics implements Iterable<AtlasStatistics.StatisticKey>, 
     public boolean equals(final Object other)
     {
         return other instanceof AtlasStatistics
-                ? ((AtlasStatistics) other).getData().equals(getData()) : false;
+                ? ((AtlasStatistics) other).getData().equals(getData())
+                : false;
     }
 
     public StatisticValue get(final StatisticKey key)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.streaming.Streams;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -76,7 +77,7 @@ public class AtlasStatistics implements Iterable<AtlasStatistics.StatisticKey>, 
         @Override
         public String toString()
         {
-            return this.tag + "," + this.type + "," + this.subType.replace("\"", "\"\"");
+            return this.tag + "," + this.type + "," + StringEscapeUtils.escapeCsv(this.subType);
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatistics.java
@@ -216,8 +216,7 @@ public class AtlasStatistics implements Iterable<AtlasStatistics.StatisticKey>, 
     public boolean equals(final Object other)
     {
         return other instanceof AtlasStatistics
-                ? ((AtlasStatistics) other).getData().equals(getData())
-                : false;
+                ? ((AtlasStatistics) other).getData().equals(getData()) : false;
     }
 
     public StatisticValue get(final StatisticKey key)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
@@ -24,6 +24,16 @@ public class AtlasStatisticsTest
     }
 
     @Test
+    public void testCSVCompatability()
+    {
+        final StatisticKey key = new StatisticKey("", "last_edit_user_name", "kepta\"sds'sds");
+        // if there is a " or , or \n character within a field in a CSV, the CSV field is wrapped in
+        // double quotes and the interior double quote is escaped
+        final String correctlyFormattedCSVKey = ",last_edit_user_name,\"kepta\"\"sds'sds\"";
+        Assert.assertEquals(key.toString(), correctlyFormattedCSVKey);
+    }
+
+    @Test
     public void testMerge()
     {
         final StatisticKey key = new StatisticKey("RESIDENTIAL", "length_named", "TRUE");


### PR DESCRIPTION
This change will escape double quote characters (") present within `sub_type` strings. This fixes an issue with unterminated CSV quoted fields.