### PR TITLE
WaySectionProcessor performance improvements

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -142,9 +142,9 @@ public class RawAtlasIntegrationTest
                 .edges(edge -> edge.getOsmIdentifier() == LINE_OSM_IDENTIFIER_CROSSING_3_SHARDS);
 
         // First look at absolute counts. Each shard will have two forward and reverse edges
-        Assert.assertEquals(8, Iterables.size(firstGroupOfEdges));
-        Assert.assertEquals(8, Iterables.size(secondGroupOfEdges));
-        Assert.assertEquals(8, Iterables.size(thirdGroupOfEdges));
+        Assert.assertEquals(4, Iterables.size(firstGroupOfEdges));
+        Assert.assertEquals(4, Iterables.size(secondGroupOfEdges));
+        Assert.assertEquals(4, Iterables.size(thirdGroupOfEdges));
 
         // Next, let's check identifier consistency
         final Set<Long> uniqueIdentifiers = new HashSet<>();
@@ -168,9 +168,9 @@ public class RawAtlasIntegrationTest
         Assert.assertTrue(piece3from123.asPolyLine().equals(piece3from62.asPolyLine()));
 
         // Let's validate absolute number of edges in each shard
-        Assert.assertEquals(38, atlasFromz8x123y122.numberOfEdges());
-        Assert.assertEquals(38, atlasFromz8x123y123.numberOfEdges());
-        Assert.assertEquals(38, atlasFromz7x62y61.numberOfEdges());
+        Assert.assertEquals(12, atlasFromz8x123y122.numberOfEdges());
+        Assert.assertEquals(16, atlasFromz8x123y123.numberOfEdges());
+        Assert.assertEquals(20, atlasFromz7x62y61.numberOfEdges());
     }
 
     @Test
