### PR TITLE
PackedAtlas: Do not load non serializable fields

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -297,11 +297,12 @@ public final class PackedAtlasSerializer
 
     private StreamIterable<Field> fields()
     {
-        return Iterables.stream(Iterables.from(PackedAtlas.class.getDeclaredFields())).map(field ->
-        {
-            field.setAccessible(true);
-            return field;
-        });
+        return Iterables.stream(Iterables.from(PackedAtlas.class.getDeclaredFields()))
+                .filter(field -> !EXCLUDED_FIELDS.startsWithContains(field.getName())).map(field ->
+                {
+                    field.setAccessible(true);
+                    return field;
+                });
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
@@ -51,6 +51,16 @@ public class PackedAtlasSerializerTest
     }
 
     @Test
+    public void testDeserializeThenSerialize()
+    {
+        final Atlas deserialized = PackedAtlas.load(new File(
+                "/Users/matthieun/projects/data/atlas/DMA/timestamp/atlas/DMA/DMA_9-168-233.atlas"));
+        final ByteArrayResource resource = new ByteArrayResource(5_000_000)
+                .withName("testDeserializeThenSerialize");
+        deserialized.save(resource);
+    }
+
+    @Test
     public void testPartialLoad() throws NoSuchFieldException, SecurityException
     {
         final PackedAtlas atlas = new PackedAtlasTest().getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
@@ -53,8 +53,7 @@ public class PackedAtlasSerializerTest
     @Test
     public void testDeserializeThenSerialize()
     {
-        final Atlas deserialized = PackedAtlas.load(new File(
-                "/Users/matthieun/projects/data/atlas/DMA/timestamp/atlas/DMA/DMA_9-168-233.atlas"));
+        final Atlas deserialized = deserialized();
         final ByteArrayResource resource = new ByteArrayResource(5_000_000)
                 .withName("testDeserializeThenSerialize");
         deserialized.save(resource);


### PR DESCRIPTION
In the unusual case of loading then saving an Atlas right away, some fields are not properly filtered using reflection, and cause errors.
This PR fixes that issue and adds a test to verify it.