### PR TITLE
Fixing raw Atlas sectioning and slicing corner cases

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -197,13 +197,15 @@ public class RawAtlasIntegrationTest
                 .getPath();
         final RawAtlasGenerator rawAtlasGenerator = new RawAtlasGenerator(new File(path));
         final Atlas rawAtlas = rawAtlasGenerator.build();
+
         final Atlas slicedRawAtlas = new RawAtlasCountrySlicer(COUNTRIES, COUNTRY_BOUNDARY_MAP)
                 .slice(rawAtlas);
+
         final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
 
         Assert.assertEquals(5011, finalAtlas.numberOfNodes());
-        Assert.assertEquals(9766, finalAtlas.numberOfEdges());
+        Assert.assertEquals(9764, finalAtlas.numberOfEdges());
         Assert.assertEquals(5128, finalAtlas.numberOfAreas());
         Assert.assertEquals(184, finalAtlas.numberOfPoints());
         Assert.assertEquals(326, finalAtlas.numberOfLines());
@@ -244,7 +246,7 @@ public class RawAtlasIntegrationTest
                 rawAtlasFetcher).run();
 
         Assert.assertEquals(5011, finalAtlas.numberOfNodes());
-        Assert.assertEquals(9766, finalAtlas.numberOfEdges());
+        Assert.assertEquals(9764, finalAtlas.numberOfEdges());
         Assert.assertEquals(5128, finalAtlas.numberOfAreas());
         Assert.assertEquals(184, finalAtlas.numberOfPoints());
         Assert.assertEquals(326, finalAtlas.numberOfLines());

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -182,7 +182,7 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(0, slicedRawAtlas.numberOfNodes());
         Assert.assertEquals(0, slicedRawAtlas.numberOfEdges());
         Assert.assertEquals(0, slicedRawAtlas.numberOfAreas());
-        Assert.assertEquals(34786, slicedRawAtlas.numberOfPoints());
+        Assert.assertEquals(34784, slicedRawAtlas.numberOfPoints());
         Assert.assertEquals(3636, slicedRawAtlas.numberOfLines());
         Assert.assertEquals(6, slicedRawAtlas.numberOfRelations());
 

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -197,10 +197,8 @@ public class RawAtlasIntegrationTest
                 .getPath();
         final RawAtlasGenerator rawAtlasGenerator = new RawAtlasGenerator(new File(path));
         final Atlas rawAtlas = rawAtlasGenerator.build();
-
         final Atlas slicedRawAtlas = new RawAtlasCountrySlicer(COUNTRIES, COUNTRY_BOUNDARY_MAP)
                 .slice(rawAtlas);
-
         final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/policy/DynamicAtlasPolicy.java
@@ -105,7 +105,6 @@ public class DynamicAtlasPolicy
                 catch (final Throwable error)
                 {
                     logger.error("Could not load shard {}, skipping.", shard.getName(), error);
-
                 }
             }
             else

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasBuilder.java
@@ -54,7 +54,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Area", e.getMessage(), e);
+            logger.error("Error adding Area ({}): {}", identifier, geometry.toWkt(), e);
         }
     }
 
@@ -106,7 +106,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Edge", e.getMessage(), e);
+            logger.error("Error adding Edge ({}): {}", identifier, geometry.toWkt(), e);
         }
     }
 
@@ -125,7 +125,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Line", e.getMessage(), e);
+            logger.error("Error adding Line ({}): {}", identifier, geometry.toWkt(), e);
         }
     }
 
@@ -144,7 +144,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Node", e.getMessage(), e);
+            logger.error("Error adding Node ({}): {}", identifier, geometry.toWkt(), e);
         }
     }
 
@@ -163,7 +163,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Point", e.getMessage(), e);
+            logger.error("Error adding Point ({}): {}", identifier, geometry.toWkt(), e);
         }
     }
 
