### PR TITLE
Removing IsoCountry from country code assignment when merging relations

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -696,9 +696,23 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                         markRemovedMemberLineForDeletion(inner, relationIdentifier);
                     }
 
-                    // Set the proper country code
+                    // Get the proper country code
+                    final String countryCode;
+                    final Optional<String> possibleCountryCode = outer.getTag(ISOCountryTag.KEY);
+                    if (possibleCountryCode.isPresent())
+                    {
+                        countryCode = possibleCountryCode.get();
+                    }
+                    else
+                    {
+                        // At this point, all members are sliced and must have a country code
+                        throw new CoreException(
+                                "Relation {} contains member {} that is missing a country code",
+                                relationIdentifier, outer);
+                    }
+
                     CountryBoundaryMap.setGeometryProperty(exteriorRing, ISOCountryTag.KEY,
-                            ISOCountryTag.first(outer).get().getIso3CountryCode());
+                            countryCode);
 
                     // Create points, lines and update members
                     createNewLineMemberForRelation(exteriorRing, relationIdentifier,


### PR DESCRIPTION
### Description:

This is a left-over from https://github.com/osmlab/atlas/pull/112. Specifically, we were relying on `IsoCountryTag.first()` call, which relies on `IsoCounty` to get the correct iso3 country code. This would break in case of custom country boundary representations (counties, states, etc.). Instead, we're now relying on a `String` representation.

### Potential Impact:

None really - this will fix multipolygon relation merging for any instance of custom country boundary representations.

### Unit Test Approach:

N/A - this is already covered by a unit test, which passes before and after change. See `RelationSlicingTest`

### Test Results:

I tested this on a custom (non `IsoCountry`) country code and boundary file, which worked as expected.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
