### PR TITLE
Double precision in Distance

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -1181,7 +1181,8 @@ public final class PackedAtlas extends AbstractAtlas
         {
             final Distance distance1 = location.distanceTo(node1.getLocation());
             final Distance distance2 = location.distanceTo(node2.getLocation());
-            final long difference = distance2.asMillimeters() - distance1.asMillimeters();
+            final long difference = (long) distance2.asMillimeters()
+                    - (long) distance1.asMillimeters();
             if (difference > 0)
             {
                 return 1;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -1181,13 +1181,12 @@ public final class PackedAtlas extends AbstractAtlas
         {
             final Distance distance1 = location.distanceTo(node1.getLocation());
             final Distance distance2 = location.distanceTo(node2.getLocation());
-            final long difference = (long) distance2.asMillimeters()
-                    - (long) distance1.asMillimeters();
-            if (difference > 0)
+            final double difference = distance2.asMillimeters() - distance1.asMillimeters();
+            if (difference > 0.0)
             {
                 return 1;
             }
-            else if (difference < 0)
+            else if (difference < 0.0)
             {
                 return -1;
             }

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
@@ -34,7 +34,7 @@ public final class Distance implements Serializable
 
     private static final int DISTANCE_PRINTING_METERS_THRESHOLD = 1000;
 
-    private final long millimeters;
+    private final double millimeters;
 
     public static Distance feet(final double feet)
     {
@@ -58,7 +58,7 @@ public final class Distance implements Serializable
 
     public static Distance meters(final double meters)
     {
-        return Distance.millimeters((long) (meters * MILLIMETERS_PER_METER));
+        return Distance.millimeters(meters * MILLIMETERS_PER_METER);
     }
 
     public static Distance miles(final double miles)
@@ -66,7 +66,7 @@ public final class Distance implements Serializable
         return Distance.feet(miles * FEET_PER_MILE);
     }
 
-    public static Distance millimeters(final long millimeters)
+    public static Distance millimeters(final double millimeters)
     {
         return new Distance(millimeters);
     }
@@ -76,7 +76,7 @@ public final class Distance implements Serializable
         return Distance.meters(nauticalMiles * METERS_PER_NAUTICAL_MILE);
     }
 
-    private Distance(final long millimeters)
+    private Distance(final double millimeters)
     {
         if (millimeters < 0)
         {
@@ -102,7 +102,7 @@ public final class Distance implements Serializable
 
     public double asMeters()
     {
-        return (double) asMillimeters() / MILLIMETERS_PER_METER;
+        return asMillimeters() / MILLIMETERS_PER_METER;
     }
 
     public double asMiles()
@@ -110,7 +110,7 @@ public final class Distance implements Serializable
         return asFeet() / FEET_PER_MILE;
     }
 
-    public long asMillimeters()
+    public double asMillimeters()
     {
         return this.millimeters;
     }
@@ -138,7 +138,7 @@ public final class Distance implements Serializable
     @Override
     public int hashCode()
     {
-        return Long.hashCode(this.millimeters);
+        return Double.hashCode(this.millimeters);
     }
 
     public boolean isGreaterThan(final Distance that)
@@ -178,7 +178,7 @@ public final class Distance implements Serializable
 
     public Distance substract(final Distance that)
     {
-        final long delta = this.asMillimeters() - that.asMillimeters();
+        final double delta = this.asMillimeters() - that.asMillimeters();
         return Distance.millimeters(Math.max(delta, 0));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/DistanceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/DistanceTest.java
@@ -22,7 +22,7 @@ public class DistanceTest
     public void testConversion()
     {
         final Distance tenMiles = Distance.miles(10);
-        Assert.assertEquals(16093440, tenMiles.asMillimeters());
+        Assert.assertEquals(16093440.0, tenMiles.asMillimeters(), 5);
         Assert.assertEquals(52800.0, tenMiles.asFeet(), 0);
         Assert.assertEquals(16.09344, tenMiles.asKilometers(), 0);
         Assert.assertEquals(8.6897624, tenMiles.asNauticalMiles(), 1e-7);

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/SpeedTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/SpeedTest.java
@@ -30,7 +30,7 @@ public class SpeedTest
         // initialization methods you choose
         Assert.assertFalse(
                 Speed.kilometersPerHour(1.000009).isSlowerThan(Speed.kilometersPerHour(1.000008)));
-        Assert.assertTrue(Speed.kilometersPerHour(1.000009)
+        Assert.assertFalse(Speed.kilometersPerHour(1.000009)
                 .isSlowerThanOrEqualTo(Speed.kilometersPerHour(1.000008)));
     }
 
@@ -43,11 +43,20 @@ public class SpeedTest
     }
 
     @Test
+    public void testDuration()
+    {
+        final Speed speed = Speed.metersPerSecond(3.0);
+        final Distance distance = Distance.meters(6.0);
+        Assert.assertEquals(Duration.seconds(2.0), speed.asDuration(distance));
+    }
+
+    @Test
     public void testEquals()
     {
         Assert.assertEquals(Speed.kilometersPerHour(9.999999), Speed.kilometersPerHour(9.999999));
         Assert.assertNotEquals(Speed.kilometersPerHour(9.99999), Speed.kilometersPerHour(9.99998));
-        Assert.assertEquals(Speed.kilometersPerHour(9.9999999), Speed.kilometersPerHour(9.9999998));
+        Assert.assertNotEquals(Speed.kilometersPerHour(9.9999999),
+                Speed.kilometersPerHour(9.9999998));
     }
 
     @Test
@@ -61,13 +70,5 @@ public class SpeedTest
                 Speed.kilometersPerHour(50));
         Assert.assertEquals(Speed.kilometersPerHour(50).subtract(Speed.kilometersPerHour(100)),
                 Speed.kilometersPerHour(0));
-    }
-
-    @Test
-    public void testDuration()
-    {
-        final Speed speed = Speed.metersPerSecond(3.0);
-        final Distance distance = Distance.meters(6.0);
-        Assert.assertEquals(Duration.seconds(2.0), speed.asDuration(distance));
     }
 }


### PR DESCRIPTION
### Description:

Underpin `Distance` with a `double` instead of a `long` when storing the value as millimeters.

### Potential Impact:

This changes the `asMillimeters` API to return a `double`. This would allow distance calculations to not lose precision due to rounding to the closest millimeter.

### Unit Test Approach:

Updated unit tests and also ran all integration tests. Also tried generating Atlas files using `AtlasGenerator` in https://github.com/osmlab/atlas-generator and those look good.

### Test Results:

Atlas files look good and all unit tests and integration tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)