### PR TITLE
StringCompressedPolyLine now supports WKB for incompressible polylines

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
@@ -17,6 +17,8 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Snapper.SnappedLocation;
 import org.openstreetmap.atlas.geography.clipping.Clip;
 import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
+import org.openstreetmap.atlas.geography.converters.WkbLocationConverter;
+import org.openstreetmap.atlas.geography.converters.WkbPolyLineConverter;
 import org.openstreetmap.atlas.geography.converters.WktLocationConverter;
 import org.openstreetmap.atlas.geography.converters.WktPolyLineConverter;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
@@ -85,6 +87,18 @@ public class PolyLine implements Collection<Location>, Located, Serializable
         {
             writer.write(asGeoJson(geometries).jsonObject());
         }
+    }
+
+    /**
+     * Create a {@link PolyLine} from Well Known Binary
+     *
+     * @param wkb
+     *            The Well Known Binary
+     * @return The {@link PolyLine}
+     */
+    public static PolyLine wkb(final byte[] wkb)
+    {
+        return new WkbPolyLineConverter().backwardConvert(wkb);
     }
 
     /**
@@ -1104,6 +1118,19 @@ public class PolyLine implements Collection<Location>, Located, Serializable
     public String toString()
     {
         return toWkt();
+    }
+
+    /**
+     * @return This {@link PolyLine} as Well Known Binary
+     */
+    public byte[] toWkb()
+    {
+        if (this.size() == 1)
+        {
+            // Handle a single location polyLine
+            return new WkbLocationConverter().convert(this.first());
+        }
+        return new WkbPolyLineConverter().convert(this);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
@@ -150,7 +150,7 @@ public class StringCompressedPolyLine implements Serializable
             // Encode the differences between the points
             encoded += encodeNumber(latitude - oldLatitude);
             final long deltaLongitude = longitude - oldLongitude;
-            if (deltaLongitude > MAXIMUM_DELTA_LONGITUDE)
+            if (Math.abs(deltaLongitude) > MAXIMUM_DELTA_LONGITUDE)
             {
                 throw new PolyLineCompressionException(
                         "Unable to compress the polyLine, two consecutive points ({} and {}) are too far apart in longitude: {} degrees.",

--- a/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
@@ -5,11 +5,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Derived from MapQuest's developer portal:
- * https://developer.mapquest.com/documentation/common/encode-decode/
+ * Encode a {@link PolyLine} using an algorithm derived from the MapQuest variant of the Google
+ * Polyline Encoding Format. The encoding scheme falls back on WKB in edge cases when the algorithm
+ * fails (such as when two consecutive points in the polyline have a longitude difference of greater
+ * than 180 degrees).
  *
+ * @see <a href="https://developer.mapquest.com/documentation/common/encode-decode">The MapQuest
+ *      algorithm</a>
+ * @see <a href=
+ *      "https://developers.google.com/maps/documentation/utilities/polylinealgorithm?csw=1">Google
+ *      Polyline Encoding Format</a>
  * @author matthieun
  */
 public class StringCompressedPolyLine implements Serializable
@@ -42,7 +51,13 @@ public class StringCompressedPolyLine implements Serializable
     private static final long MAXIMUM_DELTA_LONGITUDE = (long) (MAXIMUM_DELTA_LONGITUDE_IN_DEGREES
             * Math.pow(10, PRECISION));
 
-    private final byte[] encoding;
+    // if the first byte of the encoding array is this sentinel value, then the following encoding
+    // is WKB and not string compressed
+    private static final byte WKB_SENTINEL = 0;
+
+    private static final Logger logger = LoggerFactory.getLogger(StringCompressedPolyLine.class);
+
+    private byte[] encoding;
 
     public StringCompressedPolyLine(final byte[] encoding)
     {
@@ -55,25 +70,34 @@ public class StringCompressedPolyLine implements Serializable
         {
             this.encoding = compress(polyLine, PRECISION).getBytes(ENCODING_NAME);
         }
-        catch (final PolyLineCompressionException e)
+        catch (final PolyLineCompressionException exception)
         {
-            throw e;
+            this.encoding = getWkbFallback(polyLine);
         }
-        catch (final Exception e)
+        catch (final Exception exception)
         {
-            throw new CoreException("Could not compress polyline.", e);
+            throw new CoreException("Could not compress polyline.", exception);
         }
     }
 
     public PolyLine asPolyLine()
     {
-        try
+        if (this.encoding[0] == WKB_SENTINEL)
         {
-            return asPolyLine(new String(this.encoding, ENCODING_NAME), PRECISION);
+            final byte[] strippedEncoding = new byte[this.encoding.length - 1];
+            System.arraycopy(this.encoding, 1, strippedEncoding, 0, strippedEncoding.length);
+            return PolyLine.wkb(strippedEncoding);
         }
-        catch (final Exception e)
+        else
         {
-            throw new CoreException("Could not decompress polyline.", e);
+            try
+            {
+                return asPolyLine(new String(this.encoding, ENCODING_NAME), PRECISION);
+            }
+            catch (final Exception exception)
+            {
+                throw new CoreException("Could not decompress polyline.", exception);
+            }
         }
     }
 
@@ -85,13 +109,22 @@ public class StringCompressedPolyLine implements Serializable
     @Override
     public String toString()
     {
-        try
+        if (this.encoding[0] == WKB_SENTINEL)
         {
-            return new String(this.encoding, ENCODING_NAME);
+            final byte[] strippedEncoding = new byte[this.encoding.length - 1];
+            System.arraycopy(this.encoding, 1, strippedEncoding, 0, strippedEncoding.length);
+            return PolyLine.wkb(strippedEncoding).toWkt();
         }
-        catch (final Exception e)
+        else
         {
-            throw new CoreException("Could not stringify byte array.", e);
+            try
+            {
+                return new String(this.encoding, ENCODING_NAME);
+            }
+            catch (final Exception e)
+            {
+                throw new CoreException("Could not stringify byte array.", e);
+            }
         }
     }
 
@@ -152,6 +185,7 @@ public class StringCompressedPolyLine implements Serializable
             final long deltaLongitude = longitude - oldLongitude;
             if (Math.abs(deltaLongitude) > MAXIMUM_DELTA_LONGITUDE)
             {
+                logger.warn("Unable to use string compression for {}", points.toWkt());
                 throw new PolyLineCompressionException(
                         "Unable to compress the polyLine, two consecutive points ({} and {}) are too far apart in longitude: {} degrees.",
                         last, location, deltaLongitude / precision);
@@ -181,5 +215,14 @@ public class StringCompressedPolyLine implements Serializable
         }
         encoded += String.valueOf(Character.toChars((int) number + ENCODING_OFFSET_MINUS_ONE));
         return encoded;
+    }
+
+    private byte[] getWkbFallback(final PolyLine polyLine)
+    {
+        final byte[] wkbEncoding = polyLine.toWkb();
+        final byte[] finalEncoding = new byte[1 + wkbEncoding.length];
+        finalEncoding[0] = WKB_SENTINEL;
+        System.arraycopy(wkbEncoding, 0, finalEncoding, 1, wkbEncoding.length);
+        return finalEncoding;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
@@ -76,6 +76,7 @@ public class StringCompressedPolyLine implements Serializable
         }
         catch (final PolyLineCompressionException exception)
         {
+            logger.warn("Unable to use string compression", exception);
             this.encoding = getWkbFallback(polyLine);
         }
         catch (final Exception exception)
@@ -189,7 +190,6 @@ public class StringCompressedPolyLine implements Serializable
             final long deltaLongitude = longitude - oldLongitude;
             if (Math.abs(deltaLongitude) > MAXIMUM_DELTA_LONGITUDE)
             {
-                logger.warn("Unable to use string compression for {}", points.toWkt());
                 throw new PolyLineCompressionException(
                         "Unable to compress the polyLine, two consecutive points ({} and {}) are too far apart in longitude: {} degrees.",
                         last, location, deltaLongitude / precision);

--- a/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/StringCompressedPolyLine.java
@@ -51,8 +51,12 @@ public class StringCompressedPolyLine implements Serializable
     private static final long MAXIMUM_DELTA_LONGITUDE = (long) (MAXIMUM_DELTA_LONGITUDE_IN_DEGREES
             * Math.pow(10, PRECISION));
 
-    // if the first byte of the encoding array is this sentinel value, then the following encoding
-    // is WKB and not string compressed
+    /*
+     * If the first byte of the encoding array is this sentinel value, then the following encoding
+     * is WKB and not string-compressed. We use '0' as the sentinel value since the string
+     * compression algorithm will always use printable ASCII characters. There will never be a 0
+     * byte in a valid string-compressed polyline.
+     */
     private static final byte WKB_SENTINEL = 0;
 
     private static final Logger logger = LoggerFactory.getLogger(StringCompressedPolyLine.class);

--- a/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
@@ -27,8 +27,8 @@ public class StringCompressedPolyLineTest
     @Test
     public void testCompressionError1()
     {
-        final Location location1 = new Location(Latitude.degrees(0.0), Longitude.degrees(-179.0));
-        final Location location2 = new Location(Latitude.degrees(0.0), Longitude.degrees(179.0));
+        final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
+        final Location location2 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));
         final PolyLine line = new PolyLine(location1, location2);
         final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
     }
@@ -36,8 +36,8 @@ public class StringCompressedPolyLineTest
     @Test
     public void testCompressionError2()
     {
-        final Location location1 = new Location(Latitude.degrees(0.0), Longitude.degrees(179.0));
-        final Location location2 = new Location(Latitude.degrees(0.0), Longitude.degrees(-179.0));
+        final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));
+        final Location location2 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
         final PolyLine line = new PolyLine(location1, location2);
         final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
