### PR TITLE
Added an always true filter for atlas loading

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -59,10 +59,7 @@ public class AtlasResourceLoader
 
     private static final Logger logger = LoggerFactory.getLogger(AtlasResourceLoader.class);
 
-    private final Predicate<Resource> alwaysTrueAtlasFilter = resource ->
-    {
-        return true;
-    };
+    private final Predicate<Resource> alwaysTrueAtlasFilter = resource -> true;
 
     private Predicate<Resource> resourceFilter;
     private Predicate<AtlasEntity> atlasEntityFilter;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -54,22 +54,15 @@ public class AtlasResourceLoader
         }
     }
 
-    /**
-     * @author lcram
-     */
-    private class AlwaysTrueAtlasFilter implements Predicate<Resource>
-    {
-        @Override
-        public boolean test(final Resource resource)
-        {
-            return true;
-        }
-    }
-
     public static final Predicate<Resource> IS_ATLAS = FileSuffix.resourceFilter(FileSuffix.ATLAS)
             .or(FileSuffix.resourceFilter(FileSuffix.ATLAS, FileSuffix.GZIP));
 
     private static final Logger logger = LoggerFactory.getLogger(AtlasResourceLoader.class);
+
+    private final Predicate<Resource> alwaysTrueAtlasFilter = resource ->
+    {
+        return true;
+    };
 
     private Predicate<Resource> resourceFilter;
     private Predicate<AtlasEntity> atlasEntityFilter;
@@ -85,7 +78,7 @@ public class AtlasResourceLoader
     public Atlas load(final Iterable<? extends Resource> input)
     {
         final Predicate<Resource> toggleableAtlasFileFilter = this.filterForAtlasFileExtension
-                ? IS_ATLAS : new AlwaysTrueAtlasFilter();
+                ? IS_ATLAS : this.alwaysTrueAtlasFilter;
 
         final List<Resource> resources = Iterables.stream(input).flatMap(this::resourcesIn)
                 .filter(toggleableAtlasFileFilter).filter(this.resourceFilter).collectToList();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -54,6 +54,15 @@ public class AtlasResourceLoader
         }
     }
 
+    private class AlwaysTrueAtlasFilter implements Predicate<Resource>
+    {
+        @Override
+        public boolean test(final Resource t)
+        {
+            return true;
+        }
+    }
+
     public static final Predicate<Resource> IS_ATLAS = FileSuffix.resourceFilter(FileSuffix.ATLAS)
             .or(FileSuffix.resourceFilter(FileSuffix.ATLAS, FileSuffix.GZIP));
 
@@ -62,6 +71,7 @@ public class AtlasResourceLoader
     private Predicate<Resource> resourceFilter;
     private Predicate<AtlasEntity> atlasEntityFilter;
     private String multiAtlasName;
