### PR TITLE
Fixed bug in areasCovering that overincluded results.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -508,13 +508,12 @@ public class Location implements Located, Iterable<Location>, Serializable
                         * Math.sin((double) distance.asMillimeters()
                                 / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
                         * Math.cos(bearing));
-        final double longitude2 = longitude1 + Math.atan2(
-                Math.sin(bearing)
-                        * Math.sin((double) distance.asMillimeters()
-                                / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
-                        * Math.cos(latitude1),
-                Math.cos((double) distance.asMillimeters()
+        final double longitude2 = longitude1 + Math.atan2(Math.sin(bearing)
+                * Math.sin((double) distance.asMillimeters()
                         / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
+                * Math.cos(latitude1), Math
+                        .cos((double) distance.asMillimeters()
+                                / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
                         - Math.sin(latitude1) * Math.sin(latitude2));
         return new Location(Latitude.radiansBounded(latitude2),
                 Longitude.radiansBounded(longitude2));

--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -34,6 +34,7 @@ public class Location implements Located, Iterable<Location>, Serializable
     public static final Location TEST_5 = Location.forString("37.390535,-122.031007");
     public static final Location TEST_6 = Location.forString("37.325440,-122.033948");
     public static final Location TEST_7 = Location.forString("37.3314171,-122.0304871");
+    public static final Location TEST_8 = Location.forString("37.3214159,-122.0303831");
     public static final Location STEVENS_CREEK = Location.forString("37.324233,-122.003467");
     public static final Location CROSSING_85_280 = Location.forString("37.332439,-122.055760");
     public static final Location CROSSING_85_17 = Location.forString("37.255731,-121.955918");
@@ -507,12 +508,13 @@ public class Location implements Located, Iterable<Location>, Serializable
                         * Math.sin((double) distance.asMillimeters()
                                 / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
                         * Math.cos(bearing));
-        final double longitude2 = longitude1 + Math.atan2(Math.sin(bearing)
-                * Math.sin((double) distance.asMillimeters()
-                        / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
-                * Math.cos(latitude1), Math
-                        .cos((double) distance.asMillimeters()
+        final double longitude2 = longitude1 + Math.atan2(
+                Math.sin(bearing)
+                        * Math.sin((double) distance.asMillimeters()
                                 / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
+                        * Math.cos(latitude1),
+                Math.cos((double) distance.asMillimeters()
+                        / Distance.AVERAGE_EARTH_RADIUS.asMillimeters())
                         - Math.sin(latitude1) * Math.sin(latitude2));
         return new Location(Latitude.radiansBounded(latitude2),
                 Longitude.radiansBounded(longitude2));

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -109,7 +109,7 @@ public abstract class AbstractAtlas extends BareAtlas
     public Iterable<Area> areasCovering(final Location location)
     {
         final Iterable<Area> areas = this.getAreaSpatialIndex().get(location.bounds());
-        return Iterables.filter(areas, area ->
+        return Iterables.stream(areas).filter(area ->
         {
             final Polygon areaPolygon = area.asPolygon();
             return areaPolygon.fullyGeometricallyEncloses(location);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -108,7 +108,12 @@ public abstract class AbstractAtlas extends BareAtlas
     @Override
     public Iterable<Area> areasCovering(final Location location)
     {
-        return this.getAreaSpatialIndex().get(location.bounds());
+        final Iterable<Area> areas = this.getAreaSpatialIndex().get(location.bounds());
+        return Iterables.filter(areas, area ->
+        {
+            final Polygon areaPolygon = area.asPolygon();
+            return areaPolygon.fullyGeometricallyEncloses(location);
+        });
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/RelationMember.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/RelationMember.java
@@ -4,8 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 
 /**
- * A {@link Relation} member. It has a role and an {@link AtlasEntity}. The {@link AtlasEntity} may
- * be null in case the {@link Atlas} that created it has a sliced {@link Relation}.
+ * A {@link Relation} member. It has a role and an {@link AtlasEntity}.
  *
  * @author matthieun
  */

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
@@ -46,8 +46,8 @@ public class PackedAtlasSerializerTest
     public void testDeserializedSpatialIndex()
     {
         final Atlas deserialized = deserialized();
-        Assert.assertEquals(1, Iterables.size(
-                deserialized.areasIntersecting(Location.TEST_3.boxAround(Distance.ONE_METER))));
+        Assert.assertEquals(2, Iterables.size(
+                deserialized.areasIntersecting(Location.TEST_8.boxAround(Distance.ONE_METER))));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
@@ -107,6 +107,9 @@ public class PackedAtlasTest
         area2Tags.put("leisure", "swimming_pool");
         area2Tags.put("sport", "swimming");
 
+        final Map<String, String> area3Tags = new HashMap<>();
+        area2Tags.put("hello", "world");
+
         // Line tags
         final Map<String, String> line1Tags = new HashMap<>();
         line1Tags.put("power", "line");
@@ -153,6 +156,8 @@ public class PackedAtlasTest
         builder.addArea(54,
                 new Polygon(Location.TEST_5, Location.TEST_1, Location.TEST_4, Location.TEST_6),
                 area2Tags);
+        builder.addArea(4554, new Polygon(Location.TEST_1, Location.TEST_2, Location.TEST_3),
+                area3Tags);
 
         // Add Lines
         builder.addLine(32, new Segment(Location.TEST_5, Location.TEST_1), line1Tags);
@@ -373,9 +378,11 @@ public class PackedAtlasTest
                 Iterables.size(this.atlas.lineItemsContaining(Location.TEST_6)) == Iterables
                         .size(this.atlas.edgesContaining(Location.TEST_6))
                         + Iterables.size(this.atlas.linesContaining(Location.TEST_6)));
-        Assert.assertTrue(Iterables.size(this.atlas.areasCovering(Location.TEST_6)) == 2);
         Assert.assertTrue(Iterables.size(this.atlas.nodesAt(Location.TEST_6)) == 1);
         Assert.assertTrue(Iterables.size(this.atlas.pointsAt(Location.TEST_6)) == 1);
+
+        // check areasCovering, which uses fullyGeometricallyEncloses to check the covering property
+        Assert.assertTrue(Iterables.size(this.atlas.areasCovering(Location.TEST_8)) == 2);
 
         // Total number of AtlasItems = sum of the edges, areas, lines, nodes and points
         Assert.assertTrue(Iterables.size(this.atlas.itemsContaining(Location.TEST_6)) == Iterables


### PR DESCRIPTION
Previously, the `areasCovering` method in `AbstractAtlas` did not check if the target `Location` was actually fully enclosed by the `Area` in question. This caused the resulting set to over-include `Locations` that were within the bounding box of the `Area`, but not necessarily enclosed by the true `Area` geometry.

Interestingly enough, this change seems to break the `testLocationContaining` unit test in `PackedAtlasTest`. This is because the unit test uses `Locations` that are on the boundaries of the `Areas` in question. Since the new `areasCovering` code uses `fullyGeometricallyEncloses`, points on the border of a polygon are not considered enclosed by the polygon. I have fixed the unit test to better reflect the semantics implied by `areasCovering`.

Unrelated, but also removed a misleading, outdated comment in the `RelationMember` class.