### PR TITLE
Addressed a bug in the new caching code as reported by Sonar

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/ByteArrayCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/ByteArrayCachingStrategy.java
@@ -22,7 +22,7 @@ public class ByteArrayCachingStrategy extends AbstractCachingStrategy
     /*
      * Default size is arbitrarily set to 2 MiB
      */
-    private static final long DEFAULT_BYTE_ARRAY_SIZE = 1024 * 1024 * 2;
+    private static final long DEFAULT_BYTE_ARRAY_SIZE = 1024L * 1024 * 2;
     private static final Logger logger = LoggerFactory.getLogger(ByteArrayCachingStrategy.class);
 
     private final Map<UUID, ByteArrayResource> resourceCache;


### PR DESCRIPTION
### Description:

A `long` constant in `ByteArrayCachingStrategy` was being initialized by multiplying together 3 integer constants. In this case, there was no problem. But if, in the future, someone changed a constant to a large value then overflow could occur.

I believe this is the shortest PR ever.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