@@ -24,7 +24,7 @@ public class StringCompressedPolyLineTest
         Assert.assertEquals(polyLine, decompressed);
     }
 
-    @Test
+    @Test(expected = PolyLineCompressionException.class)
     public void testCompressionError1()
     {
         final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
@@ -33,7 +33,7 @@ public class StringCompressedPolyLineTest
         final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
     }
 
-    @Test
+    @Test(expected = PolyLineCompressionException.class)
     public void testCompressionError2()
     {
         final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));

--- a/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
@@ -25,12 +25,19 @@ public class StringCompressedPolyLineTest
     }
 
     @Test
-    public void testCompressionError()
+    public void testCompressionError1()
     {
-        final Location location1 = new Location(Latitude.degrees(-85.0546157),
-                Longitude.degrees(-179.9982464));
-        final Location location2 = new Location(Latitude.degrees(-85.0545539),
-                Longitude.degrees(179.9996629));
+        final Location location1 = new Location(Latitude.degrees(0.0), Longitude.degrees(-179.0));
+        final Location location2 = new Location(Latitude.degrees(0.0), Longitude.degrees(179.0));
+        final PolyLine line = new PolyLine(location1, location2);
+        final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
+    }
+
+    @Test
+    public void testCompressionError2()
+    {
+        final Location location1 = new Location(Latitude.degrees(0.0), Longitude.degrees(179.0));
+        final Location location2 = new Location(Latitude.degrees(0.0), Longitude.degrees(-179.0));
         final PolyLine line = new PolyLine(location1, location2);
         final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
@@ -24,6 +24,17 @@ public class StringCompressedPolyLineTest
         Assert.assertEquals(polyLine, decompressed);
     }
 
