### PR TITLE
ShardBucketCollection

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollection.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollection.java
@@ -1,0 +1,454 @@
+package org.openstreetmap.atlas.utilities.collections;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.openstreetmap.atlas.geography.Located;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.index.RTree;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.utilities.scalars.Counter;
+
+/**
+ * A collection wrapper for a set of collections associated with shards containing located items,
+ * such as CheckFlags or AtlasEntities. Supports concurrent add, contains, remove. The term bucket
+ * is used because of the usability of the collections mostly as storage for various location based
+ * sorting tasks. Does not support safe iteration while modifying.
+ *
+ * @param <LocatedType>
+ *            Located item type
+ * @param <CollectionType>
+ *            Type of the Collection of LocatedType associated with shards
+ * @author jklamer
+ */
+public abstract class ShardBucketCollection<LocatedType extends Located & Serializable, CollectionType extends Collection<LocatedType> & Serializable>
+        implements Collection<LocatedType>, Serializable
+{
+
+    /**
+     * A helper class that associates a shard with the index that its collection is at in the
+     * collectionBuckets array.
+     */
+    private static class ShardToCollectionIndex implements Located
+    {
+        private static final long serialVersionUID = 4050100671815503794L;
+        private final int index;
+        private final Shard shard;
+
+        ShardToCollectionIndex(final int index, final Shard shard)
+        {
+            this.index = index;
+            this.shard = shard;
+        }
+
+        @Override
+        public Rectangle bounds()
+        {
+            return this.getShard().bounds();
+        }
+
+        public int getIndex()
+        {
+            return this.index;
+        }
+
+        public Shard getShard()
+        {
+            return this.shard;
+        }
+    }
+
+    private static final long serialVersionUID = -7892704554302160820L;
+
+    private final CollectionType[] collectionBuckets;
+    private final RTree<ShardToCollectionIndex> collectionIndex;
+    private final HashMap<Shard, ShardToCollectionIndex> initializedShards = new HashMap<>();
+    private Rectangle maximumBounds;
+
+    public ShardBucketCollection(final Rectangle maximumBounds, final Integer zoomLevel)
+    {
+        this(maximumBounds, SlippyTile.allTiles(zoomLevel, maximumBounds));
+    }
+
+    public ShardBucketCollection(final Rectangle maximumBounds, final Sharding sharding)
+    {
+        this(maximumBounds, sharding.shards(maximumBounds));
+    }
+
+    /**
+     * Construct the collection by allocation space for a collection for each of the shards and
+     * assigning the index back.
+     * 
+     * @param maximumBounds
+     *            maximum bound of the collection
+     * @param shards
+     *            shards to use
+     */
+    @SuppressWarnings("unchecked")
+    private ShardBucketCollection(final Rectangle maximumBounds,
+            final Iterable<? extends Shard> shards)
+    {
+        this.maximumBounds = maximumBounds;
+        this.collectionIndex = new RTree<>();
+        final Counter counter = new Counter();
+        shards.forEach(shardBucket ->
+        {
+            final ShardToCollectionIndex shardToCollectionIndex = new ShardToCollectionIndex(
+                    (int) counter.getValueAndIncrement(), shardBucket);
+            this.collectionIndex.add(shardToCollectionIndex.bounds(), shardToCollectionIndex);
+        });
+        this.collectionBuckets = (CollectionType[]) Array.newInstance(
+                this.initializeBucketCollection().getClass(), (int) counter.getValue());
+    }
+
+    @Override
+    public final boolean add(final LocatedType item)
+    {
+        if (Objects.nonNull(item) && item.bounds().overlaps(this.maximumBounds))
+        {
+            final List<ShardToCollectionIndex> indexes = this.collectionIndex.get(item.bounds());
+            if (indexes.size() == 1)
+            {
+                return this.addFunction(item, this.getOrCreateBucketCollectionAt(indexes.get(0)),
+                        indexes.get(0).getShard());
+            }
+            else if (this.allowMultipleBucketInsertion())
+            {
+                final long addedAmount = indexes.stream()
+                        .filter(index -> this.addFunction(item,
+                                this.getOrCreateBucketCollectionAt(index), index.getShard()))
+                        .count();
+                return addedAmount > 0;
+            }
+            else
+            {
+                final Shard toInsertAt = this.resolveShard(item, indexes.stream()
+                        .map(ShardToCollectionIndex::getShard).collect(Collectors.toList()));
+                final Optional<ShardToCollectionIndex> toAddTo = indexes.stream()
+                        .filter(index -> toInsertAt.equals(index.getShard())).findFirst();
+                return toAddTo
+                        .map(index -> this.addFunction(item,
+                                this.getOrCreateBucketCollectionAt(index), index.getShard()))
+                        .orElse(false);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends LocatedType> collection)
+    {
+        if (Objects.nonNull(collection))
+        {
+            final long addCount = collection.stream().filter(this::add).count();
+            return addCount > 0;
+        }
+        return false;
+    }
+
+    @Override
+    public void clear()
+    {
+        synchronized (this.collectionBuckets)
+        {
+            for (int i = 0; i < this.collectionBuckets.length; i++)
+            {
+                this.collectionBuckets[i] = null;
+            }
+            this.initializedShards.clear();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean contains(final Object object)
+    {
+        final Optional<LocatedType> typedItem = this.castToLocatedType(object);
+        if (typedItem.isPresent())
+        {
+            final LocatedType item = typedItem.get();
+            return this.getBucketCollectionsForBounds(item.bounds())
+                    .anyMatch(collection -> collection.contains(item));
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> collection)
+    {
+        if (Objects.nonNull(collection))
+        {
+            return collection.stream().allMatch(this::contains);
+        }
+        return false;
+    }
+
+    /**
+     * A stream of only distinct elements in the collection. Useful if allowing multiple bucket
+     * insertion
+     *
+     * @return A disticnt stream of the collection
+     */
+    public Stream<LocatedType> distinctStream()
+    {
+        return this.stream().distinct();
+    }
+
+    /**
+     * @return a stream of all initialized bucket collections
+     */
+    public Stream<CollectionType> getAllBucketCollections()
+    {
+        return Arrays.stream(this.collectionBuckets).filter(Objects::nonNull);
+    }
+
+    /**
+     * Get a map of all Shards to their corresponding collection. This will only return shard
+     * collection entries with initialized collections.
+     *
+     * @return Map of shard to collection
+     */
+    public Map<Shard, CollectionType> getAllShardBucketCollectionPairs()
+    {
+        return this.initializedShards.values().stream()
+                .collect(Collectors.toMap(ShardToCollectionIndex::getShard, this::getCollectionAt));
+    }
+
+    /**
+     * Get the collection for a given shard. It will return optional empty if the shard's collection
+     * isn't initialized
+     *
+     * @param shard
+     *            shard whose collection you want.
+     * @return Optional of the initialized Collection
+     */
+    public Optional<CollectionType> getBucketCollectionForShard(final Shard shard)
+    {
+        return Optional.ofNullable(this.initializedShards.get(shard)).map(this::getCollectionAt)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * A stream of all the bucket collects whose associated shard overlaps with the bounds. Note it
+     * will return more than one collection if given a shard bound because the edges of shards
+     * overlap
+     *
+     * @param bounds
+     *            to use
+     * @return stream of a subset of bucket collections
+     */
+    public Stream<CollectionType> getBucketCollectionsForBounds(final Rectangle bounds)
+    {
+        return this.collectionIndex.get(bounds).stream().map(this::getCollectionAt)
+                .filter(Objects::nonNull);
+    }
+
+    /**
+     * Get the max bounds of what located can be in the collection.
+     *
+     * @return rectangle bounds
+     */
+    public Rectangle getMaximumBounds()
+    {
+        return this.maximumBounds;
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return this.size() == 0;
+    }
+
+    @Override
+    public Iterator<LocatedType> iterator()
+    {
+        return this.stream().iterator();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean remove(final Object object)
+    {
+        final Optional<LocatedType> typedItem = this.castToLocatedType(object);
+        if (typedItem.isPresent())
+        {
+            final LocatedType item = typedItem.get();
+            if (item.bounds().overlaps(this.maximumBounds))
+            {
+                final long removeCount = this.getBucketCollectionsForBounds(item.bounds())
+                        .filter(collection -> collection.remove(item)).count();
+                return removeCount > 0;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> collection)
+    {
+        if (Objects.nonNull(collection))
+        {
+            final long removeCount = collection.stream().filter(this::remove).count();
+            return removeCount > 0;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> collection)
+    {
+        final List<LocatedType> toRemove = this.stream().filter(item -> !collection.contains(item))
+                .collect(Collectors.toList());
+        return this.removeAll(toRemove);
+    }
+
+    @Override
+    public int size()
+    {
+        synchronized (this.collectionBuckets)
+        {
+            return this.getAllBucketCollections().mapToInt(CollectionType::size).sum();
+        }
+    }
+
+    @Override
+    public Stream<LocatedType> stream()
+    {
+        return this.getAllBucketCollections().flatMap(CollectionType::stream);
+    }
+
+    @Override
+    public Object[] toArray()
+    {
+        Object[] toReturn = new Object[0];
+        synchronized (this.collectionBuckets)
+        {
+            final Iterator<CollectionType> bucketIterator = this.getAllBucketCollections()
+                    .iterator();
+            while (bucketIterator.hasNext())
+            {
+                toReturn = ArrayUtils.addAll(toReturn, bucketIterator.next().toArray());
+            }
+        }
+        return toReturn;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T1> T1[] toArray(final T1[] otherArray)
+    {
+        return ArrayUtils.addAll(otherArray, (T1[]) this.toArray());
+    }
+
+    /**
+     * To add the item into the collection in a special way or dependent on the shard, this function
+     * can be overridden. The return contract is the same of {@link Collection}'s add. This function
+     * must be deterministic.
+     *
+     * @param item
+     *            to add
+     * @param collection
+     *            to add to
+     * @param shard
+     *            shard associated with the collection
+     * @return true if the collection has been added to successful and changed as a result, false
+     *         otherwise
+     */
+    protected boolean addFunction(final LocatedType item, final CollectionType collection,
+            final Shard shard)
+    {
+        return collection.add(item);
+    }
+
+    /**
+     * @return true if items are allowed to be in multiple buckets. False otherwise
+     */
+    protected abstract boolean allowMultipleBucketInsertion();
+
+    /**
+     * The collection should be agnostic to the shard. Deciding the collection to insert into and
+     * how to insert into based on the shard should be handled by resolveShard and addFunction
+     * respectively.
+     * 
+     * @return an intialized empty bucket collection.
+     */
+    protected abstract CollectionType initializeBucketCollection();
+
+    /**
+     * Resolve which of multiple overlapping shards. Note these shards overlap due to a bounds call,
+     * agnostic of the items geometry.
+     * 
+     * @param item
+     *            located item to insert
+     * @param possibleBuckets
+     *            possible buckets for the item to work into
+     * @return Shard whose collection you should add to.
+     */
+    protected Shard resolveShard(final LocatedType item,
+            final List<? extends Shard> possibleBuckets)
+    {
+        throw new UnsupportedOperationException(
+                "Implement this method when not allowing multiple bucket insertion");
+    }
+
+    private void createBucketCollectionAt(final ShardToCollectionIndex index)
+    {
+        synchronized (this.collectionBuckets)
+        {
+            if (Objects.isNull(this.collectionBuckets[index.getIndex()]))
+            {
+                this.collectionBuckets[index.getIndex()] = this.initializeBucketCollection();
+                this.initializedShards.put(index.getShard(), index);
+            }
+        }
+    }
+
+    private CollectionType getCollectionAt(final ShardToCollectionIndex index)
+    {
+        synchronized (this.collectionBuckets)
+        {
+            return this.collectionBuckets[index.getIndex()];
+        }
+    }
+
+    private CollectionType getOrCreateBucketCollectionAt(final ShardToCollectionIndex index)
+    {
+        final CollectionType collection = this.getCollectionAt(index);
+        if (Objects.isNull(collection))
+        {
+            this.createBucketCollectionAt(index);
+            return this.getCollectionAt(index);
+        }
+        else
+        {
+            return collection;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<LocatedType> castToLocatedType(final Object object)
+    {
+        try
+        {
+            return Optional.ofNullable(object).map(cast -> (LocatedType) cast);
+        }
+        catch (final ClassCastException e)
+        {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollection.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollection.java
@@ -89,7 +89,7 @@ public abstract class ShardBucketCollection<LocatedType extends Located & Serial
     }
 
     /**
-     * Construct the collection by allocation space for a collection for each of the shards and
+     * Construct the collection by allocating space for a collection for each of the shards and
      * assigning the index back.
      * 
      * @param maximumBounds
@@ -364,7 +364,7 @@ public abstract class ShardBucketCollection<LocatedType extends Located & Serial
      *            to add to
      * @param shard
      *            shard associated with the collection
-     * @return true if the collection has been added to successful and changed as a result, false
+     * @return true if the collection has been added to successfully and changed as a result, false
      *         otherwise
      */
     protected boolean addFunction(final LocatedType item, final CollectionType collection,

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Counter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Counter.java
@@ -29,6 +29,13 @@ public class Counter
         return this.value;
     }
 
+    public long getValueAndIncrement()
+    {
+        final long toReturn = this.value;
+        this.increment();
+        return toReturn;
+    }
+
     public void increment()
     {
         this.add(1L);

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTest.java
@@ -226,7 +226,7 @@ public class ShardBucketCollectionTest
         Assert.assertEquals(maxBounds, polylineBuckets1.getMaximumBounds());
     }
 
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
     public void testUnimplemented()
     {
         final Rectangle maxBounds = SlippyTile.forName("1-0-0").bounds()
@@ -237,18 +237,7 @@ public class ShardBucketCollectionTest
                 maxBounds, 3);
         // a polyline that will intersect with multiple buckets
         final PolyLine testPolyLine1 = this.polylineForShards(SlippyTile.allTiles(3, maxBounds));
-
-        boolean caught = false;
-        try
-        {
-            unsupportedOperation.add(testPolyLine1);
-        }
-        catch (final UnsupportedOperationException exception)
-        {
-            caught = true;
-        }
-
-        Assert.assertTrue("Resolve shard default method is an unsupported operation", caught);
+        unsupportedOperation.add(testPolyLine1);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTest.java
@@ -1,0 +1,297 @@
+package org.openstreetmap.atlas.utilities.collections;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Test for example {@link ShardBucketCollection}s
+ *
+ * @author jklamer
+ */
+public class ShardBucketCollectionTest
+{
+
+    @Test
+    public void testMultiPolygonSort()
+    {
+        final Rectangle maxBounds = SlippyTile.forName("1-0-0").bounds()
+                .contract(Distance.ONE_METER);
+
+        final ShardBucketCollectionTestClasses.MultiPolygonSort multiPolygonSort = new ShardBucketCollectionTestClasses.MultiPolygonSort(
+                maxBounds, 4);
+
+        final MultiPolygon firstShardMultiPolygon = this
+                .multiPolygonForShard(SlippyTile.forName("4-0-0"));
+        final MultiPolygon secondShardMultiPolygon = this
+                .multiPolygonForShard(SlippyTile.forName("4-1-0"));
+        final MultiPolygon combinedMultiPolygon = firstShardMultiPolygon
+                .merge(secondShardMultiPolygon);
+
+        // the combined multipolygon will be sorted into the two different buckets as the original
+        // multipolygons
+        multiPolygonSort.add(combinedMultiPolygon);
+        Assert.assertTrue(multiPolygonSort.contains(firstShardMultiPolygon));
+        Assert.assertTrue(multiPolygonSort.contains(secondShardMultiPolygon));
+
+        // make a multipolygon with an outer for every shard and ensure they all get sorted into
+        // their proper buckets
+        multiPolygonSort.clear();
+        multiPolygonSort.add(this.multiPolygonForShards(SlippyTile.allTiles(4, maxBounds)));
+        Assert.assertEquals(64, multiPolygonSort.size());
+        for (final Shard shard : SlippyTile.allTiles(4, maxBounds))
+        {
+            Assert.assertTrue(multiPolygonSort.getBucketCollectionForShard(shard).map(List::stream)
+                    .map(multiPolygonStream -> multiPolygonStream.allMatch(
+                            multiPolygon -> multiPolygon.equals(this.multiPolygonForShard(shard))))
+                    .orElse(false));
+        }
+        Assert.assertEquals(64L,
+                multiPolygonSort.getAllShardBucketCollectionPairs().entrySet().size());
+
+        // make some big multipolygons that will go in multiple buckets but still touch all the
+        // buckets
+        multiPolygonSort.clear();
+        multiPolygonSort.add(this.multiPolygonForShards(SlippyTile.allTiles(2, maxBounds)));
+        Assert.assertEquals(64, multiPolygonSort.size());
+        Assert.assertEquals(4, multiPolygonSort.distinctStream().count());
+    }
+
+    @Test
+    public void testShardResolution()
+    {
+        final Rectangle maxBounds = SlippyTile.forName("1-0-0").bounds()
+                .contract(Distance.ONE_METER);
+
+        // collection with implemented shard resolution strategy
+        final ShardBucketCollectionTestClasses.PolyLineBucketedAtStartLocation startLocationBuckets = new ShardBucketCollectionTestClasses.PolyLineBucketedAtStartLocation(
+                maxBounds, 3);
+        final Iterable<SlippyTile> shardsWithinBounds = SlippyTile.allTiles(3, maxBounds);
+
+        // a polyline that will cover all 16 buckets but go into the first one
+        final PolyLine allBucketsPolyline = this.polylineForShards(shardsWithinBounds);
+
+        startLocationBuckets.add(allBucketsPolyline);
+        Assert.assertEquals(1, startLocationBuckets.size());
+        Assert.assertTrue(
+                startLocationBuckets.getBucketCollectionForShard(SlippyTile.forName("3-0-0"))
+                        .map(collection -> collection.contains(allBucketsPolyline)).orElse(false));
+        startLocationBuckets.clear();
+
+        // adding reversed polyline changes bucket it is stored in
+        final PolyLine testLineAccrossBuckets = this.polylineForShards("3-0-0,3-3-3");
+        startLocationBuckets.add(testLineAccrossBuckets);
+        Assert.assertTrue(startLocationBuckets
+                .getBucketCollectionForShard(SlippyTile.forName("3-0-0"))
+                .map(collection -> collection.contains(testLineAccrossBuckets)).orElse(false));
+        startLocationBuckets.add(testLineAccrossBuckets.reversed());
+        Assert.assertTrue(
+                startLocationBuckets.getBucketCollectionForShard(SlippyTile.forName("3-3-3"))
+                        .map(collection -> collection.contains(testLineAccrossBuckets.reversed()))
+                        .orElse(false));
+        startLocationBuckets.clear();
+
+        // add a polyline whose start location intersects with 4 shards and gets resolved to the
+        // first as decided by the resolveShard method and slippy tile comparator
+        final ArrayList<Location> locations = new ArrayList<>();
+        locations.addAll(SlippyTile.forName("3-0-0").bounds());
+        locations.retainAll(SlippyTile.forName("3-1-1").bounds());
+        // at the corner of both shards
+        final Location startLocation = locations.get(0);
+        locations.clear();
+        locations.addAll(SlippyTile.forName("3-1-1").bounds());
+        locations.retainAll(SlippyTile.forName("3-2-0").bounds());
+        // across to another corner
+        final Location endLocation = locations.get(0);
+
+        final PolyLine onTheEdges = new PolyLine(Arrays.asList(startLocation, endLocation));
+        startLocationBuckets.add(onTheEdges);
+        Assert.assertEquals(1, startLocationBuckets.size());
+        Assert.assertTrue(
+                startLocationBuckets.getBucketCollectionForShard(SlippyTile.forName("3-0-0"))
+                        .map(collection -> collection.contains(onTheEdges)).orElse(false));
+
+    }
+
+    @Test
+    public void testSimplePolylineCollectionFunctionality()
+    {
+        final Rectangle maxBounds = SlippyTile.forName("1-0-0").bounds()
+                .contract(Distance.ONE_METER);
+
+        final Iterable<SlippyTile> shardsWithinBounds = SlippyTile.allTiles(3, maxBounds);
+        // a polyline that will go into all 16 buckets
+        final PolyLine allBucketsPolyline = this.polylineForShards(shardsWithinBounds);
+        // create Zoom level three buckets within the bounds of the first zoom = 1 slippy tile
+        final ShardBucketCollectionTestClasses.PolylineBuckets polylineBuckets1 = new ShardBucketCollectionTestClasses.PolylineBuckets(
+                maxBounds, 3);
+
+        // test add, contains, size, stream
+        polylineBuckets1.add(allBucketsPolyline);
+        Assert.assertTrue(polylineBuckets1.contains(allBucketsPolyline));
+        Assert.assertFalse(polylineBuckets1.contains(new Integer(0)));
+        Assert.assertFalse(polylineBuckets1.contains(null));
+        Assert.assertTrue(polylineBuckets1.getAllBucketCollections()
+                .allMatch(bucket -> bucket.contains(allBucketsPolyline)));
+        Assert.assertEquals(16L, polylineBuckets1.stream().count());
+        Assert.assertTrue(polylineBuckets1.stream().allMatch(allBucketsPolyline::equals));
+        Assert.assertEquals(16L, polylineBuckets1.size());
+        Assert.assertEquals(polylineBuckets1.size(), polylineBuckets1.toArray().length);
+        Assert.assertEquals(1L, polylineBuckets1.distinctStream().count());
+
+        polylineBuckets1.clear();
+        Assert.assertEquals(0L, polylineBuckets1.size());
+        Assert.assertFalse(polylineBuckets1.iterator().hasNext());
+
+        polylineBuckets1.add(allBucketsPolyline);
+        polylineBuckets1.remove(allBucketsPolyline);
+        Assert.assertTrue(polylineBuckets1.isEmpty());
+
+        // Test with bucket unique items
+        // reinitialize
+        final ShardBucketCollectionTestClasses.PolylineBuckets polylineBuckets2 = new ShardBucketCollectionTestClasses.PolylineBuckets(
+                maxBounds, 3);
+
+        final PolyLine firstBucketPolyline = this
+                .polylineForShards(Iterables.first(shardsWithinBounds).get().split(4));
+        final PolyLine lastBucketPolyline = this
+                .polylineForShards(Iterables.last(shardsWithinBounds).get().split(4));
+
+        // test getting buckets
+        polylineBuckets2.add(firstBucketPolyline);
+        polylineBuckets2.add(lastBucketPolyline);
+        Assert.assertFalse(polylineBuckets2.isEmpty());
+        Assert.assertEquals(2, polylineBuckets2.size());
+        Assert.assertTrue("Bucket does not exist or doesn't contain polyline",
+                polylineBuckets2.getBucketCollectionForShard(SlippyTile.forName("3-0-0"))
+                        .map(collection -> collection.contains(firstBucketPolyline)).orElse(false));
+        Assert.assertTrue(
+                polylineBuckets2.getBucketCollectionsForBounds(lastBucketPolyline.bounds())
+                        .allMatch(collection -> collection.contains(lastBucketPolyline)));
+
+        // outside of bounds shard
+        Assert.assertFalse(polylineBuckets2.getBucketCollectionForShard(SlippyTile.forName("3-4-0"))
+                .isPresent());
+        // wrong zoom shard
+        Assert.assertFalse(polylineBuckets2.getBucketCollectionForShard(SlippyTile.forName("4-0-0"))
+                .isPresent());
+
+        // test remove
+        Assert.assertTrue(polylineBuckets2
+                .containsAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+        Assert.assertTrue(
+                polylineBuckets2.removeAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+        Assert.assertFalse(polylineBuckets2.remove(firstBucketPolyline));
+        Assert.assertFalse(polylineBuckets2.remove(new Integer(0)));
+        Assert.assertFalse(polylineBuckets2
+                .containsAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+
+        // test retain
+        Assert.assertTrue(
+                polylineBuckets2.addAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+        Assert.assertFalse(
+                polylineBuckets2.retainAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+        Assert.assertTrue(polylineBuckets2
+                .containsAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline)));
+        Assert.assertTrue(polylineBuckets2.retainAll(Arrays.asList(firstBucketPolyline)));
+        Assert.assertTrue(polylineBuckets2.containsAll(Arrays.asList(firstBucketPolyline)));
+
+        // test array transfer
+        polylineBuckets1.clear();
+        polylineBuckets2.clear();
+        polylineBuckets1.add(firstBucketPolyline);
+        polylineBuckets2.addAll(Arrays.asList(firstBucketPolyline, lastBucketPolyline));
+        final Object[] firstCollectionArray = polylineBuckets1.toArray();
+        final PolyLine[] array1 = new PolyLine[] { firstBucketPolyline };
+        Assert.assertArrayEquals(array1, firstCollectionArray);
+        final PolyLine[] array2 = new PolyLine[] { firstBucketPolyline, firstBucketPolyline,
+                lastBucketPolyline };
+        final PolyLine[] allArray = polylineBuckets2.toArray(array1);
+        Assert.assertArrayEquals(array2, allArray);
+
+        // get code coverage
+        Assert.assertEquals(maxBounds, polylineBuckets1.getMaximumBounds());
+    }
+
+    @Test
+    public void testUnimplemented()
+    {
+        final Rectangle maxBounds = SlippyTile.forName("1-0-0").bounds()
+                .contract(Distance.ONE_METER);
+
+        // collection without implemented resolve shard strategy
+        final ShardBucketCollectionTestClasses.UnsupportedOperation unsupportedOperation = new ShardBucketCollectionTestClasses.UnsupportedOperation(
+                maxBounds, 3);
+        // a polyline that will intersect with multiple buckets
+        final PolyLine testPolyLine1 = this.polylineForShards(SlippyTile.allTiles(3, maxBounds));
+
+        boolean caught = false;
+        try
+        {
+            unsupportedOperation.add(testPolyLine1);
+        }
+        catch (final UnsupportedOperationException exception)
+        {
+            caught = true;
+        }
+
+        Assert.assertTrue("Resolve shard default method is an unsupported operation", caught);
+    }
+
+    /**
+     * Multipolygon for shard with outer smaller than the bounds
+     */
+    private MultiPolygon multiPolygonForShard(final Shard shard)
+    {
+        final Rectangle bounds = shard.bounds();
+        final Rectangle outer = bounds.contract(Distance.ONE_METER);
+        final Rectangle inner = outer.contract(Distance.ONE_METER);
+        final MultiMap<Polygon, Polygon> multiMap = new MultiMap<>();
+        multiMap.put(outer, Arrays.asList(inner));
+        return new MultiPolygon(multiMap);
+    }
+
+    /**
+     * multipolygon that resides in all shards. With an outer in each shard
+     */
+    private MultiPolygon multiPolygonForShards(final Iterable<? extends Shard> shards)
+    {
+        MultiPolygon toReturn = this.multiPolygonForShard(Iterables.head(shards));
+        for (final Shard shard : Iterables.tail(shards))
+        {
+            toReturn = toReturn.merge(this.multiPolygonForShard(shard));
+        }
+        return toReturn;
+    }
+
+    /**
+     * Polyline for csv SlippyTile names
+     */
+    private PolyLine polylineForShards(final String names)
+    {
+        return polylineForShards(Arrays.stream(names.split(",")).map(SlippyTile::forName)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Construct a polyline from the centers of the provided shards
+     */
+    private PolyLine polylineForShards(final Iterable<? extends Shard> shards)
+    {
+        return new PolyLine(
+                new StreamIterable<>(shards).map(tile -> tile.bounds().center()).collectToList());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTestClasses.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTestClasses.java
@@ -1,0 +1,166 @@
+package org.openstreetmap.atlas.utilities.collections;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
+
+/**
+ * Class container for test classes
+ *
+ * @author jklamer
+ */
+public class ShardBucketCollectionTestClasses
+{
+    /**
+     * Collection that will handle splitting multipolygons into buckets by overrideing the add
+     * function
+     */
+    public static class MultiPolygonSort
+            extends ShardBucketCollection<MultiPolygon, ArrayList<MultiPolygon>>
+    {
+        public MultiPolygonSort(final Rectangle maxBounds, final Integer zoomLevel)
+        {
+            super(maxBounds, zoomLevel);
+        }
+
+        /**
+         * This function only puts the part of the multipolygon with outers intersecting with the
+         * shard
+         *
+         * @param item
+         *            to add
+         * @param collection
+         *            to add to
+         * @param shard
+         *            shard associated with the collection
+         * @return whether it was added successfully
+         */
+        @Override
+        protected boolean addFunction(final MultiPolygon item,
+                final ArrayList<MultiPolygon> collection, final Shard shard)
+        {
+            final Rectangle shardBounds = shard.bounds();
+            final MultiMap<Polygon, Polygon> newMultiPolygon = new MultiMap<>();
+            item.outers().forEach(outer ->
+            {
+                if (outer.overlaps(shardBounds))
+                {
+                    newMultiPolygon.put(outer, item.innersOf(outer));
+                }
+            });
+            return collection.add(new MultiPolygon(newMultiPolygon));
+        }
+
+        @Override
+        protected boolean allowMultipleBucketInsertion()
+        {
+            return true;
+        }
+
+        @Override
+        protected ArrayList<MultiPolygon> initializeBucketCollection()
+        {
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Class where the polylines are put at the first bucket whose bounds overlap with the start
+     */
+    public static class PolyLineBucketedAtStartLocation
+            extends ShardBucketCollection<PolyLine, HashSet<PolyLine>>
+    {
+        public PolyLineBucketedAtStartLocation(final Rectangle maxBounds, final Integer zoomLevel)
+        {
+            super(maxBounds, zoomLevel);
+        }
+
+        @Override
+        protected boolean allowMultipleBucketInsertion()
+        {
+            return false;
+        }
+
+        @Override
+        protected HashSet<PolyLine> initializeBucketCollection()
+        {
+            return new HashSet<>();
+        }
+
+        /**
+         * Choose the first shard that overlaps the start point of the PolyLine as sorted by the
+         * SlippyTile class
+         *
+         * @param item
+         *            located item to insert
+         * @param possibleBuckets
+         *            possible buckets for the item to work into
+         * @return
+         */
+        @Override
+        protected Shard resolveShard(final PolyLine item,
+                final List<? extends Shard> possibleBuckets)
+        {
+            final Location start = Iterables.head(item);
+            return possibleBuckets.stream().map(shard -> (SlippyTile) shard)
+                    .filter(shard -> shard.bounds().fullyGeometricallyEncloses(start)).sorted()
+                    .findFirst().get();
+        }
+    }
+
+    /**
+     * Basic implementation for testing core functionality
+     */
+    public static class PolylineBuckets extends ShardBucketCollection<PolyLine, HashSet<PolyLine>>
+    {
+        public PolylineBuckets(final Rectangle maxBounds, final Integer zoomLevel)
+        {
+            super(maxBounds, zoomLevel);
+        }
+
+        @Override
+        protected boolean allowMultipleBucketInsertion()
+        {
+            return true;
+        }
+
+        @Override
+        protected HashSet<PolyLine> initializeBucketCollection()
+        {
+            return new HashSet<>();
+        }
+    }
+
+    /**
+     * Unimplemented resolve shard
+     */
+    public static class UnsupportedOperation
+            extends ShardBucketCollection<PolyLine, HashSet<PolyLine>>
+    {
+        public UnsupportedOperation(final Rectangle maxBounds, final Integer zoomLevel)
+        {
+            super(maxBounds, zoomLevel);
+        }
+
+        @Override
+        protected boolean allowMultipleBucketInsertion()
+        {
+            return false;
+        }
+
+        @Override
+        protected HashSet<PolyLine> initializeBucketCollection()
+        {
+            return new HashSet<>();
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTestClasses.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/ShardBucketCollectionTestClasses.java
@@ -21,7 +21,7 @@ import org.openstreetmap.atlas.utilities.maps.MultiMap;
 public class ShardBucketCollectionTestClasses
 {
     /**
-     * Collection that will handle splitting multipolygons into buckets by overrideing the add
+     * Collection that will handle splitting multipolygons into buckets by overriding the add
      * function
      */
     public static class MultiPolygonSort


### PR DESCRIPTION
### Description:
This is a new abstract collection implementation that allows for easy sorting of located items, like AtlasEntities or CheckFlags,  into different buckets as defined by shards. This collection acts as wrapper for the underlying bucket collections.  The bucket collection type is determined by the implementer. There are a number of control functions that need to be implemented to allow for simple and flexible use. 

Rectangle and Counter changes were made to enable the testing and creation of this class. 

Details: 
The collection lazily constructs collections per bucket. It uses synchronized blocks to ensure only one collection is initialized per shard and no information is lost. This is to allow for multithreaded insertion/sorting, but it does not guarantee the wrapped collection is thread safe. 
The bucket collections are stored in an array and the initializing shards are stored in an immutable R-tree with the index of its corresponding collection in the array. In the figure below I show the SlippyTile shards I used to initialize a number of test collections, each with the corresponding collection array index. 

![shardbucketcollectiontest 002](https://user-images.githubusercontent.com/9659948/43541714-e9f4a342-957f-11e8-997a-c7aaf73281b1.jpeg)

All collection functions interface with the collection index and/or collection array. 

The collection does not support safe iterating while inserting. 

### Potential Impact:

This will change no current implementations but it will enable a number of different located sorting tasks by enabling quick and simple implementation. 

### Unit Test Approach:

I created the most basic test collection possible and tested all the main collection functionalities on that as well as some of the unique functionalities. I then created more test collections that take advantage of the flexibility of the control functions and tested that they worked as intended. 

There are multiple tests checking for the same thing in different ways to gain code coverage. 

### Test Results:

As expected. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)