@@ -188,7 +188,7 @@ public final class PackedAtlasBuilder implements AtlasBuilder
         }
         catch (final Exception e)
         {
-            logger.error("Error adding Relation", e.getMessage(), e);
+            logger.error("Error adding Relation ({}): {}", identifier, structure.toString(), e);
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
@@ -394,7 +394,7 @@ public class RawAtlasGenerator
         });
 
         // Add Relations
-        atlas.relations().forEach(relation ->
+        atlas.relationsLowerOrderFirst().forEach(relation ->
         {
             final RelationBean bean = new RelationBean();
             relation.members().forEach(member ->

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
@@ -413,8 +413,17 @@ public class RawAtlasGenerator
                     bean.addItem(memberIdentifier, member.getRole(), entity.getType());
                 }
             });
-            builder.addRelation(relation.getIdentifier(), relation.getOsmIdentifier(), bean,
-                    relation.getTags());
+
+            if (!bean.isEmpty())
+            {
+                builder.addRelation(relation.getIdentifier(), relation.getOsmIdentifier(), bean,
+                        relation.getTags());
+            }
+            else
+            {
+                logger.debug("Relation {} bean is empty, dropping from Atlas",
+                        relation.getIdentifier());
+            }
         });
 
         // Build and return the new Atlas

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -80,7 +80,7 @@ public class WaySectionProcessor
     // this further by only considering the edges crossing the shard boundary and their intersecting
     // edges to reduce the memory overhead on each slave.
 
-    // Combination of the line and point predicate used to
+    // Dynamic expansion filter will be a combination of points and lines
     private final Predicate<AtlasEntity> dynamicAtlasExpansionFilter = entity -> this.pointPredicate
             .test(entity) || this.linePredicate.test(entity);
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -360,8 +360,17 @@ public class WaySectionProcessor
                                 member.getEntity().getType());
                 }
             });
-            builder.addRelation(relation.getIdentifier(), relation.getOsmIdentifier(), bean,
-                    relation.getTags());
+
+            if (!bean.isEmpty())
+            {
+                builder.addRelation(relation.getIdentifier(), relation.getOsmIdentifier(), bean,
+                        relation.getTags());
+            }
+            else
+            {
+                logger.debug("Relation {} bean is empty, dropping from Atlas",
+                        relation.getIdentifier());
+            }
         });
 
         return builder.get();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -316,8 +316,8 @@ public class WaySectionProcessor
                         }
                         else
                         {
-                            throw new CoreException(
-                                    "Could not find corresponding Atlas entity for Point {} in Relation {}",
+                            logger.debug(
+                                    "Excluding Point {} from Relation {} since it's no longer in the Atlas",
                                     memberIdentifier, relation.getIdentifier());
                         }
                         break;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -201,6 +201,9 @@ public class WaySectionProcessor
     private Atlas buildExpandedAtlas(final Shard initialShard, final Sharding sharding,
             final Function<Shard, Optional<Atlas>> rawAtlasFetcher)
     {
+        final Time time = Time.now();
+        logger.info("Started Dynamic Atlas Construction for Shard {}", initialShard.getName());
+
         // Keep track of all loaded shards. This will be used to cut the sub-atlas for the shard
         // we're processing after all sectioning is completed. Initial shard will always be first!
         this.loadedShards.add(initialShard);
@@ -233,6 +236,9 @@ public class WaySectionProcessor
 
         final DynamicAtlas atlas = new DynamicAtlas(policy);
         atlas.preemptiveLoad();
+
+        logger.info("Finished Dynamic Atlas Construction for {} in {}", initialShard.getName(),
+                time.untilNow());
         return atlas;
     }
 
@@ -247,6 +253,9 @@ public class WaySectionProcessor
      */
     private Atlas buildSectionedAtlas(final WaySectionChangeSet changeSet)
     {
+        final Time time = Time.now();
+        logger.info("Started Final Atlas Build");
+
         // Create builder and set properties
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
         final AtlasSize sizeEstimate = createAtlasSizeEstimate(changeSet);
@@ -386,6 +395,7 @@ public class WaySectionProcessor
             }
         });
 
