### PR TITLE
Aerialway & Building Tag Updates

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/AerialWayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/AerialWayTag.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.tags;
 
 import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
 
 /**
  * OSM aerialway tag
@@ -22,5 +23,8 @@ public enum AerialWayTag
     MAGIC_CARPET,
     ZIP_LINE,
     PYLON,
-    STATION
+    STATION;
+
+    @TagKey
+    public static final String KEY = "aerialway";
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/BuildingTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/BuildingTag.java
@@ -62,7 +62,8 @@ public enum BuildingTag
     HANGAR,
     STABLE,
     TRANSFORMER_TOWER,
-    RUINS;
+    RUINS,
+    ENTRANCE;
 
     private static EnumSet<BuildingTag> VALID_BUILDINGS = EnumSet.of(YES, RESIDENTIAL, COMMERCIAL,
             SHOP, HOUSE, GARAGE, APARTMENTS, HUT, INDUSTRIAL, DETACHED, ROOF, SHED, TERRACE, SCHOOL,


### PR DESCRIPTION
Added `KEY` to `AerialWayTag` and `ENTRANCE` to `BuildingTag`.

[Tag:building=entrance](https://wiki.openstreetmap.org/wiki/Tag:building%3Dentrance) is a deprecated tag, but is relatively prevalent in some areas (see [taginfo](https://taginfo.openstreetmap.org/tags/building=entrance#map)).