### PR TITLE
Fix performance issue with fullyGeometricallyEncloses (and awtOverflows)

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -61,6 +61,7 @@ public class Polygon extends PolyLine implements GeometricSurface
     private static final int MINIMUM_N_FOR_SIDE_CALCULATION = 3;
     private Area awtArea;
     private java.awt.Polygon awtPolygon;
+    private transient Boolean awtOverflows;
 
     /**
      * Generate a random polygon within bounds.
@@ -401,6 +402,7 @@ public class Polygon extends PolyLine implements GeometricSurface
         }
     }
 
+    @Override
     public boolean overlaps(final MultiPolygon multiPolygon)
     {
         for (final Polygon outer : multiPolygon.outers())
@@ -436,6 +438,7 @@ public class Polygon extends PolyLine implements GeometricSurface
      *            The {@link PolyLine} to test
      * @return True if this {@link Polygon} intersects/overlaps the given {@link PolyLine}.
      */
+    @Override
     public boolean overlaps(final PolyLine polyline)
     {
         return overlapsInternal(polyline, true);
@@ -620,7 +623,12 @@ public class Polygon extends PolyLine implements GeometricSurface
 
     private boolean awtOverflows()
     {
-        return this.bounds().width().asDm7() < 0 || this.bounds().height().asDm7() < 0;
+        if (this.awtOverflows == null)
+        {
+            final Rectangle bounds = bounds();
+            this.awtOverflows = bounds.width().asDm7() < 0 || bounds.height().asDm7() < 0;
+        }
+        return this.awtOverflows;
     }
 
     private java.awt.Polygon awtPolygon()


### PR DESCRIPTION
With complex `Polygon`s (many shape points), deciding to use AWT for `fullyGeometricallyEncloses` or not is in itself a performance hog. Calling `bounds()` twice each time this method is invoked is really expensive.

This change fixes the issue when `fullyGeometricallyEncloses` is called many times with the same Polygon, which happens often with the `OsmPbfProcessor`. The decision flag is simply stored in a transient `Boolean`.