### PR TITLE
Fix for edge case of LargeArray.trim() causing ArrayIndexOutOfBoundsException 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -298,6 +298,6 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
 
     private boolean isRightmostSubarrayFull()
     {
-        return indexInside(this.nextIndex) == 0;
+        return this.nextIndex > 0 && indexInside(this.nextIndex) == 0;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -66,16 +66,6 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
             throw new CoreException("subArraySize ({}) must be a positive integer", subArraySize);
         }
 
-        /*
-         * This is something we should be doing, since having the memoryBlockSize exceed the
-         * subArraySize ends up allocating tons of wasted padding space. However, having this check
-         * here breaks about 300 off the ~1000 unit tests.
-         */
-        // if (memoryBlockSize > subArraySize)
-        // {
-        // throw new CoreException("memoryBlockSize ({}) must not exceed the subArraySize ({})",
-        // memoryBlockSize, subArraySize);
-        // }
         this.maximumSize = maximumSize;
         this.arrays = new ArrayList<>();
         this.memoryBlockSize = memoryBlockSize;

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -227,10 +227,22 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
         {
             return;
         }
+
+        /*
+         * Exit early in the case that the rightmost subarray is full - there is nothing to trim. In
+         * fact, the trim logic below breaks in this case, and will wipe out the rightmost subarray
+         * instead of trimming it.
+         */
+        if (isRightmostSubarrayFull())
+        {
+            return;
+        }
+
         final int arrayIndex = this.arrays.size() - 1;
         final PrimitiveArray<T> last = this.arrays.get(arrayIndex);
         // Here nextIndex is actually the size, and not size-1
         final int indexInside = indexInside(this.nextIndex);
