### PR TITLE
Conditionally suppress log message in NumericValidator.setRange()

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/NumericValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/NumericValidator.java
@@ -96,6 +96,13 @@ public abstract class NumericValidator extends ExactMatchValidator
             this.minimum = minimum;
             this.maximum = maximum;
         }
+        else if (minimum == Long.MAX_VALUE || maximum == Long.MIN_VALUE)
+        {
+            /*
+             * Special case where at least one of the range endpoints is a default value. In this
+             * case, we don't want to send out a log message - instead just do nothing.
+             */
+        }
         else
         {
             logger.debug("Invalid range supplied, minimum: {} cannot be greater than maximum: {}.",


### PR DESCRIPTION
The `Range` interface in `Tag` defines the default minimum to `Long.MAX_VALUE` and the default maximum to `Long.MIN_VALUE`. This causes the logger in `NumericValidator.setRange()` to fire if either the supplied minimum or maximum uses a default value. We should suppress this log if we detect a default value, since it is not actually indicative of a problem.