### PR TITLE
Disable pyatlas autoreleases until a fix is determined.

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -10,7 +10,7 @@ then
 	then
 		echo "Promote repository"
 		./gradlew closeAndReleaseRepository
-		python -m pip install --user --upgrade twine
-		twine upload ./pyatlas/dist/*
+		#python -m pip install --user --upgrade twine
+		#twine upload ./pyatlas/dist/*
 	fi
 fi


### PR DESCRIPTION
Disable autorelease of `pyatlas` until a fix for the hanging `twine` command is in place. For now, new `pyatlas` releases can be pushed to PyPI manually. This is workable since `pyatlas` is not iterated often.