### PR TITLE
Small changes to AtlasDelta toDiffViewFriendlyString method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
@@ -350,7 +350,7 @@ public class Diff implements Comparable<Diff>, Serializable
     {
         final String newLine = System.getProperty("line.separator");
         final StringBuilder builder = new StringBuilder();
-        builder.append("Diff [");
+        builder.append("Diff {");
         builder.append(newLine);
         builder.append("diffType: " + this.diffType);
         builder.append(newLine);
@@ -380,7 +380,7 @@ public class Diff implements Comparable<Diff>, Serializable
             builder.append("null");
         }
         builder.append(newLine);
-        builder.append("]");
+        builder.append("}");
         return builder.toString();
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
@@ -69,7 +69,6 @@ public class Diff implements Comparable<Diff>, Serializable
     {
         final String newLine = System.getProperty("line.separator");
         final StringBuilder builder = new StringBuilder();
-        builder.append(newLine);
         builder.append("Diffset {");
         final StringList list = new StringList();
         for (final Diff diff : diffs)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
@@ -69,14 +69,15 @@ public class Diff implements Comparable<Diff>, Serializable
     {
         final String newLine = System.getProperty("line.separator");
         final StringBuilder builder = new StringBuilder();
-        builder.append("[Diffs: ");
+        builder.append(newLine);
+        builder.append("Diffset {");
         final StringList list = new StringList();
         for (final Diff diff : diffs)
         {
             list.add(newLine + diff.toDiffViewFriendlyString());
         }
         builder.append(list.join(newLine));
-        builder.append(newLine + "]");
+        builder.append(newLine + "}");
         return builder.toString();
     }
 
@@ -350,16 +351,15 @@ public class Diff implements Comparable<Diff>, Serializable
     {
         final String newLine = System.getProperty("line.separator");
         final StringBuilder builder = new StringBuilder();
-        builder.append("[Diff: ");
-        builder.append(this.diffType);
+        builder.append("Diff [");
         builder.append(newLine);
-        builder.append(this.diffReason);
+        builder.append("diffType: " + this.diffType);
         builder.append(newLine);
-        builder.append("Entity = ");
-        builder.append(this.itemType);
+        builder.append("diffReason: " + this.diffReason);
         builder.append(newLine);
-        builder.append("ID = ");
-        builder.append(this.identifier);
+        builder.append("Entity = " + this.itemType);
+        builder.append(newLine);
+        builder.append("ID = " + this.identifier);
         builder.append(newLine);
         if (this.getBaseEntity() != null)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/Diff.java
@@ -353,6 +353,8 @@ public class Diff implements Comparable<Diff>, Serializable
         builder.append("[Diff: ");
         builder.append(this.diffType);
         builder.append(newLine);
+        builder.append(this.diffReason);
+        builder.append(newLine);
         builder.append("Entity = ");
         builder.append(this.itemType);
         builder.append(newLine);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaLineTest.java
@@ -38,7 +38,7 @@ public class AtlasDeltaLineTest
         final SortedSet<Diff> diffs = new AtlasDelta(base, alter).generate().getDifferences();
 
         Assert.assertEquals(1, diffs.size());
-        logger.debug("testDifferentGeometry(): {}", Diff.toString(diffs));
+        logger.debug("testDifferentGeometry(): {}", Diff.toDiffViewFriendlyString(diffs));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaLineTest.java
@@ -38,7 +38,7 @@ public class AtlasDeltaLineTest
         final SortedSet<Diff> diffs = new AtlasDelta(base, alter).generate().getDifferences();
 
         Assert.assertEquals(1, diffs.size());
-        logger.debug("testDifferentGeometry(): {}", Diff.toDiffViewFriendlyString(diffs));
+        logger.debug("testDifferentGeometry(): {}", Diff.toString(diffs));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Added the diffReason field from `Diff` to the printout, which was missing from the regular toString method. It is very useful when glancing at a diff, so you know exactly what to look for. Additionally, I updated the format of the printout so it is easy to see exactly what changed in any given diff. Each feature is now printed on a separate line, so all you have to do is scroll until you see a change.

### Potential Impact:

No potential impact. No code currently depends on the diff friendly printouts (barring one or two unit tests which simply log the printouts).

### Unit Test Approach:

AtlasDeltaEdgeTest prints out the the diff view friendly string at the DEBUG level, for a demo viewing. No actual code logic is changed.

### Test Results:

N/A