### PR TITLE
ManMadeTag enum typo

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/ManMadeTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ManMadeTag.java
@@ -24,7 +24,7 @@ public enum ManMadeTag
     CROSS,
     CUTLINE,
     CLEARCUT,
-    EMBARKMENT,
+    EMBANKMENT,
     DYKE,
     FLAGPOLE,
     GASOMETER,


### PR DESCRIPTION
`ManMadeTag.EMBANKMENT` is mispelled.

This update would break all direct references to `ManMadeTag.EMBARKMENT`