### PR TITLE
Lowering serialization logging level

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -110,7 +110,7 @@ public final class PackedAtlasSerializer
         final AtlasSerializationFormat[] possibleFormats = AtlasSerializationFormat.values();
         for (final AtlasSerializationFormat candidateFormat : possibleFormats)
         {
-            logger.info("Trying load format {}", candidateFormat);
+            logger.debug("Trying load format {}", candidateFormat);
             atlas.setLoadSerializationFormat(candidateFormat);
             try
             {
@@ -118,11 +118,11 @@ public final class PackedAtlasSerializer
             }
             catch (final CoreException exception)
             {
-                logger.info("Load format {} invalid", candidateFormat);
+                logger.error("Load format {} invalid", candidateFormat);
                 continue;
             }
             // If we make it here, then we found the appropriate format and we can bail out
-            logger.info("Using load format {}", candidateFormat);
+            logger.debug("Using load format {}", candidateFormat);
             break;
         }
     }


### PR DESCRIPTION
Every time we're creating a `MultiAtlas`, we're going to be loading the underlying `PackedAtlas`, resulting in chatty logs. Lowering the logging level in appropriate spots.

```
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:113 - Trying load format JAVA
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:125 - Using load format JAVA
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:113 - Trying load format JAVA
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:125 - Using load format JAVA
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:113 - Trying load format JAVA
2018-06-29 10:36:34 INFO  [main] PackedAtlasSerializer:125 - Using load format JAVA

```