+
         if (Ratio.ratio((double) indexInside / last.size()).isLessThan(ratio))
         {
             this.arrays.set(arrayIndex, last.trimmed(indexInside));
@@ -282,5 +294,10 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
     private int indexInside(final long index)
     {
         return (int) (index % this.subArraySize);
+    }
+
+    private boolean isRightmostSubarrayFull()
+    {
+        return indexInside(this.nextIndex) == 0;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -227,6 +227,8 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
         {
             return;
         }
+        final int arrayIndex = this.arrays.size() - 1;
+        final PrimitiveArray<T> rightmost = this.arrays.get(arrayIndex);
 
         /*
          * Exit early in the case that the rightmost subarray is full - there is nothing to trim. In
@@ -238,13 +240,11 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
             return;
         }
 
-        final int arrayIndex = this.arrays.size() - 1;
-        final PrimitiveArray<T> last = this.arrays.get(arrayIndex);
         // Here nextIndex is actually the size, and not size-1
         final int indexInside = indexInside(this.nextIndex);
-        if (Ratio.ratio((double) indexInside / last.size()).isLessThan(ratio))
+        if (Ratio.ratio((double) indexInside / rightmost.size()).isLessThan(ratio))
         {
-            this.arrays.set(arrayIndex, last.trimmed(indexInside));
+            this.arrays.set(arrayIndex, rightmost.trimmed(indexInside));
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -242,7 +242,6 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
         final PrimitiveArray<T> last = this.arrays.get(arrayIndex);
         // Here nextIndex is actually the size, and not size-1
         final int indexInside = indexInside(this.nextIndex);
-
         if (Ratio.ratio((double) indexInside / last.size()).isLessThan(ratio))
         {
             this.arrays.set(arrayIndex, last.trimmed(indexInside));

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -56,6 +56,20 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
      */
     public LargeArray(final long maximumSize, final int memoryBlockSize, final int subArraySize)
     {
+        if (memoryBlockSize <= 0)
+        {
+            throw new CoreException("memoryBlockSize ({}) must be a positive integer",
+                    memoryBlockSize);
+        }
+        if (subArraySize <= 0)
+        {
+            throw new CoreException("subArraySize ({}) must be a positive integer", subArraySize);
+        }
+        if (memoryBlockSize > subArraySize)
+        {
+            throw new CoreException("memoryBlockSize ({}) must not exceed the subArraySize ({})",
+                    memoryBlockSize, subArraySize);
+        }
         this.maximumSize = maximumSize;
         this.arrays = new ArrayList<>();
         this.memoryBlockSize = memoryBlockSize;
@@ -235,7 +249,7 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
          * fact, the trim logic below breaks in this case, and will wipe out the rightmost subarray
          * instead of trimming it.
          */
-        if (isRightmostSubarrayFull())
+        if (rightmostSubarrayIsFull())
         {
             return;
         }
@@ -295,7 +309,7 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
         return (int) (index % this.subArraySize);
     }
 
-    private boolean isRightmostSubarrayFull()
+    private boolean rightmostSubarrayIsFull()
     {
         return this.nextIndex > 0 && indexInside(this.nextIndex) == 0;
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/arrays/LargeArray.java
@@ -65,11 +65,17 @@ public abstract class LargeArray<T> implements Iterable<T>, Serializable
         {
             throw new CoreException("subArraySize ({}) must be a positive integer", subArraySize);
         }
-        if (memoryBlockSize > subArraySize)
-        {
-            throw new CoreException("memoryBlockSize ({}) must not exceed the subArraySize ({})",
-                    memoryBlockSize, subArraySize);
-        }
+
+        /*
+         * This is something we should be doing, since having the memoryBlockSize exceed the
+         * subArraySize ends up allocating tons of wasted padding space. However, having this check
+         * here breaks about 300 off the ~1000 unit tests.
+         */
+        // if (memoryBlockSize > subArraySize)
+        // {
+        // throw new CoreException("memoryBlockSize ({}) must not exceed the subArraySize ({})",
+        // memoryBlockSize, subArraySize);
+        // }
         this.maximumSize = maximumSize;
         this.arrays = new ArrayList<>();
         this.memoryBlockSize = memoryBlockSize;

--- a/src/test/java/org/openstreetmap/atlas/utilities/arrays/LargeArrayTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/arrays/LargeArrayTest.java
@@ -26,76 +26,6 @@ public class LargeArrayTest
         new LargeArrayTest().largeSerialization();
     }
 
-    @Test
-    public void exposeTrimEdgecaseBug1()
-    {
-        final int maxSize = 30;
-        final int subArraySize = 10;
-        final int blockSize = subArraySize;
-
-        final LongArray array = new LongArray(maxSize, blockSize, subArraySize);
-
-        // Completely fill the first subarray
-        for (int i = 0; i < subArraySize; i++)
-        {
-            array.add(2L);
-        }
-
-        // Now, we trim the array. This will corrupt the rightmost* subarray if and only if it is
-        // completely full (ie. a subsequent call to add() will force a new array allocation)
-        // * Here, rightmost indicates it is the last subarray in LargeArray's list of subarrays
-        array.trim();
-
-        // this assert will throw an ArrayIndexOutOfBounds exception because the trim method resized
-        // the rightmost subarray to a size-0 array
-        try
-        {
-            Assert.assertEquals(2L, array.get(1).longValue());
-        }
-        catch (final ArrayIndexOutOfBoundsException exception)
-        {
-            exception.printStackTrace();
-            Assert.fail("Caught the bug!");
-        }
-    }
-
-    @Test
-    public void exposeTrimEdgecaseBug2()
-    {
-        final int maxSize = 30;
-        final int subArraySize = 10;
-        final int blockSize = subArraySize;
-
-        final LongArray array = new LongArray(maxSize, blockSize, subArraySize);
-
-        // fill all the subarrays
-        for (int i = 0; i < maxSize; i++)
-        {
-            array.add(2L);
-        }
-
-        // Now we trim. Like in exposeTrimEdgecaseBug1, this corrupts the rightmost subarray in the
-        // list. However, it does not corrupt any of the other subarrays
-        array.trim();
-
-        // this is fine, since we are reading from the first subarray
-        Assert.assertEquals(2L, array.get(1).longValue());
-
-        // also fine, since we are reading from the second subarray
-        Assert.assertEquals(2L, array.get(17).longValue());
-
-        // grab a value from the last subarray, this assert will fail
-        try
-        {
-            Assert.assertEquals(2L, array.get(28).longValue());
-        }
-        catch (final ArrayIndexOutOfBoundsException exception)
-        {
-            exception.printStackTrace();
-            Assert.fail("Caught the bug!");
-        }
-    }
-
     @Before
     public void init()
     {
@@ -158,5 +88,41 @@ public class LargeArrayTest
         this.array.trim();
         Assert.assertEquals(10,
                 this.array.getArrays().get(this.array.getArrays().size() - 1).size());
+    }
+
+    /*
+     * A NOTE ABOUT THIS TEST: Historically, LargeArray would mishandle trim() in the case that the
+     * rightmost subarray was completely full. The trim() function has now been fixed, so this
+     * should no longer happen. If this test ever fails, that means the bug has been re-introduced.
+     */
+    @Test
+    public void trimArrayWithFullRightmostSubArray()
+    {
+        final int maxSize = 100;
+        final int subArraySize = 10;
+        final int blockSize = subArraySize;
+
+        final LongArray array = new LongArray(maxSize, blockSize, subArraySize);
+        array.trim();
+
+        // completely fill up three subarrays
+        for (int i = 0; i < subArraySize * 3; i++)
+        {
+            array.add(2L);
+        }
+
+        // Now, we trim the array. This should only affect the rightmost* subarray
+        // * Here, rightmost indicates it is the last subarray in LargeArray's list of subarrays
+        array.trim();
+
+        // this is fine, since the first subarray is not corrupted by trim()
+        Assert.assertEquals(2L, array.get(2).longValue());
+
+        // this is also fine, the second subarray is not corrupted
+        Assert.assertEquals(2L, array.get(12).longValue());
+
+        // this should be fine as well, now that the bug is fixed
+        // NOTE that the bug would have caused this line to throw ArrayIndexOutOfBoundsException
+        Assert.assertEquals(2L, array.get(23).longValue());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/arrays/LargeArrayTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/arrays/LargeArrayTest.java
@@ -103,7 +103,6 @@ public class LargeArrayTest
         final int blockSize = subArraySize;
 
         final LongArray array = new LongArray(maxSize, blockSize, subArraySize);
-        array.trim();
 
         // completely fill up three subarrays
         for (int i = 0; i < subArraySize * 3; i++)


### PR DESCRIPTION
The previous version of `LargeArray`'s `trim()` method had a bug that would only appear when the rightmost subarray was completely full. This bug was due to the logic that calculated the size to which the subarray would be trimmed. Checking out `LargeArray.trimIfFilledLessThan()`, you can see the code effectively does the following:

```java
final int arrayIndex = this.arrays.size() - 1;
final int indexInside = this.nextIndex % this.subArraySize;
this.arrays.set(arrayIndex, rightmost.trimmed(indexInside));
```

In the case that the rightmost subarray is full, `this.nextIndex % this.subArraySize` will of course be zero. So then the `arrays.set` would reset the rightmost subarray by calling `trimmed(0)` on it, which would wipe it out completely.

The fix is simply to exit `LargeArray.trimIfFilledLessThan()` early in the case that the rightmost subarray is full.


There is another possible issue I discovered while fixing this bug that is orthogonal to the `trim()` bug. Currently, `LargeArray` allows for `memoryBlockSize` to exceed `subArraySize`. This seems to be a problem. When `memoryBlockSize > subArraySize`, the LargeArray will over allocate each subarray by `memoryBlockSize - subArraySize`. Apparently there are many places in the code where arrays are created with `memoryBlockSize = 1024` and `subArraySize = 1`. This means that at each of these points, 1023 blocks are completely wasted by the `LargeArray`. This does not seem like something we want, but I am unsure of what to do here.
@matthieun we definitely need to take a closer look at this