### PR TITLE
Fix way-section identifier bug for closed loops

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -1001,10 +1001,11 @@ public class WaySectionProcessor
                     // identifier will start at 000.
                     final long edgeIdentifier;
                     if (!line.isClosed() && nodesToSectionAt.size() == 2
-                            && polyline.size() - 1 == index)
+                            && polyline.size() - 1 == index && newEdgesForLine.isEmpty())
                     {
                         // The only time we want to do this is if there are two nodes, the line
-                        // isn't a ring and the last node is the end of the polyline
+                        // isn't a ring, the last node is the end of the polyline and if we haven't
+                        // split this line previously
                         edgeIdentifier = line.getIdentifier();
                     }
                     else

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -43,6 +43,7 @@ public class WaySectionProcessorTest
                 finalAtlas.numberOfEdges());
         Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
 
+        // Explicit check for expected identifiers
         Assert.assertTrue(finalAtlas.edge(317579533000001L) != null);
         Assert.assertTrue(finalAtlas.edge(-317579533000001L) != null);
         Assert.assertTrue(finalAtlas.edge(317579533000002L) != null);
@@ -62,6 +63,12 @@ public class WaySectionProcessorTest
         Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
         Assert.assertEquals(4, finalAtlas.node(4566499618000000L).connectedEdges().size());
         Assert.assertEquals(2, finalAtlas.node(4566499619000000L).connectedEdges().size());
