### PR TITLE
Sonar: Include code coverage & Build script improvements

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -29,5 +29,7 @@ then
 	./gradlew sonarqube \
 		-Dsonar.organization=osmlab \
 		-Dsonar.host.url=https://sonarcloud.io \
-		-Dsonar.login=$SONAR_TOKEN
+		-Dsonar.login=$SONAR_TOKEN \
+		-Dsonar.junit.reportPaths=build/test-results/test \
+		-Dsonar.jacoco.reportPaths=build/jacoco/test.exec
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,23 @@
-buildscript {
-    dependencies {
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.4.0'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.1'
-    }
-}
-
-plugins
-{
-	// Used to promote a staging release build
-    id "io.codearte.nexus-staging" version "0.8.0"
-    id "com.google.protobuf" version "0.8.1"
-    id "org.sonarqube" version "2.6"
+plugins {
+	id 'java'
+	id 'maven'
+	id 'idea'
+	id 'signing'
+	id 'checkstyle'
+	id 'jacoco'
+	id "com.diffplug.gradle.spotless" version "3.4.0"
+	id 'org.sonarqube' version '2.6'
+	id 'com.google.protobuf' version '0.8.1'
+	id "io.codearte.nexus-staging" version "0.8.0"
 }
 
 apply from: 'dependencies.gradle'
-apply plugin: 'java'
-apply plugin: 'checkstyle'
-apply plugin: 'maven'
-apply plugin: 'signing'
-apply plugin: 'com.diffplug.gradle.spotless'
-apply plugin: 'idea'
-apply plugin: 'com.google.protobuf'
-apply plugin: 'jacoco'
+apply from: 'gradle/quality.gradle'
+apply from: 'gradle/protobuf.gradle'
+apply from: 'gradle/pyatlas.gradle'
+apply from: 'gradle/deployment.gradle'
+
+description = "Atlas Library"
 
 sourceCompatibility=1.8
 targetCompatibility=1.8
@@ -33,139 +29,15 @@ repositories
     mavenCentral()
 }
 
-idea {
-    project {
-        languageLevel = '1.8'
-    }
-}
-
-spotless {
-    java {
-        target project.fileTree(project.rootDir) {
-            include '**/*.java'
-            exclude 'src/generated/**/*.java'
-        }
-        importOrder(['static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'])
-        removeUnusedImports()
-        eclipse().configFile 'config/format/code_format.xml'
-    }
-}
-
-jacoco {
-    toolVersion = "0.8.1"
-}
-
-jacocoTestReport {
-    reports {
-        xml.enabled true
-        csv.enabled true
-        html.destination file("${buildDir}/reports/jacoco")
-    }
-}
-
-sonarqube {
-    properties {
-        property "sonar.exclusions", "src/generated/**/*.java"
-    }
-}
-
-// corresponds to POM description
-description = "Atlas Library"
-
-// This is to skip the tasks for which there is a skip<TaskName>=true environment variable
-def skippedTaskNames = System.getenv().findAll { key, value ->
-    key.startsWith("skip") && value.equalsIgnoreCase("true")
-}.keySet().collect { it.substring(4) }
-
-gradle.startParameter.excludedTaskNames += skippedTaskNames
-
-checkstyle
-{
-    toolVersion = versions.checkstyle
-}
-
-sourceSets
-{
-    integrationTest
-    {
-        java
-        {
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
-            srcDir file('src/integrationTest/java')
-        }
-        resources.srcDir file('src/integrationTest/resources')
-    }
-    main
-    {
-        java
-        {
-            srcDirs 'src/main/java', 'src/generated/main/java'
-        }
-    }
-}
-
-test
-{
-    testLogging
-    {
-        events "failed"
-        exceptionFormat = 'full'
-    }
-    jacoco {
-        excludes += ['org.openstreetmap.atlas.proto/**']
-    }
-}
-
 configurations
 {
     shaded
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
-}
-
-protobuf {
-
-    generatedFilesBaseDir = 'src/generated/'
-
-    protoc {
-        artifact = "${packages.protoc}"
-    }
-
-    generateProtoTasks {
-        all().each { task ->
-            if (task.name == "generateProto") {
-                task.outputs.upToDateWhen {
-                    new File(generatedFilesBaseDir).exists()
-                }
-            }
-        }
-
-        task deleteGeneratedProto {
-            doLast{
-                println "Deleting generated protos"
-                delete generatedFilesBaseDir
-            }
-        }
-
-        task recompileProto {}
-        recompileProto.dependsOn(deleteGeneratedProto)
-        recompileProto.dependsOn(generateProto)
-
-        compileJava.dependsOn(generateProto)
-        clean.dependsOn(deleteGeneratedProto)
-    }
 }
 
 dependencies
 {
     compile packages.slf4j.api
     compile packages.junit
-    testCompile packages.slf4j.log4j12
-    testCompile packages.log4j
-    testCompile packages.junit
-    integrationTestCompile packages.junit
-
     compile packages.opencsv
     compile packages.gson
     compile packages.math
@@ -212,69 +84,6 @@ task shaded(type: Jar){
     zip64 = true
 }
 
-task integrationTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    testLogging
-    {
-        events "failed"
-    }
-}
-
-check.dependsOn integrationTest
-integrationTest.mustRunAfter test
-
-tasks.withType(Test) {
-    reports.html.destination = file("${reporting.baseDir}/${name}")
-}
-
-/**
- * pyatlas tasks
- */
-task cleanPyatlas(type: Exec) {
-    commandLine './pyatlas/clean.sh'
-    args 'ranFromGradle'
-}
-
-task createVenvPyatlas(type: Exec) {
-    commandLine './pyatlas/venv.sh'
-    args 'ranFromGradle'
-}
-
-task checkFormatPyatlas(type: Exec) {
-    dependsOn 'createVenvPyatlas'
-    commandLine './pyatlas/format.sh'
-    args 'ranFromGradle'
-    args 'CHECK'
-}
-
-task applyFormatPyatlas(type: Exec) {
-    dependsOn 'createVenvPyatlas'
-    commandLine './pyatlas/format.sh'
-    args 'ranFromGradle'
-    args 'APPLY'
-}
-
-task packagePyatlas(type: Exec) {
-    dependsOn 'checkFormatPyatlas'
-    commandLine './pyatlas/package.sh'
-    args 'ranFromGradle'
-}
-
-task testPyatlas(type: Exec) {
-    dependsOn 'packagePyatlas'
-    commandLine './pyatlas/test.sh'
-    args 'ranFromGradle'
-}
-
-task buildPyatlas() {
-    dependsOn 'createVenvPyatlas'
-    dependsOn 'checkFormatPyatlas'
-    dependsOn 'packagePyatlas'
-    dependsOn 'testPyatlas'
-}
-
-
 /**
  * Artifact related items
  */