+        logger.info("Finished Final Atlas Build in {}", time.untilNow());
         return builder.get();
     }
 
@@ -484,8 +494,13 @@ public class WaySectionProcessor
      */
     private void distinguishPointsFromShapePoints(final WaySectionChangeSet changeSet)
     {
+        final Time time = Time.now();
+        logger.info("Started Shape Point Detection...");
+
         Iterables.stream(this.rawAtlas.points()).filter(point -> isAtlasPoint(changeSet, point))
                 .forEach(changeSet::recordPoint);
+
+        logger.info("Finished Shape Point Detection in {}", time.untilNow());
     }
 
     /**
@@ -501,6 +516,9 @@ public class WaySectionProcessor
      */
     private void identifyEdgesNodesAndAreasFromLines(final WaySectionChangeSet changeSet)
     {
+        final Time time = Time.now();
+        logger.info("Started Atlas Feature Detection...");
+
         this.rawAtlas.lines().forEach(line ->
         {
             if (isAtlasEdge(line))
@@ -595,6 +613,8 @@ public class WaySectionProcessor
                         line.getIdentifier());
             }
         });
+
+        logger.info("Finished Atlas Feature Detection in {}", time.untilNow());
     }
 
     /**
@@ -783,6 +803,9 @@ public class WaySectionProcessor
      */
     private void sectionEdges(final WaySectionChangeSet changeSet)
     {
+        final Time time = Time.now();
+        logger.info("Started Edge Sectioning...");
+
         changeSet.getLinesThatBecomeEdges().forEach(lineIdentifier ->
         {
             final Line line = this.rawAtlas.line(lineIdentifier);
@@ -797,6 +820,8 @@ public class WaySectionProcessor
             }
             changeSet.createLineToEdgeMapping(line, edges);
         });
+
+        logger.info("Finished Edge Sectioning in {}", time.untilNow());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -144,7 +144,7 @@ public class WaySectionProcessor
     public Atlas run()
     {
         final Time time = Time.now();
-        logger.info("Started way-sectioning atlas {}", this.rawAtlas.getName());
+        logger.info("Started Way-Sectioning for Shard {}", this.loadedShards.get(0));
 
         // Create a changeset to keep track of any intermediate state transitions (points becomes
         // nodes, lines becoming areas, etc.)
@@ -161,7 +161,8 @@ public class WaySectionProcessor
         sectionEdges(changeSet);
 
         final Atlas atlas = buildSectionedAtlas(changeSet);
-        logger.info("Finished way-sectioning atlas {} in {}", atlas.getName(), time.untilNow());
+        logger.info("Finished Way-Sectioning for Shard {} in {}", this.loadedShards.get(0),
+                time.untilNow());
 
         return cutSubAtlasForOriginalShard(atlas);
     }
@@ -202,7 +203,8 @@ public class WaySectionProcessor
             final Function<Shard, Optional<Atlas>> rawAtlasFetcher)
     {
         final Time time = Time.now();
-        logger.info("Started Dynamic Atlas Construction for Shard {}", initialShard.getName());
+        logger.info("Started Dynamic Atlas Construction for Way-Sectioning Shard {}",
+                initialShard.getName());
 
         // Keep track of all loaded shards. This will be used to cut the sub-atlas for the shard
         // we're processing after all sectioning is completed. Initial shard will always be first!
@@ -237,8 +239,8 @@ public class WaySectionProcessor
         final DynamicAtlas atlas = new DynamicAtlas(policy);
         atlas.preemptiveLoad();
 
-        logger.info("Finished Dynamic Atlas Construction for {} in {}", initialShard.getName(),
-                time.untilNow());
+        logger.info("Finished Dynamic Atlas Construction for Way-Sectioning Shard {} in {}",
+                initialShard.getName(), time.untilNow());
         return atlas;
     }
 
