### PR TITLE
Added shaded jar classifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies
 
 task shaded(type: Jar){
     baseName = project.name
+    classifier = 'shaded'
     from
     {
         configurations.shaded.collect


### PR DESCRIPTION
This is to have proper shaded jar naming and resolve file conflicts between the regular jar and the shaded jar.