@@ -293,78 +102,17 @@ artifacts
     archives javadocJar, sourcesJar
 }
 
-/**
- * Deployment related items
+/*
+ * This is to skip the tasks for which there is a skip<TaskName>=true
+ * environment variable
  */
-import org.gradle.plugins.signing.Sign
+def skippedTaskNames = System.getenv().findAll { key, value ->
+    key.startsWith("skip") && value.equalsIgnoreCase("true")
+}.keySet().collect { it.substring(4) }
+gradle.startParameter.excludedTaskNames += skippedTaskNames
 
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.allTasks.any { it instanceof Sign }) {
-        allprojects { ext."signing.keyId" = System.getenv('GPG_KEY_ID') }
-        allprojects { ext."signing.secretKeyRingFile" = System.getenv('GPG_KEY_LOCATION') }
-        allprojects { ext."signing.password" = System.getenv('GPG_PASSPHRASE') }
-    }
-    // Do not sign archives by default (a local build without gpg keyring should succeed)
-    if (taskGraph.allTasks.any { it.name == 'build' || it.name == 'assemble' }) {
-        tasks.findAll { it.name == 'signArchives' || it.name == 'signDocsJar' || it.name == 'signTestJar' }.each { task ->
-            task.enabled = false
-        }
-    }
-}
-
-signing
-{
-    sign configurations.archives
-}
-build.dependsOn.remove(signArchives)
-
-uploadArchives
-{
-    repositories
-    {
-        mavenDeployer
-        {
-            beforeDeployment
-            {
-                MavenDeployment deployment -> signing.signPom(deployment)
-            }
-
-            repository(url: maven2_url) {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
-            }
-
-            snapshotRepository(url: snapshot_url) {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
-            }
-
-            pom.project
-            {
-                name project_name
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description project_description
-                url project_url
-
-                scm {
-                    connection project_scm
-                    developerConnection project_scm
-                    url project_url
-                }
-
-                licenses {
-                    license {
-                        name project_license_slug
-                        url project_license_url
-                    }
-                }
-
-                developers {
-                    developer {
-                        id project_developer
-                        name project_developer
-                    }
-                }
-            }
-        }
+idea {
+    project {
+        languageLevel = '1.8'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,9 @@ buildscript {
     }
 }
 
-// Used to promote a staging release build
-// https://github.com/Codearte/gradle-nexus-staging-plugin
-// gradle closeAndReleaseRepository
 plugins
 {
+	// Used to promote a staging release build
     id "io.codearte.nexus-staging" version "0.8.0"
     id "com.google.protobuf" version "0.8.1"
     id "org.sonarqube" version "2.6"
@@ -20,9 +18,10 @@ apply plugin: 'java'
 apply plugin: 'checkstyle'
 apply plugin: 'maven'
 apply plugin: 'signing'
-apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'idea'
 apply plugin: 'com.google.protobuf'
+apply plugin: 'jacoco'
 
 sourceCompatibility=1.8
 targetCompatibility=1.8
@@ -49,6 +48,18 @@ spotless {
         importOrder(['static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'])
         removeUnusedImports()
         eclipse().configFile 'config/format/code_format.xml'
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.1"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled true
+        html.destination file("${buildDir}/reports/jacoco")
     }
 }
 
@@ -98,8 +109,11 @@ test
 {
     testLogging
     {
-        events "passed", "skipped", "failed"
+        events "failed"
         exceptionFormat = 'full'
+    }
+    jacoco {
+        excludes += ['org.openstreetmap.atlas.proto/**']
     }
 }
 
@@ -203,7 +217,7 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
     testLogging
     {
-        events "passed", "skipped", "failed"
+        events "failed"
     }
 }
 

--- a/gradle/deployment.gradle
+++ b/gradle/deployment.gradle
@@ -1,0 +1,72 @@
+import org.gradle.plugins.signing.Sign
+
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.allTasks.any { it instanceof Sign }) {
+        allprojects { ext."signing.keyId" = System.getenv('GPG_KEY_ID') }
+        allprojects { ext."signing.secretKeyRingFile" = System.getenv('GPG_KEY_LOCATION') }
+        allprojects { ext."signing.password" = System.getenv('GPG_PASSPHRASE') }
+    }
+    // Do not sign archives by default (a local build without gpg keyring should succeed)
+    if (taskGraph.allTasks.any { it.name == 'build' || it.name == 'assemble' }) {
+        tasks.findAll { it.name == 'signArchives' || it.name == 'signDocsJar' || it.name == 'signTestJar' }.each { task ->
+            task.enabled = false
+        }
+    }
+}
+
+signing
+{
+    sign configurations.archives
+}
+build.dependsOn.remove(signArchives)
+
+uploadArchives
+{
+    repositories
+    {
+        mavenDeployer
+        {
+            beforeDeployment
+            {
+                MavenDeployment deployment -> signing.signPom(deployment)
+            }
+
+            repository(url: maven2_url) {
+                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+            }
+
+            snapshotRepository(url: snapshot_url) {
+                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+            }
+
+            pom.project
+            {
+                name project_name
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description project_description
+                url project_url
+
+                scm {
+                    connection project_scm
+                    developerConnection project_scm
+                    url project_url
+                }
+
+                licenses {
+                    license {
+                        name project_license_slug
+                        url project_license_url
+                    }
+                }
+
+                developers {
+                    developer {
+                        id project_developer
+                        name project_developer
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/protobuf.gradle
+++ b/gradle/protobuf.gradle
@@ -1,0 +1,46 @@
+sourceSets
+{
+    main
+    {
+        java
+        {
+            srcDirs 'src/main/java', 'src/generated/main/java'
+        }
+    }
+}
+
+protobuf {
+    generatedFilesBaseDir = 'src/generated/'
+
+    protoc {
+        artifact = "${packages.protoc}"
+    }
+
+    generateProtoTasks {
+        all().each { task ->
+            if (task.name == "generateProto") {
+                task.outputs.upToDateWhen {
+                    new File(generatedFilesBaseDir).exists()
+                }
+            }
+        }
+
+        task deleteGeneratedProto {
+            doLast{
+                println "Deleting generated protos"
+                delete generatedFilesBaseDir
+            }
+        }
+
+        task recompileProto {}
+        recompileProto.dependsOn(deleteGeneratedProto)
+        recompileProto.dependsOn(generateProto)
+
+        compileJava.dependsOn(generateProto)
+        clean.dependsOn(deleteGeneratedProto)
+    }
+}
+
+javadoc {
+    exclude 'org/openstreetmap/atlas/proto/**'
+}

--- a/gradle/pyatlas.gradle
+++ b/gradle/pyatlas.gradle
@@ -1,0 +1,42 @@
+task cleanPyatlas(type: Exec) {
+    commandLine './pyatlas/clean.sh'
+    args 'ranFromGradle'
+}
+
+task createVenvPyatlas(type: Exec) {
+    commandLine './pyatlas/venv.sh'
+    args 'ranFromGradle'
+}
+
+task checkFormatPyatlas(type: Exec) {
+    dependsOn 'createVenvPyatlas'
+    commandLine './pyatlas/format.sh'
+    args 'ranFromGradle'
+    args 'CHECK'
+}
+
+task applyFormatPyatlas(type: Exec) {
+    dependsOn 'createVenvPyatlas'
+    commandLine './pyatlas/format.sh'
+    args 'ranFromGradle'
+    args 'APPLY'
+}
+
+task packagePyatlas(type: Exec) {
+    dependsOn 'checkFormatPyatlas'
+    commandLine './pyatlas/package.sh'
+    args 'ranFromGradle'
+}
+
+task testPyatlas(type: Exec) {
+    dependsOn 'packagePyatlas'
+    commandLine './pyatlas/test.sh'
+    args 'ranFromGradle'
+}
+
+task buildPyatlas() {
+    dependsOn 'createVenvPyatlas'
+    dependsOn 'checkFormatPyatlas'
+    dependsOn 'packagePyatlas'
+    dependsOn 'testPyatlas'
+}

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -1,0 +1,95 @@
+jacoco {
+    toolVersion = "0.8.1"
+}
+
+sourceSets
+{
+    integrationTest
+    {
+        java
+        {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
+    }
+}
+
+test
+{
+    testLogging
+    {
+        events "failed"
+        exceptionFormat = 'full'
+    }
+    jacoco {
+        excludes += ['org.openstreetmap.atlas.proto/**']
+    }
+}
+
+task integrationTest(type: Test) {
+    testClassesDir = sourceSets.integrationTest.output.classesDir
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    testLogging
+    {
+        events "failed"
+    }
+}
+
+check.dependsOn integrationTest
+integrationTest.mustRunAfter test
+
+tasks.withType(Test) {
+    reports.html.destination = file("${reporting.baseDir}/${name}")
+}
+
+configurations
+{
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
+dependencies
+{
+    testCompile packages.slf4j.log4j12
+    testCompile packages.log4j
+    testCompile packages.junit
+    integrationTestCompile packages.junit
+}
+
+spotless {
+    java {
+        target project.fileTree(project.rootDir) {
+            include '**/*.java'
+            exclude 'src/generated/**/*.java'
+        }
+        importOrder(['static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'])
+        removeUnusedImports()
+        eclipse().configFile 'config/format/code_format.xml'
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled true
+        html.destination file("${buildDir}/reports/jacoco")
+    }
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: 'org/openstreetmap/atlas/proto/**')
+        })
+    }
+}
+
+sonarqube {
+    properties {
+        property "sonar.exclusions", "src/generated/**/*.java"
+    }
+}
+
+checkstyle
+{
+    toolVersion = versions.checkstyle
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -71,7 +71,8 @@ public final class PackedAtlasSerializer
     private static final StringList EXCLUDED_FIELDS = new StringList(PackedAtlas.FIELD_BOUNDS,
             PackedAtlas.FIELD_SERIAL_VERSION_UID, PackedAtlas.FIELD_LOGGER, "$SWITCH_TABLE$",
             PackedAtlas.FIELD_SERIALIZER, PackedAtlas.FIELD_SAVE_SERIALIZATION_FORMAT,
-            PackedAtlas.FIELD_LOAD_SERIALIZATION_FORMAT, PackedAtlas.FIELD_PREFIX);
+            PackedAtlas.FIELD_LOAD_SERIALIZATION_FORMAT, PackedAtlas.FIELD_PREFIX,
+            /* https://stackoverflow.com/a/39037512/1558687 */"$jacocoData");
 
     public static final String META_DATA_ERROR_MESSAGE = "MetaData not here!";
 


### PR DESCRIPTION
This includes:
- Jacoco integration (so sonar gets code coverage metrics)
  - Added one excluded field in `PackedAtlasSerializer` to avoid failing tests due to the jacoco instrumentation
- Breakdown of build scripts
  - deployment.gradle: Contains all the build to maven central deployment
  - protobuf.gradle: Contains all the proto generated code tasks
  - pyatlas.gradle: Contains tasks to build the python Atlas code
  - quality.gradle: Contains all the code quality/test tasks
    - sonar
    - checkstyle
    - spotless
    - test
    - integrationTest