@@ -254,7 +256,7 @@ public class WaySectionProcessor
     private Atlas buildSectionedAtlas(final WaySectionChangeSet changeSet)
     {
         final Time time = Time.now();
-        logger.info("Started Final Atlas Build");
+        logger.info("Started Final Atlas Build for Shard {}", this.loadedShards.get(0));
 
         // Create builder and set properties
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
@@ -395,7 +397,8 @@ public class WaySectionProcessor
             }
         });
 
-        logger.info("Finished Final Atlas Build in {}", time.untilNow());
+        logger.info("Finished Final Atlas Build for Shard {} in {}", this.loadedShards.get(0),
+                time.untilNow());
         return builder.get();
     }
 
@@ -495,12 +498,13 @@ public class WaySectionProcessor
     private void distinguishPointsFromShapePoints(final WaySectionChangeSet changeSet)
     {
         final Time time = Time.now();
-        logger.info("Started Shape Point Detection...");
+        logger.info("Started Shape Point Detection for Shard {}", this.loadedShards.get(0));
 
         Iterables.stream(this.rawAtlas.points()).filter(point -> isAtlasPoint(changeSet, point))
                 .forEach(changeSet::recordPoint);
 
-        logger.info("Finished Shape Point Detection in {}", time.untilNow());
+        logger.info("Finished Shape Point Detection for Shard {} in {}", this.loadedShards.get(0),
+                time.untilNow());
     }
 
     /**
@@ -517,7 +521,7 @@ public class WaySectionProcessor
     private void identifyEdgesNodesAndAreasFromLines(final WaySectionChangeSet changeSet)
     {
         final Time time = Time.now();
-        logger.info("Started Atlas Feature Detection...");
+        logger.info("Started Atlas Feature Detection for Shard {}", this.loadedShards.get(0));
 
         this.rawAtlas.lines().forEach(line ->
         {
@@ -614,7 +618,8 @@ public class WaySectionProcessor
             }
         });
 
-        logger.info("Finished Atlas Feature Detection in {}", time.untilNow());
+        logger.info("Finished Atlas Feature Detection for Shard {} in {}", this.loadedShards.get(0),
+                time.untilNow());
     }
 
     /**
@@ -804,7 +809,7 @@ public class WaySectionProcessor
     private void sectionEdges(final WaySectionChangeSet changeSet)
     {
         final Time time = Time.now();
-        logger.info("Started Edge Sectioning...");
+        logger.info("Started Edge Sectioning for Shard {}", this.loadedShards.get(0));
 
         changeSet.getLinesThatBecomeEdges().forEach(lineIdentifier ->
         {
@@ -821,7 +826,8 @@ public class WaySectionProcessor
             changeSet.createLineToEdgeMapping(line, edges);
         });
 
-        logger.info("Finished Edge Sectioning in {}", time.untilNow());
+        logger.info("Finished Edge Sectioning for Shard {} in {}", this.loadedShards.get(0),
+                time.untilNow());
     }
 
     /**
@@ -911,7 +917,8 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier) : 0;
+                                ? duplicateLocations.get(startIdentifier)
+                                : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1039,7 +1046,8 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 0;
+                                ? duplicateLocations.get(currentLocation)
+                                : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1052,9 +1060,9 @@ public class WaySectionProcessor
                             if (endNode.get().equals(startNode.get()) && index - 1 == startIndex)
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations
-                                        .containsKey(currentLocation)
-                                                ? duplicateLocations.get(currentLocation) : 0;
+                                final int duplicateCount = duplicateLocations.containsKey(
+                                        currentLocation) ? duplicateLocations.get(currentLocation)
+                                                : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1116,7 +1124,8 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 1;
+                                ? duplicateLocations.get(currentLocation)
+                                : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -366,10 +366,8 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         {
             final Location location = JTS_LOCATION_CONVERTER.backwardConvert(coordinate);
             final Iterable<Point> existingRawAtlasPoints = this.rawAtlas.pointsAt(location);
-            existingRawAtlasPoints.forEach(point ->
-            {
-                this.pointsMarkedForRemoval.add(point.getIdentifier());
-            });
+            existingRawAtlasPoints
+                    .forEach(point -> this.pointsMarkedForRemoval.add(point.getIdentifier()));
         }
     }
 
@@ -447,6 +445,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                 }
             }
         });
+
+        // Update all removed points
+        this.pointsMarkedForRemoval
+                .forEach(point -> this.slicedPointAndLineChanges.deletePoint(point));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.raw.slicing;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +51,9 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
 
     // Keeps track of all changes made during slicing
     private final SimpleChangeSet slicedPointAndLineChanges;
+
+    // Keeps track of points marked for removal
+    private final Set<Long> pointsMarkedForRemoval = new HashSet<>();
 
     public RawAtlasPointAndLineSlicer(final Set<String> countries,
             final CountryBoundaryMap countryBoundaryMap, final Atlas atlas,
@@ -228,6 +232,8 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                     // Check if the slice is within the working bound
                     if (isOutsideWorkingBound(slice))
                     {
+                        // Mark all existing points from this slice for removal and continue
+                        removeShapePointsFromFilteredSliced(slice);
                         continue;
                     }
 
@@ -286,6 +292,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                                 // Update all existing points to have the country code.
                                 for (final Point rawAtlasPoint : rawAtlasPointsAtSliceVertex)
                                 {
+                                    // Make sure to keep this point
+                                    this.pointsMarkedForRemoval
+                                            .remove(rawAtlasPoint.getIdentifier());
+
                                     // Update the country codes
                                     this.slicedPointAndLineChanges.updatePointTags(
                                             rawAtlasPoint.getIdentifier(), pointTags);
@@ -338,6 +348,28 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
             // Update to use all country codes
             updateLineToHaveCountryCodesFromAllSlices(line, slices);
             getStatistics().recordSkippedLine();
+        }
+    }
+
+    /**
+     * Given a slice, that is outside the working bound, mark all shape points for this slice for
+     * removal from the final atlas. Since we are removing the slice, we don't need its shape
+     * points.
+     *
+     * @param slice
+     *            The {@link Geometry} slice being filtered
+     */
+    private void removeShapePointsFromFilteredSliced(final Geometry slice)
+    {
+        final Coordinate[] jtsSliceCoordinates = slice.getCoordinates();
+        for (final Coordinate coordinate : jtsSliceCoordinates)
+        {
+            final Location location = JTS_LOCATION_CONVERTER.backwardConvert(coordinate);
+            final Iterable<Point> existingRawAtlasPoints = this.rawAtlas.pointsAt(location);
+            existingRawAtlasPoints.forEach(point ->
+            {
+                this.pointsMarkedForRemoval.add(point.getIdentifier());
+            });
         }
     }
 