+    @Test
+    public void testCompressionError()
+    {
+        final Location location1 = new Location(Latitude.degrees(-85.0546157),
+                Longitude.degrees(-179.9982464));
+        final Location location2 = new Location(Latitude.degrees(-85.0545539),
+                Longitude.degrees(179.9996629));
+        final PolyLine line = new PolyLine(location1, location2);
+        final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
+    }
+
     /**
      * Here the delta longitude between loc2 and loc3 is more than 180 degrees, hence the
      * compression exception.

--- a/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/StringCompressedPolyLineTest.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.geography;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openstreetmap.atlas.geography.StringCompressedPolyLine.PolyLineCompressionException;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
@@ -24,39 +23,26 @@ public class StringCompressedPolyLineTest
         Assert.assertEquals(polyLine, decompressed);
     }
 
-    @Test(expected = PolyLineCompressionException.class)
-    public void testCompressionError1()
+    /**
+     * Here the delta longitude between loc1/loc2 and loc3/loc4 is more than 180 degrees, so the
+     * algorithm falls back on WKB.
+     */
+    @Test
+    public void testCompressionWkbFallback()
     {
         final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
         final Location location2 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));
-        final PolyLine line = new PolyLine(location1, location2);
-        final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
-    }
+        final Location location3 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));
+        final Location location4 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
+        final PolyLine line1 = new PolyLine(location1, location2);
+        final PolyLine line2 = new PolyLine(location3, location4);
+        final StringCompressedPolyLine compressedLine1 = new StringCompressedPolyLine(line1);
+        final StringCompressedPolyLine compressedLine2 = new StringCompressedPolyLine(line2);
 