+    private boolean filterForAtlasFileExtension = true;
 
     public AtlasResourceLoader()
     {
@@ -71,8 +81,11 @@ public class AtlasResourceLoader
 
     public Atlas load(final Iterable<? extends Resource> input)
     {
+        final Predicate<Resource> toggleableAtlasFileFilter = this.filterForAtlasFileExtension
+                ? IS_ATLAS : new AlwaysTrueAtlasFilter();
+
         final List<Resource> resources = Iterables.stream(input).flatMap(this::resourcesIn)
-                .filter(IS_ATLAS).filter(this.resourceFilter).collectToList();
+                .filter(toggleableAtlasFileFilter).filter(this.resourceFilter).collectToList();
         final long size = resources.size();
         if (size == 1)
         {
@@ -138,6 +151,19 @@ public class AtlasResourceLoader
     public AtlasResourceLoader withAtlasEntityFilter(final Predicate<AtlasEntity> filter)
     {
         setAtlasEntityFilter(filter);
+        return this;
+    }
+
+    /**
+     * Enable or disable atlas file extension filtering on this loader.
+     *
+     * @param value
+     *            whether to enable or disable
+     * @return the modified {@link AtlasResourceLoader}
+     */
+    public AtlasResourceLoader withAtlasFileExtensionFilterSetTo(final boolean value)
+    {
+        this.filterForAtlasFileExtension = value;
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -54,6 +54,9 @@ public class AtlasResourceLoader
         }
     }
 
+    /**
+     * @author lcram
+     */
     private class AlwaysTrueAtlasFilter implements Predicate<Resource>
     {
         @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -18,7 +18,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Load an {@link Atlas} from a {@link Resource} or an {@link Iterable} of {@link Resource}s.
- * Supports also loading based on a resource name filter.
+ * Supports also loading based on a resource name filter. Note that by default, this class will
+ * filter the provided {@link Iterable} and remove any {@link Resource} that does not have a valid
+ * atlas file extension (defined in the {@link FileSuffix} enum). This funtionality can be disabled
+ * by calling {@link AtlasResourceLoader#withAtlasFileExtensionFilterSetTo(boolean)} with
+ * {@code false}. Disabling this functionality is useful if combining this class with atlases
+ * fetched from a cache that does not respect the .atlas file extension convention.
  *
  * @author cstaylor
  * @author mgostintsev

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -57,7 +57,7 @@ public class AtlasResourceLoader
     private class AlwaysTrueAtlasFilter implements Predicate<Resource>
     {
         @Override
-        public boolean test(final Resource t)
+        public boolean test(final Resource resource)
         {
             return true;
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -92,7 +92,7 @@ public class AtlasResourceLoaderTest
         final File parent = File.temporaryFolder();
         try
         {
-            final File atlas1 = parent.child("iAmNotAnAtlas.txt");
+            final File atlas1 = parent.child("iAmNotAnAtlas2.txt");
             atlas1.writeAndClose("1");
             Assert.assertNull(new AtlasResourceLoader().load(atlas1));
             Assert.assertNotNull(new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -87,6 +87,18 @@ public class AtlasResourceLoaderTest
     }
 
     @Test
+    public void testAtlasFileExtensionFilter()
+    {
+        final File parent = File.temporaryFolder();
+        final File atlas1 = parent.child("iAmNotAnAtlas.txt");
+        atlas1.writeAndClose("1");
+
+        Assert.assertNull(new AtlasResourceLoader().load(atlas1));
+        Assert.assertNotNull(
+                new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false).load(atlas1));
+    }
+
+    @Test
     public void testLoadingAtlasResourceWithFiltering()
     {
         // Dummy predicate, which brings in all entities

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -90,12 +90,18 @@ public class AtlasResourceLoaderTest
     public void testAtlasFileExtensionFilter()
     {
         final File parent = File.temporaryFolder();
-        final File atlas1 = parent.child("iAmNotAnAtlas.txt");
-        atlas1.writeAndClose("1");
-
-        Assert.assertNull(new AtlasResourceLoader().load(atlas1));
-        Assert.assertNotNull(
-                new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false).load(atlas1));
+        try
+        {
+            final File atlas1 = parent.child("iAmNotAnAtlas.txt");
+            atlas1.writeAndClose("1");
+            Assert.assertNull(new AtlasResourceLoader().load(atlas1));
+            Assert.assertNotNull(new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false)
+                    .load(atlas1));
+        }
+        finally
+        {
+            parent.deleteRecursively();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description:

Currently, the `AtlasResourceLoader` automatically and silently skips loading an atlas resource if it does not have a `.atlas` extension. This PR provides a simple way to disable this behavior if required.

```java
new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false).load(myAtlasResource);
```

I have some upcoming changes to `atlas-generator` that add a `HadoopAtlasFileCache`, but these are blocked until the changes in this PR are integrated and I can update `atlas-generator` to depend on them.

### Potential Impact:

This will have no downstream impact, as it is completely opt-in. All existing code will continue to function identically.

### Unit Test Approach:

I have added a unit test to `AtlasResourceLoaderTest` called `testAtlasFileExtensionFilter` that demonstrates proper functionality.

### Test Results:

All tests in `AtlasResourceLoaderTest` pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)