@@ -396,8 +428,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         {
             final long pointIdentifier = point.getIdentifier();
 
-            // Only update points that haven't been assigned a country code after way slicing
-            if (!this.slicedPointAndLineChanges.getUpdatedPointTags().containsKey(pointIdentifier))
+            // Only update points that haven't been assigned a country code after way slicing or
+            // those marked for removal
+            if (!this.slicedPointAndLineChanges.getUpdatedPointTags().containsKey(pointIdentifier)
+                    && !this.pointsMarkedForRemoval.contains(pointIdentifier))
             {
                 getStatistics().recordProcessedPoint();
                 final Map<String, String> updatedTags = createPointTags(point.getLocation(), true);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSet.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSet.java
@@ -42,6 +42,7 @@ import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
 public class RelationChangeSet
 {
     // Created entities
+    private final Set<Long> deletedPoints;
     private final Map<Long, TemporaryPoint> createdPoints;
     private final Map<Long, TemporaryLine> createdLines;
     private final Map<Long, TemporaryRelation> createdRelations;
@@ -63,6 +64,7 @@ public class RelationChangeSet
 
     public RelationChangeSet()
     {
+        this.deletedPoints = new HashSet<>();
         this.createdPoints = new HashMap<>();
         this.createdLines = new HashMap<>();
         this.createdRelations = new HashMap<>();
@@ -106,6 +108,11 @@ public class RelationChangeSet
         this.deletedLines.add(identifier);
     }
 
+    public void deletePoint(final Long identifier)
+    {
+        this.deletedPoints.add(identifier);
+    }
+
     public void deleteRelation(final long identifier)
     {
         this.deletedRelations.add(identifier);
@@ -140,6 +147,11 @@ public class RelationChangeSet
     public Set<Long> getDeletedLines()
     {
         return this.deletedLines;
+    }
+
+    public Set<Long> getDeletedPoints()
+    {
+        return this.deletedPoints;
     }
 
     public MultiMapWithSet<Long, TemporaryRelationMember> getDeletedRelationMembers()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSetHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSetHandler.java
@@ -88,11 +88,19 @@ public class RelationChangeSetHandler extends ChangeSetHandler
 
     private void addExistingPointsAndLines()
     {
-        this.getAtlas().points().forEach(point -> this.getBuilder().addPoint(point.getIdentifier(),
-                point.getLocation(), point.getTags()));
+        this.getAtlas().points().forEach(point ->
+        {
+            // Add the point, if it hasn't been deleted
+            if (!this.changeSet.getDeletedPoints().contains(point.getIdentifier()))
+            {
+                this.getBuilder().addPoint(point.getIdentifier(), point.getLocation(),
+                        point.getTags());
+            }
+        });
+
         this.getAtlas().lines().forEach(line ->
         {
-            // Add the line, if it hasn't been removed
+            // Add the line, if it hasn't been deleted
             if (!this.changeSet.getDeletedLines().contains(line.getIdentifier()))
             {
                 this.getBuilder().addLine(line.getIdentifier(), line.asPolyLine(), line.getTags());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveLineI
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveLocationItem;
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveObjectStore;
 import org.openstreetmap.atlas.geography.atlas.builder.store.AtlasPrimitiveRelation;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.pbf.OsmPbfLoader;
@@ -122,7 +123,7 @@ public class RawAtlasGeneratorTest
 
         Assert.assertEquals(
                 "The original Atlas counts of (Lines + Master Edges + Areas) should equal the total number of all Lines in the Raw Atlas, let's verify this",
-                Iterables.size(Iterables.filter(oldAtlas.edges(), edge -> edge.isMasterEdge()))
+                Iterables.size(Iterables.filter(oldAtlas.edges(), Edge::isMasterEdge))
                         + oldAtlas.numberOfAreas() + oldAtlas.numberOfLines(),
                 rawAtlas.numberOfLines());
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -99,6 +99,21 @@ public class WaySectionProcessorTest
     }
 
     @Test
+    public void testLineWithRepeatedLocation()
+    {
+        // Based on a prior version of https://www.openstreetmap.org/way/488453376
+        final Atlas slicedRawAtlas = this.setup.getLineWithRepeatedLocationAtlas();
+        final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
+                AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
+
+        Assert.assertEquals("Four edges, each having a reverse counterpart", 4,
+                finalAtlas.numberOfEdges());
+        Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
+        Assert.assertTrue("This way got sectioned 4 times, with reverse edges", Iterables
+                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)) == 4);
+    }
+
+    @Test
     public void testLoopingWayWithIntersection()
     {
         // Based on https://www.openstreetmap.org/way/310540517 and partial excerpt of
@@ -114,6 +129,22 @@ public class WaySectionProcessorTest
                 .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540517L)) == 6);
         Assert.assertTrue("This edge got sectioned once, with reverse edges", Iterables
                 .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540519L)) == 2);
+    }
+
+    @Test
+    public void testLoopWithRepeatedLocation()
+    {
+        // Based on a prior version of https://www.openstreetmap.org/way/488453376 with a piece of
+        // https://www.openstreetmap.org/way/386313688
+        final Atlas slicedRawAtlas = this.setup.getLoopWithRepeatedLocationAtlas();
+        final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
+                AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
+
+        Assert.assertEquals("Four edges, each having a reverse counterpart", 4,
+                finalAtlas.numberOfEdges());
+        Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
+        Assert.assertTrue("This way got sectioned once, with a reverse edge", Iterables
+                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)) == 2);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -47,6 +47,12 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "roundAbout.atlas.txt")
     private Atlas roundAbout;
 