-    @Test(expected = PolyLineCompressionException.class)
-    public void testCompressionError2()
-    {
-        final Location location1 = new Location(Latitude.degrees(45.0), Longitude.degrees(179.0));
-        final Location location2 = new Location(Latitude.degrees(45.0), Longitude.degrees(-179.0));
-        final PolyLine line = new PolyLine(location1, location2);
-        final StringCompressedPolyLine compressedLine = new StringCompressedPolyLine(line);
-    }
-
-    /**
-     * Here the delta longitude between loc2 and loc3 is more than 180 degrees, hence the
-     * compression exception.
-     */
-    @Test(expected = PolyLineCompressionException.class)
-    public void testJumpyPolyLine()
-    {
-        final Location loc1 = Location.forString("5.972761,-75.8373644");
-        final Location loc2 = Location.forString("5.9712693,-75.8363875");
-        final Location loc3 = Location.forString("18.6398595,157.7635783");
-        final Location loc4 = Location.forString("15.3405183,13.9936102");
-        final PolyLine polyLine = new PolyLine(loc1, loc2, loc3, loc4);
-
-        System.out.println(polyLine);
-        new StringCompressedPolyLine(polyLine);
+        // the toString method should return WKT since the compression is WKB instead of MapQuest
+        // string compression
+        Assert.assertEquals(compressedLine1.toString(), compressedLine1.asPolyLine().toWkt());
+        Assert.assertEquals(compressedLine2.toString(), compressedLine2.asPolyLine().toWkt());
     }
 
     @Test


### PR DESCRIPTION
### Description:

In the case that a user attempted to create a compressed polyline in which two consecutive points had a longitudinal difference of > 180, the algorithm would throw up an exception and fail loudly.

In the alternate case that a user attempted to create a compressed polyline in which two consecutive points had a longitudinal difference of < -180, the algorithm would fail to catch this error condition. Instead, it would happily create a bogus polyline - which would have an undefined value when decompressed.

This PR applies the following fix strategy: an adaptable format, using string compression for closely packed polylines and regular WKB for incompressible polylines. 

### Potential Impact:

This PR effectively changes the atlas file format. The changes are self contained within `StringCompressedPolyLine`, so as far as the Java codebase is concerned, there is no discernible difference. But, if there is any code out there using the protobuf atlas (think `pyatlas`) that does not expect WKB polylines, it is possible that decompression errors could occur. This is due to the fact that atlas generation with > 180 degree polylines no longer fails, but produces an atlas file with a WKB polyline.

### Unit Test Approach:

I have added `testCompressionWkbFallback` which is designed to encode polylines using the WKB fallback. It then tests that their `toString` representation correctly matches their WKT, which only occurs if string compression failed. In the case that string compression succeeded, `toString` instead would have return the encoded string.

### Test Results:

All unit tests continue to pass. I also ran the full atlas integration test suite, which continues to pass. I think it is worth discussing potential downstream impact before merging.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)