### PR TITLE
Update TestAtlasHandler to rely on Raw Atlas Flow

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -1001,10 +1001,11 @@ public class WaySectionProcessor
                     // identifier will start at 000.
                     final long edgeIdentifier;
                     if (!line.isClosed() && nodesToSectionAt.size() == 2
-                            && polyline.size() - 1 == index)
+                            && polyline.size() - 1 == index && newEdgesForLine.isEmpty())
                     {
                         // The only time we want to do this is if there are two nodes, the line
-                        // isn't a ring and the last node is the end of the polyline
+                        // isn't a ring, the last node is the end of the polyline and if we haven't
+                        // split this line previously
                         edgeIdentifier = line.getIdentifier();
                     }
                     else


### PR DESCRIPTION
### Description:

There's a number of `TestAtlas` annotations that build `Atlas` files from an OSM file (of various formats). Under the covers, these relied on the `OsmPbfLoader` to construct the Atlas file. This PR updates the Atlas construction to leverage the new Raw Atlas flow for all annotations.

### Potential Impact:

This impacts all tests using the annotations.

### Unit Test Approach:

There's an existing explicit test (TestAtlasTest) that tests this functionality - which passes after the changes.

### Test Results:

All other unit tests that rely on the annotations are passing after the test, implying the constructed Atlas is valid.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