+    @TestAtlas(loadFromTextResource = "lineWithRepeatedLocation.atlas.txt")
+    private Atlas lineWithRepeatedLocation;
+
+    @TestAtlas(loadFromTextResource = "loopWithRepeatedLocation.atlas.txt")
+    private Atlas loopWithRepeatedLocation;
+
     public Atlas getBidirectionalRingAtlas()
     {
         return this.bidirectioalRingAtlas;
@@ -72,9 +78,19 @@ public class WaySectionProcessorTestRule extends CoreTestRule
         return this.lineWithLoopInMiddle;
     }
 
+    public Atlas getLineWithRepeatedLocationAtlas()
+    {
+        return this.lineWithRepeatedLocation;
+    }
+
     public Atlas getLoopingWayWithIntersectionAtlas()
     {
         return this.loopingWayWithIntersection;
+    }
+
+    public Atlas getLoopWithRepeatedLocationAtlas()
+    {
+        return this.loopWithRepeatedLocation;
     }
 
     public Atlas getOneWayRingAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
@@ -122,15 +122,19 @@ public class RelationSlicingTest
         // This relation is made up of two closed lines, forming a multi-polygon with one inner and
         // one outer, both spanning the boundary of two countries.
         final Atlas rawAtlas = this.setup.getSimpleMultiPolygonWithHoleAtlas();