@@ -276,9 +276,8 @@ public class RawAtlasIntegrationTest
 
         final Atlas finalAtlas = new WaySectionProcessor(new SlippyTile(122, 122, 8),
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
-                        .getResource(
-                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
+                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
 
@@ -353,9 +352,8 @@ public class RawAtlasIntegrationTest
     {
         return new WaySectionProcessor(shard,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
-                        .getResource(
-                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
+                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
     }

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -282,11 +282,11 @@ public class RawAtlasIntegrationTest
                         .getFile())),
                 rawAtlasFetcher).run();
 
-        Assert.assertEquals(5011, finalAtlas.numberOfNodes());
-        Assert.assertEquals(9764, finalAtlas.numberOfEdges());
-        Assert.assertEquals(5128, finalAtlas.numberOfAreas());
+        Assert.assertEquals(5009, finalAtlas.numberOfNodes());
+        Assert.assertEquals(9760, finalAtlas.numberOfEdges());
+        Assert.assertEquals(5126, finalAtlas.numberOfAreas());
         Assert.assertEquals(184, finalAtlas.numberOfPoints());
-        Assert.assertEquals(326, finalAtlas.numberOfLines());
+        Assert.assertEquals(271, finalAtlas.numberOfLines());
         Assert.assertEquals(14, finalAtlas.numberOfRelations());
     }
 

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -276,8 +276,9 @@ public class RawAtlasIntegrationTest
 
         final Atlas finalAtlas = new WaySectionProcessor(new SlippyTile(122, 122, 8),
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
-                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
+                        .getResource(
+                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
 
@@ -352,8 +353,9 @@ public class RawAtlasIntegrationTest
     {
         return new WaySectionProcessor(shard,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
-                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
+                        .getResource(
+                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
     }

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -142,9 +142,9 @@ public class RawAtlasIntegrationTest
                 .edges(edge -> edge.getOsmIdentifier() == LINE_OSM_IDENTIFIER_CROSSING_3_SHARDS);
 
         // First look at absolute counts. Each shard will have two forward and reverse edges
-        Assert.assertTrue(Iterables.size(firstGroupOfEdges) == 4);
-        Assert.assertTrue(Iterables.size(secondGroupOfEdges) == 4);
-        Assert.assertTrue(Iterables.size(thirdGroupOfEdges) == 4);
+        Assert.assertEquals(8, Iterables.size(firstGroupOfEdges));
+        Assert.assertEquals(8, Iterables.size(secondGroupOfEdges));
+        Assert.assertEquals(8, Iterables.size(thirdGroupOfEdges));
 
         // Next, let's check identifier consistency
         final Set<Long> uniqueIdentifiers = new HashSet<>();
@@ -168,9 +168,9 @@ public class RawAtlasIntegrationTest
         Assert.assertTrue(piece3from123.asPolyLine().equals(piece3from62.asPolyLine()));
 
         // Let's validate absolute number of edges in each shard
-        Assert.assertTrue(atlasFromz8x123y122.numberOfEdges() == 12);
-        Assert.assertTrue(atlasFromz8x123y123.numberOfEdges() == 16);
-        Assert.assertTrue(atlasFromz7x62y61.numberOfEdges() == 20);
+        Assert.assertEquals(38, atlasFromz8x123y122.numberOfEdges());
+        Assert.assertEquals(38, atlasFromz8x123y123.numberOfEdges());
+        Assert.assertEquals(38, atlasFromz7x62y61.numberOfEdges());
     }
 
     @Test
@@ -276,9 +276,8 @@ public class RawAtlasIntegrationTest
 
         final Atlas finalAtlas = new WaySectionProcessor(new SlippyTile(122, 122, 8),
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
-                        .getResource(
-                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
+                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
 
@@ -353,9 +352,8 @@ public class RawAtlasIntegrationTest
     {
         return new WaySectionProcessor(shard,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP),
-                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class
-                        .getResource(
-                                "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
+                new DynamicTileSharding(new File(ShardFileOverlapsPolygonTest.class.getResource(
+                        "/org/openstreetmap/atlas/geography/boundary/tree-6-14-100000.txt.gz")
                         .getFile())),
                 rawAtlasFetcher).run();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -639,19 +639,19 @@ public abstract class BareAtlas implements Atlas
         // would include only edges, but all the nodes would have to be pulled in. In that case, we
         // use the same size as the source Atlas, but we trim it at the end.
         final PackedAtlasBuilder builder = new PackedAtlasBuilder().withSizeEstimates(size())
-                .withMetaData(metaData());
+                .withMetaData(metaData()).withName(this.getName() + "_sub");
 
         // First, index all the nodes contained by relations and all start/stop nodes from edges
         // contained by relations
-        for (final AtlasEntity entity : relations(relation -> matcher.test(relation)))
+        for (final AtlasEntity entity : relations(matcher::test))
         {
             indexAllNodesFromRelation((Relation) entity, builder, 0);
         }
 
         // Next, index all the individual nodes and edge start/stop nodes coming from the predicate
-        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(item -> matcher.test(item)))
+        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(matcher::test))
                 .map(item -> (AtlasEntity) item);
-        final Iterable<AtlasEntity> edges = Iterables.stream(edges(item -> matcher.test(item)))
+        final Iterable<AtlasEntity> edges = Iterables.stream(edges(matcher::test))
                 .map(item -> (AtlasEntity) item);
         for (final AtlasEntity entity : new MultiIterable<>(nodes, edges))
         {
@@ -664,19 +664,19 @@ public abstract class BareAtlas implements Atlas
         // Similarly, Relations depend on all other entities to have been added, since they make up
         // the member list. For this pass, add all entities, except Relations, that match the given
         // Predicate to the builder.
-        for (final Edge edge : edges(item -> matcher.test(item)))
+        for (final Edge edge : edges(matcher::test))
         {
             indexEdge(edge, builder);
         }
-        for (final Area area : areas(item -> matcher.test(item)))
+        for (final Area area : areas(matcher::test))
         {
             builder.addArea(area.getIdentifier(), area.asPolygon(), area.getTags());
         }
-        for (final Line line : lines(item -> matcher.test(item)))
+        for (final Line line : lines(matcher::test))
         {
             builder.addLine(line.getIdentifier(), line.asPolyLine(), line.getTags());
         }
-        for (final Point point : points(item -> matcher.test(item)))
+        for (final Point point : points(matcher::test))
         {
             builder.addPoint(point.getIdentifier(), point.getLocation(), point.getTags());
         }
@@ -689,7 +689,7 @@ public abstract class BareAtlas implements Atlas
         // relation has been processed). This guarantees that anything we add to the index has all
         // of its members indexed already.
         Set<Long> stagedRelationIdentifiers = new HashSet<>();
-        final Iterable<Relation> relations = relations(item -> matcher.test(item));
+        final Iterable<Relation> relations = relations(matcher::test);
         for (final Relation relation : relations)
         {
             checkRelationMembersAndIndexRelation(relation, matcher, stagedRelationIdentifiers,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -639,19 +639,19 @@ public abstract class BareAtlas implements Atlas
         // would include only edges, but all the nodes would have to be pulled in. In that case, we
         // use the same size as the source Atlas, but we trim it at the end.
         final PackedAtlasBuilder builder = new PackedAtlasBuilder().withSizeEstimates(size())
-                .withMetaData(metaData()).withName(this.getName() + "_sub");
+                .withMetaData(metaData());
 
         // First, index all the nodes contained by relations and all start/stop nodes from edges
         // contained by relations
-        for (final AtlasEntity entity : relations(matcher::test))
+        for (final AtlasEntity entity : relations(relation -> matcher.test(relation)))
         {
             indexAllNodesFromRelation((Relation) entity, builder, 0);
         }
 
         // Next, index all the individual nodes and edge start/stop nodes coming from the predicate
-        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(matcher::test))
+        final Iterable<AtlasEntity> nodes = Iterables.stream(nodes(item -> matcher.test(item)))
                 .map(item -> (AtlasEntity) item);
-        final Iterable<AtlasEntity> edges = Iterables.stream(edges(matcher::test))
+        final Iterable<AtlasEntity> edges = Iterables.stream(edges(item -> matcher.test(item)))
                 .map(item -> (AtlasEntity) item);
         for (final AtlasEntity entity : new MultiIterable<>(nodes, edges))
         {
@@ -664,19 +664,19 @@ public abstract class BareAtlas implements Atlas
         // Similarly, Relations depend on all other entities to have been added, since they make up
         // the member list. For this pass, add all entities, except Relations, that match the given
         // Predicate to the builder.
-        for (final Edge edge : edges(matcher::test))
+        for (final Edge edge : edges(item -> matcher.test(item)))
         {
             indexEdge(edge, builder);
         }
-        for (final Area area : areas(matcher::test))
+        for (final Area area : areas(item -> matcher.test(item)))
         {
             builder.addArea(area.getIdentifier(), area.asPolygon(), area.getTags());
         }
-        for (final Line line : lines(matcher::test))
+        for (final Line line : lines(item -> matcher.test(item)))
         {
             builder.addLine(line.getIdentifier(), line.asPolyLine(), line.getTags());
         }
-        for (final Point point : points(matcher::test))
+        for (final Point point : points(item -> matcher.test(item)))
         {
             builder.addPoint(point.getIdentifier(), point.getLocation(), point.getTags());
         }
@@ -689,7 +689,7 @@ public abstract class BareAtlas implements Atlas
         // relation has been processed). This guarantees that anything we add to the index has all
         // of its members indexed already.
         Set<Long> stagedRelationIdentifiers = new HashSet<>();
-        final Iterable<Relation> relations = relations(matcher::test);
+        final Iterable<Relation> relations = relations(item -> matcher.test(item));
         for (final Relation relation : relations)
         {
             checkRelationMembersAndIndexRelation(relation, matcher, stagedRelationIdentifiers,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -513,22 +513,16 @@ public class WaySectionProcessor
     {
         try
         {
-            if (this.loadedShards.size() > 1)
-            {
-                // The first shard is always the initial one. Use its bounds to build the atlas.
-                final Rectangle originalShardBounds = this.loadedShards.get(0).bounds();
-                return atlas.subAtlas(originalShardBounds).get();
-            }
-            else
-            {
-                // We don't need to cut anything away, since no other shards were loaded
-                return atlas;
-            }
+            // The first shard is always the initial one. Use its bounds to build the atlas.
+            final Rectangle originalShardBounds = this.loadedShards.get(0).bounds();
+            return atlas.subAtlas(originalShardBounds)
+                    .orElseThrow(() -> new CoreException(
+                            "Cannot have an empty atlas after way sectioning {}",
+                            this.loadedShards.get(0).getName()));
         }
         catch (final Exception e)
         {
-            logger.error("Error creating sub-atlas for original shard bounds", e);
-            return null;
+            throw new CoreException("Error creating sub-atlas for original shard bounds", e);
         }
     }
 
@@ -1000,7 +994,8 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier) : 0;
+                                ? duplicateLocations.get(startIdentifier)
+                                : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1129,7 +1124,8 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 0;
+                                ? duplicateLocations.get(currentLocation)
+                                : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1155,9 +1151,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations
-                                        .containsKey(currentLocation)
-                                                ? duplicateLocations.get(currentLocation) : 0;
+                                final int duplicateCount = duplicateLocations.containsKey(
+                                        currentLocation) ? duplicateLocations.get(currentLocation)
+                                                : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1218,7 +1214,8 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 1;
+                                ? duplicateLocations.get(currentLocation)
+                                : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -513,12 +513,19 @@ public class WaySectionProcessor
     {
         try
         {
-            // The first shard is always the initial one. Use its bounds to build the atlas.
-            final Rectangle originalShardBounds = this.loadedShards.get(0).bounds();
-            return atlas.subAtlas(originalShardBounds)
-                    .orElseThrow(() -> new CoreException(
-                            "Cannot have an empty atlas after way sectioning {}",
-                            this.loadedShards.get(0).getName()));
+            if (!this.loadedShards.isEmpty())
+            {
+                // The first shard is always the initial one. Use its bounds to build the atlas.
+                final Rectangle originalShardBounds = this.loadedShards.get(0).bounds();
+                return atlas.subAtlas(originalShardBounds)
+                        .orElseThrow(() -> new CoreException(
+                                "Cannot have an empty atlas after way sectioning {}",
+                                this.loadedShards.get(0).getName()));
+            }
+            else
+            {
+                return atlas;
+            }
         }
         catch (final Exception e)
         {
@@ -994,7 +1001,8 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier) : 0;
+                                ? duplicateLocations.get(startIdentifier)
+                                : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1123,7 +1131,8 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 0;
+                                ? duplicateLocations.get(currentLocation)
+                                : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1149,9 +1158,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations
-                                        .containsKey(currentLocation)
-                                                ? duplicateLocations.get(currentLocation) : 0;
+                                final int duplicateCount = duplicateLocations.containsKey(
+                                        currentLocation) ? duplicateLocations.get(currentLocation)
+                                                : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1212,7 +1221,8 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 1;
+                                ? duplicateLocations.get(currentLocation)
+                                : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -1000,8 +1000,7 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier)
-                                : 0;
+                                ? duplicateLocations.get(startIdentifier) : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1130,8 +1129,7 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 0;
+                                ? duplicateLocations.get(currentLocation) : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1157,9 +1155,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations.containsKey(
-                                        currentLocation) ? duplicateLocations.get(currentLocation)
-                                                : 0;
+                                final int duplicateCount = duplicateLocations
+                                        .containsKey(currentLocation)
+                                                ? duplicateLocations.get(currentLocation) : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1220,8 +1218,7 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 1;
+                                ? duplicateLocations.get(currentLocation) : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -89,9 +89,7 @@ public class WaySectionProcessor
     private final List<Shard> loadedShards = new ArrayList<>();
 
     // Bring in all points that are part of any line that will become an edge
-    private final Predicate<AtlasEntity> pointPredicate = entity -> entity instanceof Point
-            && Iterables.stream(entity.getAtlas().linesContaining(((Point) entity).getLocation()))
-                    .anyMatch(this::isAtlasEdge);
+    private final Predicate<AtlasEntity> pointPredicate = entity -> entity instanceof Point;
 
     // TODO - we are pulling in all edges and their contained points in the shard. We can optimize
     // this further by only considering the edges crossing the shard boundary and their intersecting
@@ -244,19 +242,19 @@ public class WaySectionProcessor
                 final Optional<Atlas> possibleAtlas = rawAtlasFetcher.apply(shard);
                 logTaskAsInfo(SHARD_SPECIFIC_COMPLETED_TASK_MESSAGE, getShardOrAtlasName(),
                         ATLAS_FETCHING_TASK, shard.getName(), fetchTime.elapsedSince());
-
-                if (possibleAtlas.isPresent())
-                {
-                    this.loadedShards.add(shard);
-                    final Atlas atlas = possibleAtlas.get();
-                    final Time subAtlasTime = Time.now();
-                    final Optional<Atlas> subAtlas = atlas
-                            .subAtlas(this.dynamicAtlasExpansionFilter);
-                    logTaskAsInfo(SHARD_SPECIFIC_COMPLETED_TASK_MESSAGE, getShardOrAtlasName(),
-                            SUB_ATLAS_CUTTING_TASK, shard.getName(), subAtlasTime.elapsedSince());
-                    return subAtlas;
-                }
-                return Optional.empty();
+                return possibleAtlas;
+                // if (possibleAtlas.isPresent())
+                // {
+                // this.loadedShards.add(shard);
+                // final Atlas atlas = possibleAtlas.get();
+                // final Time subAtlasTime = Time.now();
+                // final Optional<Atlas> subAtlas = atlas
+                // .subAtlas(this.dynamicAtlasExpansionFilter);
+                // logTaskAsInfo(SHARD_SPECIFIC_COMPLETED_TASK_MESSAGE, getShardOrAtlasName(),
+                // SUB_ATLAS_CUTTING_TASK, shard.getName(), subAtlasTime.elapsedSince());
+                // return subAtlas;
+                // }
+                // return Optional.empty();
             }
         };
 
@@ -1002,7 +1000,8 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier) : 0;
+                                ? duplicateLocations.get(startIdentifier)
+                                : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1131,7 +1130,8 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 0;
+                                ? duplicateLocations.get(currentLocation)
+                                : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1157,9 +1157,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations
-                                        .containsKey(currentLocation)
-                                                ? duplicateLocations.get(currentLocation) : 0;
+                                final int duplicateCount = duplicateLocations.containsKey(
+                                        currentLocation) ? duplicateLocations.get(currentLocation)
+                                                : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1220,7 +1220,8 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation) : 1;
+                                ? duplicateLocations.get(currentLocation)
+                                : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -1015,8 +1015,7 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier)
-                                : 0;
+                                ? duplicateLocations.get(startIdentifier) : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1145,8 +1144,7 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 0;
+                                ? duplicateLocations.get(currentLocation) : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1172,9 +1170,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations.containsKey(
-                                        currentLocation) ? duplicateLocations.get(currentLocation)
-                                                : 0;
+                                final int duplicateCount = duplicateLocations
+                                        .containsKey(currentLocation)
+                                                ? duplicateLocations.get(currentLocation) : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1235,8 +1233,7 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 1;
+                                ? duplicateLocations.get(currentLocation) : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -741,9 +741,16 @@ public class WaySectionProcessor
     private boolean isAtlasPoint(final WaySectionChangeSet changeSet, final Point point)
     {
         final boolean hasExplicitOsmTags = pointHasExplicitOsmTags(point);
+
+        // We use the presence of explicit OSM tagging to determine if it's a point
+        if (hasExplicitOsmTags)
+        {
+            return true;
+        }
+
         final boolean isRelationMember = !point.relations().isEmpty();
 
-        if (isRelationMember && !hasExplicitOsmTags && !isAtlasNode(changeSet, point))
+        if (isRelationMember && !isAtlasNode(changeSet, point))
         {
             // When the OSM node is part of a relation, doesn't have explicit OSM tagging and is not
             // at an intersection (not an atlas node), then we want to create an atlas point so we
@@ -753,7 +760,7 @@ public class WaySectionProcessor
 
         final boolean isIsolatedNode = Iterables
                 .isEmpty(this.rawAtlas.linesContaining(point.getLocation()));
-        if (!isRelationMember && !hasExplicitOsmTags && isIsolatedNode)
+        if (!isRelationMember && isIsolatedNode)
         {
             // This is a special case - when an OSM node is not part of a relation, doesn't have
             // explicit OSM tagging and is not a part of an OSM way, then we want to bring it in as
@@ -761,8 +768,7 @@ public class WaySectionProcessor
             return true;
         }
 
-        // All other times, we use the presence of explicit OSM tagging to determine if it's a point
-        return hasExplicitOsmTags;
+        return false;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -994,8 +994,7 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier)
-                                : 0;
+                                ? duplicateLocations.get(startIdentifier) : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1124,8 +1123,7 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 0;
+                                ? duplicateLocations.get(currentLocation) : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1151,9 +1149,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations.containsKey(
-                                        currentLocation) ? duplicateLocations.get(currentLocation)
-                                                : 0;
+                                final int duplicateCount = duplicateLocations
+                                        .containsKey(currentLocation)
+                                                ? duplicateLocations.get(currentLocation) : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1214,8 +1212,7 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 1;
+                                ? duplicateLocations.get(currentLocation) : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -1001,8 +1001,7 @@ public class WaySectionProcessor
                         // Found a duplicate point, update the map and skip over it
                         final long startIdentifier = startNode.get().getIdentifier();
                         final int duplicateCount = duplicateLocations.containsKey(startIdentifier)
-                                ? duplicateLocations.get(startIdentifier)
-                                : 0;
+                                ? duplicateLocations.get(startIdentifier) : 0;
                         duplicateLocations.put(startIdentifier, duplicateCount + 1);
                         continue;
                     }
@@ -1131,8 +1130,7 @@ public class WaySectionProcessor
                     if (!endNode.isPresent() && !startNode.isPresent())
                     {
                         final int duplicateCount = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 0;
+                                ? duplicateLocations.get(currentLocation) : 0;
                         duplicateLocations.put(currentLocation, duplicateCount + 1);
                     }
 
@@ -1158,9 +1156,9 @@ public class WaySectionProcessor
                                     && polyline.get(index).equals(polyline.get(index - 1)))
                             {
                                 // Found a duplicate point, update the map and skip over it
-                                final int duplicateCount = duplicateLocations.containsKey(
-                                        currentLocation) ? duplicateLocations.get(currentLocation)
-                                                : 0;
+                                final int duplicateCount = duplicateLocations
+                                        .containsKey(currentLocation)
+                                                ? duplicateLocations.get(currentLocation) : 0;
                                 duplicateLocations.put(currentLocation, duplicateCount + 1);
                                 continue;
                             }
@@ -1221,8 +1219,7 @@ public class WaySectionProcessor
 
                         // Get the raw polyline from the last node to the last(first) location
                         final int endOccurence = duplicateLocations.containsKey(currentLocation)
-                                ? duplicateLocations.get(currentLocation)
-                                : 1;
+                                ? duplicateLocations.get(currentLocation) : 1;
                         final PolyLine rawPolylineFromLastNodeToLastLocation = polyline.between(
                                 polyline.get(startIndex),
                                 nodesToSectionAt.getOccurrence(startNode.get()) - 1,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -59,6 +59,9 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "wayExceedingSectioningLimit.atlas.txt")
     private Atlas wayExceedingSectioningLimit;
 
+    @TestAtlas(loadFromTextResource = "rawAtlasSpanningOutsideBoundary.atlas.txt")
+    private Atlas rawAtlasSpanningOutsideBoundary;
+
     public Atlas getBidirectionalRingAtlas()
     {
         return this.bidirectioalRingAtlas;
@@ -107,6 +110,11 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     public Atlas getOneWaySimpleLineAtlas()
     {
         return this.oneWaySimpleLine;
+    }
+
+    public Atlas getRawAtlasSpanningOutsideBoundary()
+    {
+        return this.rawAtlasSpanningOutsideBoundary;
     }
 
     public Atlas getReversedOneWayLineAtlas()

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/rawAtlasSpanningOutsideBoundary.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/rawAtlasSpanningOutsideBoundary.atlas.txt
@@ -1,0 +1,18 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+112429000000 && 7.0133271,-7.0304936:7.0128905,-7.0306545:7.0123688,-7.0304453 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || highway -> motorway || last_edit_version -> 1 || oneway -> yes
+112440000000 && 7.0128905,-7.0306545:7.0131088,-7.0316684:7.012832,-7.0324623:7.0130236,-7.0330041 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || highway -> motorway || last_edit_version -> 1 || oneway -> yes
+112452000000 && 7.0133697,-7.0323443:7.012832,-7.0324623:7.0122357,-7.0323121 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || highway -> motorway || last_edit_version -> 1 || oneway -> yes
+# Points
+112404000000 && 6.9272056,-6.7232943 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112427000000 && 7.0133271,-7.0304936 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112428000000 && 7.0128905,-7.0306545 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112430000000 && 7.0123688,-7.0304453 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112439000000 && 7.0131088,-7.0316684 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112441000000 && 7.012832,-7.0324623 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112449000000 && 7.0130236,-7.0330041 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112451000000 && 7.0133697,-7.0323443 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+112453000000 && 7.0122357,-7.0323121 && last_edit_user_name -> myself || last_edit_changeset -> 1 || last_edit_time -> 1513719782000 || last_edit_user_id -> 1 || last_edit_version -> 1
+# Relations


### PR DESCRIPTION
### Description:

- When the WaySectionProcessor expands to neighboring shards, using subAtlas was being slow for a minor gain in memory improvement. This PR disables it.
- Fixes an issue when after way sectioning, the data was not always cut along the shard borders, sometimes resulting extra load time
- Changed the dynamic atlas policy's expansion filter to remove a spatial index query on every point on the slicedRawAtlas files.

### Potential Impact:

- Slightly larger memory usage with WaySectionProcessor
- Faster way sectioning

### Unit Test Approach:

Added a new unit test for ensuring of the cut at the border.

<img width="790" alt="image" src="https://user-images.githubusercontent.com/1944860/44935338-23c04b00-ad25-11e8-9ac4-6972ac8d9bfa.png">

All other tests pass.

### Test Results:

The proper number of edges are excluded in the new unit test.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/1944860/44935450-9e896600-ad25-11e8-9836-568c17d8d43f.png">


------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)