### PR TITLE
Using a Double to convert angle to radians

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Angle.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Angle.java
@@ -21,6 +21,8 @@ public class Angle implements Serializable
     protected static final int DM7_PER_DEGREE = 10_000_000;
     // There are approximately 57 degrees per radian
     public static final int DM7_PER_RADIAN = 572_957_795;
+    // When precision is needed
+    public static final double DM7_PER_RADIAN_DOUBLE = Double.valueOf(1_800_000_000) / Math.PI;
     // An angle is >= -180 degrees
     protected static final int MINIMUM_DM7 = -1_800_000_000;
     // An angle is < 180 degrees
@@ -160,7 +162,7 @@ public class Angle implements Serializable
      */
     public double asRadians()
     {
-        return (double) this.asDm7() / DM7_PER_RADIAN;
+        return (double) this.asDm7() / DM7_PER_RADIAN_DOUBLE;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Angle.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Angle.java
@@ -19,14 +19,14 @@ public class Angle implements Serializable
 
     // There are ten million microdegrees per degree
     protected static final int DM7_PER_DEGREE = 10_000_000;
-    // There are approximately 57 degrees per radian
-    public static final int DM7_PER_RADIAN = 572_957_795;
-    // When precision is needed
-    public static final double DM7_PER_RADIAN_DOUBLE = Double.valueOf(1_800_000_000) / Math.PI;
     // An angle is >= -180 degrees
     protected static final int MINIMUM_DM7 = -1_800_000_000;
     // An angle is < 180 degrees
     protected static final int MAXIMUM_DM7 = 1_800_000_000;
+    // There are approximately 57 degrees per radian
+    public static final int DM7_PER_RADIAN = 572_957_795;
+    // When precision is needed
+    public static final double DM7_PER_RADIAN_DOUBLE = Double.valueOf(MAXIMUM_DM7) / Math.PI;
     // dm7 unit per microdegree
     protected static final int DM7_PER_MICRODEGREE = 10;
     // Threshold to print a dm7 value
@@ -162,7 +162,7 @@ public class Angle implements Serializable
      */
     public double asRadians()
     {
-        return (double) this.asDm7() / DM7_PER_RADIAN_DOUBLE;
+        return this.asDm7() / DM7_PER_RADIAN_DOUBLE;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -153,6 +153,15 @@ public class LocationTest extends Command
         System.out.println(calculatedLoxodromicMidPoint.toString() + "\n");
     }
 
+    @Test
+    public void testAntiMeridianMidPoint()
+    {
+        final Location location1 = Location.forWkt("POINT(-180 25)");
+        final Location location2 = Location.forWkt("POINT(-180 -25)");
+        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location1.midPoint(location2));
+        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location2.midPoint(location1));
+    }
+
     @Override
     protected int onRun(final CommandMap command)
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -160,6 +160,11 @@ public class LocationTest extends Command
         final Location location2 = Location.forWkt("POINT(-180 -25)");
         Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location1.midPoint(location2));
         Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location2.midPoint(location1));
+
+        final Location location3 = Location.forWkt("POINT(180 25)");
+        final Location location4 = Location.forWkt("POINT(180 -25)");
+        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location3.midPoint(location4));
+        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location4.midPoint(location3));
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
@@ -82,13 +82,13 @@ public class MultiPolyLineTest
     @Test
     public void testCreateMultiPolyLineFromPolyLine()
     {
-        final PolyLine polyLine1 = PolyLine.wkt(
-                "LINESTRING (10.5553105 48.3419094, 10.5552096 48.3417501, 10.5551312 48.3416583, "
+        final PolyLine polyLine1 = PolyLine
+                .wkt("LINESTRING (10.5553105 48.3419094, 10.5552096 48.3417501, 10.5551312 48.3416583, "
                         + "10.5551027 48.341611, 10.5550183 48.3415143, 10.5549357 48.3414668, "
                         + "10.5548325 48.3414164, 10.5548105 48.3415201, 10.5548015 48.3415686, "
                         + "10.5548925 48.3416166, 10.5550334 48.3416375, 10.5551312 48.3416583)");
-        final PolyLine polyLine2 = PolyLine.wkt(
-                "LINESTRING (10.5551312 48.3416583, 10.5551027 48.341611, 10.5550183 48.3415143, "
+        final PolyLine polyLine2 = PolyLine
+                .wkt("LINESTRING (10.5551312 48.3416583, 10.5551027 48.341611, 10.5550183 48.3415143, "
                         + "10.5549357 48.3414668, 10.5548325 48.3414164, 10.5548105 48.3415201, "
                         + "10.5548015 48.3415686, 10.5548925 48.3416166, 10.5550334 48.3416375)");
         final MultiPolyLine multiPolyLine = new MultiPolyLine(Arrays.asList(polyLine1, polyLine2));

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -606,7 +606,7 @@ public class PolygonTest
     {
         Assert.assertEquals(Location.TEST_3, this.quadrant.offsetFromStart(Ratio.MINIMUM));
         Assert.assertEquals(Location.TEST_3, this.quadrant.offsetFromStart(Ratio.MAXIMUM));
-        Assert.assertEquals(Location.forString("37.3352356,-122.0096688"), this.quadrant.middle());
+        Assert.assertEquals(Location.forString("37.3352356,-122.0096687"), this.quadrant.middle());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/AngleTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/AngleTest.java
@@ -37,7 +37,7 @@ public class AngleTest
     {
         final Angle value = Angle.dm7(325_000_020);
         Assert.assertEquals(32.500002, value.asDegrees(), 0);
-        Assert.assertEquals(0.567232042, value.asRadians(), 1e-10);
+        Assert.assertEquals(0.5672320418047421, value.asRadians(), 1e-10);
     }
 
     @Test


### PR DESCRIPTION
Changing to use a double factor to convert an angle (dm7 representation) to radians. The int factor was causing an issue in ```Location::midPoint``` where the loss of precision was causing the midPoint of two Locations on the antiMeridian(-180) to have a Longitude of 179.9999999, and visa versa two Locations on the antiMeridian(180) had a midpoint  Longitude of -179.9999999.

Other tests changed to reflect new precision of output.