+
+        System.out.println(rawAtlas);
         Assert.assertEquals(2, rawAtlas.numberOfLines());
         Assert.assertEquals(8, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
         final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
 
+        System.out.println(slicedAtlas);
+
         new ComplexBuildingFinder().find(slicedAtlas).forEach(System.out::println);
 
-        Assert.assertEquals(29, slicedAtlas.numberOfPoints());
+        Assert.assertEquals(23, slicedAtlas.numberOfPoints());
         Assert.assertEquals(2, slicedAtlas.numberOfLines());
         Assert.assertEquals(2, slicedAtlas.numberOfRelations());
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
@@ -123,15 +123,11 @@ public class RelationSlicingTest
         // one outer, both spanning the boundary of two countries.
         final Atlas rawAtlas = this.setup.getSimpleMultiPolygonWithHoleAtlas();
 
-        System.out.println(rawAtlas);
         Assert.assertEquals(2, rawAtlas.numberOfLines());
         Assert.assertEquals(8, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
         final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
-
-        System.out.println(slicedAtlas);
-
         new ComplexBuildingFinder().find(slicedAtlas).forEach(System.out::println);
 
         Assert.assertEquals(23, slicedAtlas.numberOfPoints());

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithRepeatedLocation.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithRepeatedLocation.atlas.txt
@@ -1,0 +1,15 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+488453376000000 && 22.539148,113.9448557:22.539148,113.9448557:22.5392348,113.9448542:22.539495,113.9448495:22.5395425,113.9448487:22.5395455,113.9451532:22.5395009,113.9451538:22.5392333,113.9451574:22.5391521,113.9451585:22.539148,113.9448557 && last_edit_user_name -> ulrichm || last_edit_changeset -> 58630764 || last_edit_time -> 1525301434000 || last_edit_user_id -> 3331814 || iso_country_code -> CHN || footway -> crossing || highway -> footway || last_edit_version -> 4 || crossing -> zebra
+# Points
+5178935335000000 && 22.539148,113.9448557 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || synthetic_duplicate_osm_node -> YES || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935343000000 && 22.5392348,113.9448542 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503663000000 && 22.539495,113.9448495 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 2
+5178935349000000 && 22.5395425,113.9448487 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935333000000 && 22.5395455,113.9451532 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4808413267000000 && 22.5395009,113.9451538 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533154000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+5178935332000000 && 22.5392333,113.9451574 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503687000000 && 22.5391521,113.9451585 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+# Relations

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/loopWithRepeatedLocation.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/loopWithRepeatedLocation.atlas.txt
@@ -1,0 +1,17 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+488453376000000 && 22.539148,113.9448557:22.539148,113.9448557:22.5392348,113.9448542:22.539495,113.9448495:22.5395425,113.9448487:22.5395455,113.9451532:22.5395009,113.9451538:22.5392333,113.9451574:22.5391521,113.9451585:22.539148,113.9448557 && last_edit_user_name -> ulrichm || last_edit_changeset -> 58630764 || last_edit_time -> 1525301434000 || last_edit_user_id -> 3331814 || iso_country_code -> CHN || footway -> crossing || highway -> footway || last_edit_version -> 4 || crossing -> zebra
+386313688000000 && 22.5392333,113.9451574:22.5392462,113.9471391 && last_edit_user_name -> ulrichm || last_edit_changeset -> 58630764 || last_edit_time -> 1525301434000 || last_edit_user_id -> 3331814 || iso_country_code -> CHN || footway -> crossing || highway -> footway || last_edit_version -> 4
+# Points
+5178935335000000 && 22.539148,113.9448557 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || synthetic_duplicate_osm_node -> YES || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935343000000 && 22.5392348,113.9448542 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503663000000 && 22.539495,113.9448495 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 2
+5178935349000000 && 22.5395425,113.9448487 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935333000000 && 22.5395455,113.9451532 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4808413267000000 && 22.5395009,113.9451538 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533154000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+5178935332000000 && 22.5392333,113.9451574 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503687000000 && 22.5391521,113.9451585 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+3896278676000000 && 22.5392462,113.9471391 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533156000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 2
+# Relations


### PR DESCRIPTION
Multiple changes here:

1. Fixing a `ClassCastException` when merging raw `Atlas Relation`s.
2. Making `Relation` handling more dynamic - check for an empty bean before adding a `Relation`.
3. When we filter our a sliced chunk of a way - we weren't getting rid of the shape points for the filtered slices. They were remaining as part of the Atlas when they should not have been.
4. During way-sectioning - our previous predicate was to bring in all Points in the neighboring shards. This caused some issues since we want to keep isolated Points. We now only bring in points that are part of a Line that qualifies to be an Edge. This slows down the DynamicAtlas to some degree, but allows for a more accurate result in the end. Thinking of other optimizations for this.
5. Updated `RawAtlasRelationSlicer` to avoid returning sliced members and instead just update the change set. This was a remnant from a recursive implementation attempt that never got cleaned up!
6. Added better logging around raw atlas generation, logging the shard name being processed, filtered and generated.
7. For a shard that contains no data, or is empty as a result of filtering out features, doing a null check before processing.
8. Accounting for repeated shape points in an OSM Way when way-sectioning and getting rid of single-`Node` `Edge`s. Two test cases for this behavior
9. Added more logging around way-sectioning and time spent on each step
10. Added better logging around failures when building a `PackedAtlas`. 
11. Cosmetic cleanup

Tested locally on multiple PBFs that ran into the issue.