+
+        // Explicit check for expected identifiers
+        Assert.assertTrue(finalAtlas.edge(461101743000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(-461101743000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(461101743000002L) != null);
+        Assert.assertTrue(finalAtlas.edge(-461101743000002L) != null);
     }
 
     @Test
@@ -78,6 +85,14 @@ public class WaySectionProcessorTest
         Assert.assertEquals(4, finalAtlas.node(4560902689000000L).connectedEdges().size());
         Assert.assertEquals(2, finalAtlas.node(4560902695000000L).connectedEdges().size());
         Assert.assertEquals(4, finalAtlas.node(4560902693000000L).connectedEdges().size());
+
+        // Explicit check for expected identifiers
+        Assert.assertTrue(finalAtlas.edge(460419987000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(460419987000002L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000002L) != null);
+        Assert.assertTrue(finalAtlas.edge(460419987000003L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
     }
 
     @Test
@@ -96,6 +111,16 @@ public class WaySectionProcessorTest
         Assert.assertEquals(4, finalAtlas.node(4560902693000000L).connectedEdges().size());
         Assert.assertEquals(2, finalAtlas.node(4560902612000000L).connectedEdges().size());
         Assert.assertEquals(6, finalAtlas.node(4560902689000000L).connectedEdges().size());
+
+        // Explicit check for expected identifiers
+        Assert.assertTrue(finalAtlas.edge(460419987000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(460419987000002L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
+        Assert.assertTrue(finalAtlas.edge(460419987000003L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
+        Assert.assertTrue(finalAtlas.edge(460419987000004L) != null);
+        Assert.assertTrue(finalAtlas.edge(-460419987000004L) != null);
     }
 
     @Test


### PR DESCRIPTION
### Description:

The original issue was reported by @jklamer - lots of benign `MultiAtlasBorderFixer` logs failing to fix conflicts (see below for sample output) when stitching together raw atlas shards. I dug into this and found a corner case in identifier assignment for way-sectioned edges that had a loop as part of the underlying PolyLine. Specifically, we would assign 000 as one of the identifiers for the Edge, even though the underlying way was being way-sectioned. This would trigger the `MultiAtlasBorderFixer` to attempt an edge fix, specifically triggering the `hasInconsistentIdentifier()` [method](https://github.com/osmlab/atlas/blob/736b649b2657083a651acdc4dbc33e4db1ef4f01/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasBorderFixer.java#L827) to return inconsistencies and begin the fix process.

Sample Error in Logs:
`2018-07-25 13:47:13 WARN  [Executor task launch worker-0] MultiAtlasBorderFixer:288 - OSM way 201288149 fix for [[TemporaryRoad: subAtlas = CUB_7-35-55.atlas, osm = 201288149000, members =
	[Edge: id=201288149000000, startNode=2112447504000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4222758 22.9527279, -81.4223432 22.952432, -81.4223722 22.9522485, -81.4223175 22.9521124, -81.4222147 22.951926, -81.4222147 22.9517869, -81.422385 22.9517248, -81.4225521 22.9517366, -81.4226999 22.9518402, -81.4229859 22.9519378, -81.4231434 22.9518964, -81.4231466 22.9517603, -81.4231016 22.951568, -81.4230116 22.9513608, -81.4230181 22.9512306, -81.423108 22.9511892, -81.4232526 22.9512158, -81.4233715 22.9513076, -81.4234615 22.951562, -81.4234936 22.951852, -81.4235451 22.9521686, -81.4235129 22.9523196, -81.4232334 22.9524616, -81.4230598 22.9525089, -81.4229217 22.9525888, -81.4229666 22.9528019, -81.4230759 22.9529972, -81.4231241 22.9531777, -81.4230116 22.9532664, -81.4228895 22.9532428, -81.4227578 22.953154, -81.422581 22.9530149, -81.4224075 22.9528463, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]
	[Edge: id=201288149000001, startNode=2112447568000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4215302 22.9537931, -81.4215302 22.9535564, -81.4216973 22.9534292, -81.421903 22.9534706, -81.4221183 22.9535623, -81.4222468 22.953586, -81.4223047 22.9534943, -81.4222276 22.9532339, -81.422144 22.9530475, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]
]] is failed.
org.openstreetmap.atlas.exception.CoreException: Found end first! POINT (-81.4215302 22.9537931)(occurrence 0) and POINT (-81.4222758 22.9527279)(occurrence 0) are not in order with respect to LINESTRING (-81.4222758 22.9527279, -81.4223432 22.952432, -81.4223722 22.9522485, -81.4223175 22.9521124, -81.4222147 22.951926, -81.4222147 22.9517869, -81.422385 22.9517248, -81.4225521 22.9517366, -81.4226999 22.9518402, -81.4229859 22.9519378, -81.4231434 22.9518964, -81.4231466 22.9517603, -81.4231016 22.951568, -81.4230116 22.9513608, -81.4230181 22.9512306, -81.423108 22.9511892, -81.4232526 22.9512158, -81.4233715 22.9513076, -81.4234615 22.951562, -81.4234936 22.951852, -81.4235451 22.9521686, -81.4235129 22.9523196, -81.4232334 22.9524616, -81.4230598 22.9525089, -81.4229217 22.9525888, -81.4229666 22.9528019, -81.4230759 22.9529972, -81.4231241 22.9531777, -81.4230116 22.9532664, -81.4228895 22.9532428, -81.4227578 22.953154, -81.422581 22.9530149, -81.4224075 22.9528463, -81.4222758 22.9527279, -81.4215302 22.9535564, -81.4216973 22.9534292, -81.421903 22.9534706, -81.4221183 22.9535623, -81.4222468 22.953586, -81.4223047 22.9534943, -81.4222276 22.9532339, -81.422144 22.9530475, -81.4222758 22.9527279)
	at org.openstreetmap.atlas.geography.PolyLine.between(PolyLine.java:302)
	at org.openstreetmap.atlas.geography.atlas.multi.MultiAtlasBorderFixer.fixBorderIssues(MultiAtlasBorderFixer.java:212)
	at org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas.<init>(MultiAtlas.java:418)
	at org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas.<init>(MultiAtlas.java:267)
	at org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas.loadFromPackedAtlas(MultiAtlas.java:165)
	at org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas.loadFromPackedAtlas(MultiAtlas.java:138)
	at org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader.load(AtlasResourceLoader.java:90)
	at ...
`

### Potential Impact:

This was a benign error, as no actual fixes took place or were necessary (because of the consistent identifiers). However, the resulting output clogged up the logs and potentially increased runtime, as an attempt to fix the underlying PolyLines was made for multiple Edges within an Atlas.

### Unit Test Approach:

I've updated the existing unit tests that handle loop scenarios to explicitly check identifier correctness. Without the fix, these would fail.

### Test Results:

I verified the fix in several ways:

1. Programmatically:

I set a conditional break-point in the `MultiAtlasBorderFixer` to trigger when attempting to see if a fix was required for the first Edge in the output logs. Before the fix, the two edges for this OSM Identifier were: 

```
{201288149000000=[[Edge: id=201288149000000, startNode=2112447504000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4222758 22.9527279, -81.4223432 22.952432, -81.4223722 22.9522485, -81.4223175 22.9521124, -81.4222147 22.951926, -81.4222147 22.9517869, -81.422385 22.9517248, -81.4225521 22.9517366, -81.4226999 22.9518402, -81.4229859 22.9519378, -81.4231434 22.9518964, -81.4231466 22.9517603, -81.4231016 22.951568, -81.4230116 22.9513608, -81.4230181 22.9512306, -81.423108 22.9511892, -81.4232526 22.9512158, -81.4233715 22.9513076, -81.4234615 22.951562, -81.4234936 22.951852, -81.4235451 22.9521686, -81.4235129 22.9523196, -81.4232334 22.9524616, -81.4230598 22.9525089, -81.4229217 22.9525888, -81.4229666 22.9528019, -81.4230759 22.9529972, -81.4231241 22.9531777, -81.4230116 22.9532664, -81.4228895 22.9532428, -81.4227578 22.953154, -81.422581 22.9530149, -81.4224075 22.9528463, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]], 

201288149000001=[[Edge: id=201288149000001, startNode=2112447568000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4215302 22.9537931, -81.4215302 22.9535564, -81.4216973 22.9534292, -81.421903 22.9534706, -81.4221183 22.9535623, -81.4222468 22.953586, -81.4223047 22.9534943, -81.4222276 22.9532339, -81.422144 22.9530475, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]]}
```

This caused an attempted fix, since an identifier ending with 000 implies no way-sectioning took place, but the presence of multiple edges for a single OSM Identifier implies way-sectioning did take place, prompting an attempted fix. Here is the output after the fix - which correctly resulted in no necessary fix:

```
{201288149000001=[[Edge: id=201288149000001, startNode=2112447568000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4215302 22.9537931, -81.4215302 22.9535564, -81.4216973 22.9534292, -81.421903 22.9534706, -81.4221183 22.9535623, -81.4222468 22.953586, -81.4223047 22.9534943, -81.4222276 22.9532339, -81.422144 22.9530475, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]], 

201288149000002=[[Edge: id=201288149000002, startNode=2112447504000000, endNode=2112447504000000, polyLine=LINESTRING (-81.4222758 22.9527279, -81.4223432 22.952432, -81.4223722 22.9522485, -81.4223175 22.9521124, -81.4222147 22.951926, -81.4222147 22.9517869, -81.422385 22.9517248, -81.4225521 22.9517366, -81.4226999 22.9518402, -81.4229859 22.9519378, -81.4231434 22.9518964, -81.4231466 22.9517603, -81.4231016 22.951568, -81.4230116 22.9513608, -81.4230181 22.9512306, -81.423108 22.9511892, -81.4232526 22.9512158, -81.4233715 22.9513076, -81.4234615 22.951562, -81.4234936 22.951852, -81.4235451 22.9521686, -81.4235129 22.9523196, -81.4232334 22.9524616, -81.4230598 22.9525089, -81.4229217 22.9525888, -81.4229666 22.9528019, -81.4230759 22.9529972, -81.4231241 22.9531777, -81.4230116 22.9532664, -81.4228895 22.9532428, -81.4227578 22.953154, -81.422581 22.9530149, -81.4224075 22.9528463, -81.4222758 22.9527279), [Tags: [last_edit_user_name => Bilbo-denmark], [last_edit_changeset => 14662455], [last_edit_time => 1358265285000], [last_edit_user_id => 295005], [iso_country_code => CUB], [highway => service], [last_edit_version => 1]]]]}

```
2. Visually:

Below are the two edges created in the pre-fix atlas and the same two-edge in the post-fix atlas. You'll notice that the geometry and tags are identical, but the identifier is now correct. Because of way-sectioning, the identifiers changes from 000 and 001 to 001 and 002.

**Original Atlas - first Edge:**
![prefixstart](https://user-images.githubusercontent.com/18317260/43664857-2ee76396-9723-11e8-8142-fa8a4a764eb7.png)

**Original Atlas - second Edge:**
![prefixend](https://user-images.githubusercontent.com/18317260/43664874-3fec00c0-9723-11e8-96c1-34771354aa23.png)

**New Atlas - first Edge:**
![postfixstart](https://user-images.githubusercontent.com/18317260/43664887-5316e93a-9723-11e8-9444-05f861b9b409.png)

**New Atlas - second Edge:**
![postfixend](https://user-images.githubusercontent.com/18317260/43664892-583258be-9723-11e8-9504-36eb47d69091.png)

3. Building new atlases and forming a `MultiAtlas` - I constructed two Cuba shards with the fix and combined them into a `MultiAtlas`, the `MultiAtlasBorderFixer` output was no longer present, but the data was identical across the MultiAtlases. I leveraged `AtlasDelta` to compare old and new multi-atlas and the only difference was the removal of the 000 edges.
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
