### PR TITLE
DynamicAtlas improvements: Multi-Atlas loading and hotspots

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -119,7 +119,7 @@ public abstract class AbstractAtlas extends BareAtlas
     @Override
     public Iterable<Area> areasCovering(final Location location, final Predicate<Area> matcher)
     {
-        return Iterables.filter(this.getAreaSpatialIndex().get(location.bounds()), matcher);
+        return Iterables.filter(areasCovering(location), matcher);
     }
 
     @Override
@@ -146,14 +146,14 @@ public abstract class AbstractAtlas extends BareAtlas
         return Iterables.filter(edges, edge ->
         {
             final PolyLine polyline = edge.asPolyLine();
-            return location.bounds().overlaps(polyline);
+            return polyline.contains(location);
         });
     }
 
     @Override
     public Iterable<Edge> edgesContaining(final Location location, final Predicate<Edge> matcher)
     {
-        return Iterables.filter(this.getEdgeSpatialIndex().get(location.bounds()), matcher);
+        return Iterables.filter(edgesContaining(location), matcher);
     }
 
     @Override
@@ -223,7 +223,7 @@ public abstract class AbstractAtlas extends BareAtlas
     @Override
     public Iterable<Line> linesContaining(final Location location, final Predicate<Line> matcher)
     {
-        return Iterables.filter(this.getLineSpatialIndex().get(location.bounds()), matcher);
+        return Iterables.filter(linesContaining(location), matcher);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -216,7 +216,7 @@ public abstract class AbstractAtlas extends BareAtlas
         return Iterables.filter(lines, line ->
         {
             final PolyLine polyline = line.asPolyLine();
-            return location.bounds().overlaps(polyline);
+            return polyline.contains(location);
         });
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -639,19 +639,19 @@ public abstract class BareAtlas implements Atlas
         // would include only edges, but all the nodes would have to be pulled in. In that case, we
         // use the same size as the source Atlas, but we trim it at the end.
         final PackedAtlasBuilder builder = new PackedAtlasBuilder().withSizeEstimates(size())
-                .withMetaData(metaData());
+                .withMetaData(metaData()).withName(this.getName() + "_sub");
 
         // First, index all the nodes contained by relations and all start/stop nodes from edges
         // contained by relations
-        for (final AtlasEntity entity : relations(relation -> matcher.test(relation)))
+        for (final AtlasEntity entity : relations(matcher::test))
         {
             indexAllNodesFromRelation((Relation) entity, builder, 0);
         }
 
         // Next, index all the individual nodes and edge start/stop nodes coming from the predicate
-        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(item -> matcher.test(item)))
+        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(matcher::test))
                 .map(item -> (AtlasEntity) item);
-        final Iterable<AtlasEntity> edges = Iterables.stream(edges(item -> matcher.test(item)))
+        final Iterable<AtlasEntity> edges = Iterables.stream(edges(matcher::test))
                 .map(item -> (AtlasEntity) item);
         for (final AtlasEntity entity : new MultiIterable<>(nodes, edges))
         {
@@ -664,19 +664,19 @@ public abstract class BareAtlas implements Atlas
         // Similarly, Relations depend on all other entities to have been added, since they make up
         // the member list. For this pass, add all entities, except Relations, that match the given
         // Predicate to the builder.
-        for (final Edge edge : edges(item -> matcher.test(item)))
+        for (final Edge edge : edges(matcher::test))
         {
             indexEdge(edge, builder);
         }
-        for (final Area area : areas(item -> matcher.test(item)))
+        for (final Area area : areas(matcher::test))
         {
             builder.addArea(area.getIdentifier(), area.asPolygon(), area.getTags());
         }
-        for (final Line line : lines(item -> matcher.test(item)))
+        for (final Line line : lines(matcher::test))
         {
             builder.addLine(line.getIdentifier(), line.asPolyLine(), line.getTags());
         }
-        for (final Point point : points(item -> matcher.test(item)))
+        for (final Point point : points(matcher::test))
         {
             builder.addPoint(point.getIdentifier(), point.getLocation(), point.getTags());
         }
@@ -689,7 +689,7 @@ public abstract class BareAtlas implements Atlas
         // relation has been processed). This guarantees that anything we add to the index has all
         // of its members indexed already.
         Set<Long> stagedRelationIdentifiers = new HashSet<>();
-        final Iterable<Relation> relations = relations(item -> matcher.test(item));
+        final Iterable<Relation> relations = relations(matcher::test);
         for (final Relation relation : relations)
         {
             checkRelationMembersAndIndexRelation(relation, matcher, stagedRelationIdentifiers,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -71,6 +71,7 @@ public class DynamicAtlas extends BareAtlas
     // This is true when, in case of deferred loading, the loading of the shards has been called
     // (unlocking further automatic loading later)
     private boolean isAlreadyLoaded = false;
+    private boolean preemptiveLoadDone = false;
 
     /**
      * @param dynamicAtlasExpansionPolicy
@@ -426,6 +427,7 @@ public class DynamicAtlas extends BareAtlas
             // Loop through the entities again to find potential shards to add.
             this.entities();
         }
+        this.preemptiveLoadDone = true;
     }
 
     @Override
@@ -602,7 +604,9 @@ public class DynamicAtlas extends BareAtlas
     {
         StreamIterable<V> result = Iterables.stream(entitiesSupplier.get())
                 .filter(Objects::nonNull);
-        while (!entitiesCovered(result, entityCoveredPredicate))
+        final boolean shouldStopExploring = this.policy.isDeferLoading()
+                && !this.policy.isExtendIndefinitely() && this.preemptiveLoadDone;
+        while (!shouldStopExploring && !entitiesCovered(result, entityCoveredPredicate))
         {
             result = Iterables.stream(entitiesSupplier.get()).filter(Objects::nonNull);
         }


### PR DESCRIPTION
### Description:

Atlas performance improvements:
- When a `MultiAtlas` underpinning a `DynamicAtlas` is already built from the same set of shards, avoid re-loading the `MultiAtlas`.
- Streamlined the lineContaining, edgeContaining and areaCovering methods in `AbstractAtlas` to be faster.
- Removed code smells in `BareAtlas`

### Potential Impact:

- `DynamicAtlas` creation should be faster when working with indefinite expansion disabled, and deferred loading enabled, and expansion beyond the initial shard set is not necessary.
- Raw Atlas way sectioning should be faster when assigning Raw Atlas Points to either Points or Nodes.

### Unit Test Approach:

- Added unit test for DynamicAtlas and MultiAtlas creation in `DynamicAtlasPreemptiveLoadTest`
- AbstractAtlas changes covered by `PackedAtlasTest.testLocationContaining`

### Test Results:

All unit/integration tests pass. Raw Atlas Way Sectioning is 9x faster on average.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)