### PR TITLE
DNM: Add MultiPolyLine and related converters

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolyLine.java
@@ -1,0 +1,79 @@
+package org.openstreetmap.atlas.geography;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.converters.WktMultiPolyLineConverter;
+import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+import com.google.common.collect.Lists;
+
+/**
+ * A MultiPolyLine is a set of {@link PolyLine}s in a specific order
+ *
+ * @author yalimu
+ */
+public class MultiPolyLine implements Iterable<PolyLine>, Located, Serializable
+{
+    private static final long serialVersionUID = 5907807607388840698L;
+    private final List<PolyLine> polyLineList;
+
+    /**
+     * Create a {@link MultiPolyLine} from Well Known Text
+     *
+     * @param wkt
+     *            The Well Known Text
+     * @return The {@link MultiPolyLine}
+     */
+    public static MultiPolyLine wkt(final String wkt)
+    {
+        return new WktMultiPolyLineConverter().backwardConvert(wkt);
+    }
+
+    public MultiPolyLine(final Iterable<? extends PolyLine> polyLines)
+    {
+        this(Iterables.asList(polyLines));
+    }
+
+    public MultiPolyLine(final List<? extends PolyLine> polyLines)
+    {
+        if (polyLines.isEmpty())
+        {
+            throw new CoreException("Cannot have an empty list of PolyLine or Polygon.");
+        }
+        this.polyLineList = new ArrayList<>(polyLines);
+    }
+
+    public MultiPolyLine(final PolyLine... polyLines)
+    {
+        this(Iterables.iterable(polyLines));
+    }
+
+    public Iterable<GeoJsonBuilder.LocationIterableProperties> asLocationIterableProperties()
+    {
+        return this.polyLineList.stream()
+                .map(polyLine -> new GeoJsonBuilder.LocationIterableProperties(polyLine,
+                        new HashMap<>()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Rectangle bounds()
+    {
+        final List<Location> locations = Lists.newArrayList();
+        this.polyLineList.stream().map(PolyLine::getPoints).forEach(locations::addAll);
+        return Rectangle.forLocations(locations);
+    }
+
+    @Override
+    public Iterator<PolyLine> iterator()
+    {
+        return this.polyLineList.iterator();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/WktMultiPolyLineConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/WktMultiPolyLineConverter.java
@@ -1,0 +1,42 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.MultiPolyLine;
+import org.openstreetmap.atlas.geography.converters.jts.JtsMultiPolyLineConverter;
+import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
+
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+/**
+ * Given an WKT string generate a {@link MultiLineString} and vice-versa
+ *
+ * @author yalimu
+ */
+public class WktMultiPolyLineConverter implements TwoWayConverter<MultiPolyLine, String>
+{
+    @Override
+    public MultiPolyLine backwardConvert(final String wkt)
+    {
+        MultiLineString geometry = null;
+        final WKTReader myReader = new WKTReader();
+        try
+        {
+            geometry = (MultiLineString) myReader.read(wkt);
+        }
+        catch (final ParseException | ClassCastException e)
+        {
+            throw new CoreException("Cannot parse wkt : {}", wkt);
+        }
+        return new JtsMultiPolyLineConverter().backwardConvert(geometry);
+    }
+
+    @Override
+    public String convert(final MultiPolyLine multiPolyLine)
+    {
+        final MultiLineString geometry = new JtsMultiPolyLineConverter().convert(multiPolyLine);
+        return new WKTWriter().write(geometry);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
@@ -1,0 +1,45 @@
+package org.openstreetmap.atlas.geography.converters.jts;
+
+import java.util.List;
+
+import org.openstreetmap.atlas.geography.MultiPolyLine;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.MultiLineString;
+
+/**
+ * Convert a {@link MultiPolyLine} to a JTS {@link MultiLineString}.
+ *
+ * @author yalimu
+ */
+public class JtsMultiPolyLineConverter implements TwoWayConverter<MultiPolyLine, MultiLineString>
+{
+    private static final JtsCoordinateArrayConverter COORDINATE_ARRAY_CONVERTER = new JtsCoordinateArrayConverter();
+    private static final GeometryFactory FACTORY = JtsPrecisionManager.getGeometryFactory();
+
+    @Override
+    public MultiPolyLine backwardConvert(final MultiLineString multiLineString)
+    {
+        final List<PolyLine> polyLineList = Lists.newArrayList();
+        for (int i = 0; i < multiLineString.getNumGeometries(); i++)
+        {
+            final LineString lineString = (LineString) multiLineString.getGeometryN(i);
+            polyLineList.add(new PolyLine(COORDINATE_ARRAY_CONVERTER
+                    .backwardConvert(lineString.getCoordinateSequence())));
+        }
+        return new MultiPolyLine(polyLineList);
+    }
+
+    @Override
+    public MultiLineString convert(final MultiPolyLine multiPolyLine)
+    {
+        final LineString[] lineStrings = (LineString[]) ImmutableList
+                .copyOf(multiPolyLine.iterator()).toArray();
+        return new MultiLineString(lineStrings, FACTORY);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/geojson/GeoJsonBuilder.java
@@ -26,6 +26,44 @@ import com.google.gson.JsonPrimitive;
 public class GeoJsonBuilder
 {
     /**
+     * @author matthieun
+     * @author mgostintsev
+     */
+    public enum GeoJsonType
+    {
+        POINT("Point"),
+        LINESTRING("LineString"),
+        POLYGON("Polygon"),
+        MULTI_POINT("MultiPoint"),
+        MULTI_LINESTRING("MultiLineString"),
+        MULTI_POLYGON("MultiPolygon");
+
+        private final String type;
+
+        public static GeoJsonType forType(final String type)
+        {
+            for (final GeoJsonType value : values())
+            {
+                if (value.getType().equals(type))
+                {
+                    return value;
+                }
+            }
+            throw new CoreException("Invalid geoJson type: {}", type);
+        }
+
+        GeoJsonType(final String type)
+        {
+            this.type = type;
+        }
+
+        public String getType()
+        {
+            return this.type;
+        }
+    }
+
+    /**
      * Java bean to store the geometry (as an {@link Iterable} of {@link Location}s) and all the
      * tags as a {@link String} to {@link String} {@link Map}
      *
@@ -264,6 +302,31 @@ public class GeoJsonBuilder
     }
 
     /**
+     * Creates a GeoJson FeatureCollection from an iterable of GeoJsonObject
+     *
+     * @param geoJsonObjects
+     *            a iterable of GeoJsonObject
+     * @return a GeoJson FeatureCollection
+     */
+    public GeoJsonObject createFromGeoJson(final Iterable<GeoJsonObject> geoJsonObjects)
+    {
+        final JsonObject result = new JsonObject();
+        result.addProperty(TYPE, FEATURE_COLLECTION);
+        final JsonArray features = new JsonArray();
+        int counter = 0;
+        for (final GeoJsonObject object : geoJsonObjects)
+        {
+            if (this.logFrequency > 0 && ++counter % this.logFrequency == 0)
+            {
+                logger.info("Processed {} features.", counter);
+            }
+            features.add(object.jsonObject());
+        }
+        result.add(FEATURES, features);
+        return new GeoJsonObject(result);
+    }
+
+    /**
      * Creates a GeometryCollection type Feature containing geometries derived from a collection of
      * {@link LocationIterableProperties}. <strong>Note:</strong> feature parameters are not present
      * in the resulting GeometryCollection and must be handled separately to avoid data loss.
@@ -404,7 +467,7 @@ public class GeoJsonBuilder
 
     /**
      * Creates a MultiPolygon type GeoJson Feature
-     * 
+     *
      * @param polygons
      *            geometries
      * @return a GeoJson Feature
@@ -441,7 +504,7 @@ public class GeoJsonBuilder
     /**
      * Creates multipolygon from {@link Iterable} of {@link Polygon}s where first polygon is assumed
      * to be the outer ring and the rest are inner.
-     * 
+     *
      * @param polygons
      *            an iterable of polygons where the first is assumed to be the outer polygon in a
      *            multipolygon
@@ -476,43 +539,5 @@ public class GeoJsonBuilder
         result.add(GEOMETRY, geometry);
         result.add(PROPERTIES, new JsonObject());
         return new GeoJsonObject(result);
-    }
-
-    /**
-     * @author matthieun
-     * @author mgostintsev
-     */
-    public enum GeoJsonType
-    {
-        POINT("Point"),
-        LINESTRING("LineString"),
-        POLYGON("Polygon"),
-        MULTI_POINT("MultiPoint"),
-        MULTI_LINESTRING("MultiLineString"),
-        MULTI_POLYGON("MultiPolygon");
-
-        private final String type;
-
-        public static GeoJsonType forType(final String type)
-        {
-            for (final GeoJsonType value : values())
-            {
-                if (value.getType().equals(type))
-                {
-                    return value;
-                }
-            }
-            throw new CoreException("Invalid geoJson type: {}", type);
-        }
-
-        GeoJsonType(final String type)
-        {
-            this.type = type;
-        }
-
-        public String getType()
-        {
-            return this.type;
-        }
     }
 }


### PR DESCRIPTION
This is some code from @Yamu that unfortunately did not make it in for some reason. Adding it here, thanks @Yamu!

- Add `MultiPolyLine` to mapping to `MultiLineString` in JTS.
- Add `WktMultiPolyLineConverter`.
- Add `JtsMultiPolyLineConverter`.
- Modify `GeoJsonBuilder` to build one GeoJson out of several GeoJson.

This still needs some testing. Will add that soon before this PR gets to be merged.