### PR TITLE
Version increment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=5.1.2-SNAPSHOT
+version=5.1.3-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
I manually published a 5.1.2 package to PyPI, so a travis build with 5.1.2 will fail, since the PyPI package already exists. Updated to 5.1.3