### PR TITLE
DNM: Fixed a bug in BareAtlas.relationsLowerOrderFirst() that broke DynamicAtlas

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -287,7 +287,15 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(5126, finalAtlas.numberOfAreas());
         Assert.assertEquals(184, finalAtlas.numberOfPoints());
         Assert.assertEquals(271, finalAtlas.numberOfLines());
-        Assert.assertEquals(14, finalAtlas.numberOfRelations());
+
+        /*
+         * This has been updated to 16 instead of 14. This is because two of the relations in
+         * 8-122-122-trimmed.osm.pbf have subrelations, and so the WaySectionProcessor was simply
+         * dropping them when using the old BareAtlas.relationsLowerOrderFirstCode (We have now
+         * fixed BareAtlas.relationsLowerOrderFirst to not drop relations when the BareAtlas is a
+         * DynamicAtlas). In reality, we should process them and include then in the final atlas.
+         */
+        Assert.assertEquals(16, finalAtlas.numberOfRelations());
     }
 
     @Test

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -291,9 +291,9 @@ public class RawAtlasIntegrationTest
         /*
          * This has been updated to 16 instead of 14. This is because two of the relations in
          * 8-122-122-trimmed.osm.pbf have subrelations, and so the WaySectionProcessor was simply
-         * dropping them when using the old BareAtlas.relationsLowerOrderFirstCode (We have now
-         * fixed BareAtlas.relationsLowerOrderFirst to not drop relations when the BareAtlas is a
-         * DynamicAtlas). In reality, we should process them and include then in the final atlas.
+         * dropping them when using the old BareAtlas.relationsLowerOrderFirst (We have now fixed
+         * BareAtlas.relationsLowerOrderFirst to not drop relations when the BareAtlas is a
+         * DynamicAtlas). In reality, we should process them and include them in the final atlas.
          */
         Assert.assertEquals(16, finalAtlas.numberOfRelations());
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -420,55 +420,6 @@ public abstract class BareAtlas implements Atlas
                     {
                         if (!result.contains(member.getEntity()))
                         {
-                            if (relation.getIdentifier() == 33L
-                                    && member.getEntity().getIdentifier() == 31L)
-                            {
-                                Relation fromResult = null;
-                                Relation fromMember = null;
-                                for (final AtlasEntity relationInResult : result)
-                                {
-                                    if (relationInResult.getIdentifier() == 31L)
-                                    {
-                                        fromResult = (Relation) relationInResult;
-                                    }
-                                }
-                                fromMember = (Relation) member.getEntity();
-                                if (fromResult != null && fromMember != null)
-                                {
-                                    logger.error(
-                                            "----------------------------------------------------------------------------------------------------");
-                                    logger.error(
-                                            "BAREATLAS relationsLowerOrderFirst DIAGNOSTIC DEBUG MESSAGE SECTION");
-                                    logger.error("fromResult:\n{}",
-                                            fromResult.toDiffViewFriendlyString());
-                                    logger.error("fromMember:\n{}",
-                                            fromMember.toDiffViewFriendlyString());
-                                    logger.error("fromResult hashCode: {}, fromMember hashCode: {}",
-                                            fromResult.hashCode(), fromMember.hashCode());
-                                    logger.error("fromResult class: {}, fromMember class: {}",
-                                            fromResult.getClass(), fromMember.getClass());
-                                    logger.error("fromResult.equals(fromMember): {}",
-                                            fromResult.equals(fromMember));
-                                    logger.error(
-                                            "fromResult.parentAtlas == fromMember.parentAtlas: {}",
-                                            fromResult.getAtlas() == fromMember.getAtlas());
-                                    logger.error(
-                                            "fromResult.parentAtlas class: {}, fromMember.parentAtlas class: {}",
-                                            fromResult.getAtlas().getClass(),
-                                            fromMember.getAtlas().getClass());
-                                    logger.error(
-                                            "fromResult.parentAtlas hashcode: {}, fromMember.parentAtlas hashcode: {}",
-                                            fromResult.getAtlas().hashCode(),
-                                            fromMember.getAtlas().hashCode());
-                                    logger.error(
-                                            "fromResult.getIdentifier: {}, fromMember.getIdentifier: {}",
-                                            fromResult.getIdentifier(), fromMember.getIdentifier());
-                                    logger.error("fromResult.getType: {}, fromMember.getType: {}",
-                                            fromResult.getType(), fromMember.getType());
-                                    logger.error(
-                                            "----------------------------------------------------------------------------------------------------");
-                                }
-                            }
                             stageable = true;
                         }
                     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -394,12 +394,11 @@ public abstract class BareAtlas implements Atlas
         for (final Relation relation : relations())
         {
             boolean hasUnprocessedMemberRelations = false;
-            final RelationMemberList members = relation.members();
-            for (final RelationMember member : members)
+            for (final RelationMember member : relation.members())
             {
                 /*
                  * We cannot process this relation in the first pass, since it has some member
-                 * relations which have not yet been processed.
+                 * relations which possibly have not yet been processed.
                  */
                 if (member.getEntity() instanceof Relation)
                 {
@@ -428,8 +427,9 @@ public abstract class BareAtlas implements Atlas
             for (final Relation relationA : relationsRemainingToProcess)
             {
                 /*
-                 * By default, we assume that a relation does not have unprocessed member relations.
-                 * The rest of the code in this loop will attempt to disprove this assumption.
+                 * By default, we assume that a relation (relation A) does not have unprocessed
+                 * member relations. The rest of the code in this loop will attempt to disprove this
+                 * assumption.
                  */
                 boolean hasUnprocessedMemberRelations = false;
                 for (final RelationMember member : relationA.members())

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -420,6 +420,55 @@ public abstract class BareAtlas implements Atlas
                     {
                         if (!result.contains(member.getEntity()))
                         {
+                            if (relation.getIdentifier() == 33L
+                                    && member.getEntity().getIdentifier() == 31L)
+                            {
+                                Relation fromResult = null;
+                                Relation fromMember = null;
+                                for (final AtlasEntity relationInResult : result)
+                                {
+                                    if (relationInResult.getIdentifier() == 31L)
+                                    {
+                                        fromResult = (Relation) relationInResult;
+                                    }
+                                }
+                                fromMember = (Relation) member.getEntity();
+                                if (fromResult != null && fromMember != null)
+                                {
+                                    logger.error(
+                                            "----------------------------------------------------------------------------------------------------");
+                                    logger.error(
+                                            "BAREATLAS relationsLowerOrderFirst DIAGNOSTIC DEBUG MESSAGE SECTION");
+                                    logger.error("fromResult:\n{}",
+                                            fromResult.toDiffViewFriendlyString());
+                                    logger.error("fromMember:\n{}",
+                                            fromMember.toDiffViewFriendlyString());
+                                    logger.error("fromResult hashCode: {}, fromMember hashCode: {}",
+                                            fromResult.hashCode(), fromMember.hashCode());
+                                    logger.error("fromResult class: {}, fromMember class: {}",
+                                            fromResult.getClass(), fromMember.getClass());
+                                    logger.error("fromResult.equals(fromMember): {}",
+                                            fromResult.equals(fromMember));
+                                    logger.error(
+                                            "fromResult.parentAtlas == fromMember.parentAtlas: {}",
+                                            fromResult.getAtlas() == fromMember.getAtlas());
+                                    logger.error(
+                                            "fromResult.parentAtlas class: {}, fromMember.parentAtlas class: {}",
+                                            fromResult.getAtlas().getClass(),
+                                            fromMember.getAtlas().getClass());
+                                    logger.error(
+                                            "fromResult.parentAtlas hashcode: {}, fromMember.parentAtlas hashcode: {}",
+                                            fromResult.getAtlas().hashCode(),
+                                            fromMember.getAtlas().hashCode());
+                                    logger.error(
+                                            "fromResult.getIdentifier: {}, fromMember.getIdentifier: {}",
+                                            fromResult.getIdentifier(), fromMember.getIdentifier());
+                                    logger.error("fromResult.getType: {}, fromMember.getType: {}",
+                                            fromResult.getType(), fromMember.getType());
+                                    logger.error(
+                                            "----------------------------------------------------------------------------------------------------");
+                                }
+                            }
                             stageable = true;
                         }
                     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -416,11 +416,14 @@ public abstract class BareAtlas implements Atlas
         while (!relationsRemainingToProcess.isEmpty() && depth < MAXIMUM_RELATION_DEPTH)
         {
             final List<Relation> updatedRelationsRemainingToProcess = new ArrayList<>();
-            for (final Relation relation : relationsRemainingToProcess)
+            for (final Relation relationA : relationsRemainingToProcess)
             {
+                /*
+                 * By default, we assume that a relation does not need to be processed. The rest of
+                 * the code in this loop will attempt to disprove this assumption.
+                 */
                 boolean needToProcess = false;
-                final RelationMemberList members = relation.members();
-                for (final RelationMember member : members)
+                for (final RelationMember member : relationA.members())
                 {
                     if (member.getEntity() instanceof Relation)
                     {
@@ -429,8 +432,9 @@ public abstract class BareAtlas implements Atlas
                          * another relation (relation B) as a member. We check our processed map to
                          * see if we already processed relation B.
                          */
-                        final Relation processedRelationWithEquivalentIdentifierToMember = processedRelationsMap
-                                .get(member.getEntity().getIdentifier());
+                        final Relation relationB = (Relation) member.getEntity();
+                        final Relation processedRelationWithEquivalentIdentifierToRelationB = processedRelationsMap
+                                .get(relationB.getIdentifier());
 
                         /*
                          * If we found relation B's ID in our processed map, we now just check to
@@ -440,9 +444,9 @@ public abstract class BareAtlas implements Atlas
                          * atlas references. In the case that we are operating on a DynamicAtlas, it
                          * is not guaranteed that these parent atlases will be equivalent.
                          */
-                        final boolean memberRelationWasAlreadyProcessed = processedRelationWithEquivalentIdentifierToMember != null
-                                ? processedRelationWithEquivalentIdentifierToMember
-                                        .isCongruentWith(member.getEntity())
+                        final boolean memberRelationWasAlreadyProcessed = processedRelationWithEquivalentIdentifierToRelationB != null
+                                ? processedRelationWithEquivalentIdentifierToRelationB
+                                        .isCongruentWith(relationB)
                                 : false;
                         if (!memberRelationWasAlreadyProcessed)
                         {
@@ -463,11 +467,11 @@ public abstract class BareAtlas implements Atlas
                 }
                 if (needToProcess)
                 {
-                    updatedRelationsRemainingToProcess.add(relation);
+                    updatedRelationsRemainingToProcess.add(relationA);
                 }
                 else
                 {
-                    processedRelationsMap.put(relation.getIdentifier(), relation);
+                    processedRelationsMap.put(relationA.getIdentifier(), relationA);
                 }
             }
             relationsRemainingToProcess = updatedRelationsRemainingToProcess;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -6,9 +6,9 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -385,7 +385,7 @@ public abstract class BareAtlas implements Atlas
     public Iterable<Relation> relationsLowerOrderFirst()
     {
         List<Relation> relationsRemainingToProcess = new ArrayList<>();
-        final Map<Long, Relation> processedRelationsMap = new HashMap<>();
+        final Map<Long, Relation> processedRelationsMap = new LinkedHashMap<>();
         // First pass
         for (final Relation relation : relations())
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -15,6 +15,8 @@ import org.openstreetmap.atlas.tags.LastEditUserNameTag;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.scalars.Duration;
 import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A located entity with tags
@@ -25,6 +27,8 @@ import org.openstreetmap.atlas.utilities.time.Time;
  */
 public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
 {
+    private static final Logger logger = LoggerFactory.getLogger(AtlasEntity.class);
+
     private static final long serialVersionUID = -6072525057489468736L;
 
     // The atlas this item belongs to

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -85,17 +85,17 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
     @Override
     public boolean equals(final Object other)
     {
-        if (this == other)
+        final AtlasEntity otherEntity = (AtlasEntity) other;
+        if (this == otherEntity)
         {
             return true;
         }
-        if (other != null && this.getClass() == other.getClass())
+        if (otherEntity != null && this.getType() == otherEntity.getType())
         {
-            final AtlasEntity that = (AtlasEntity) other;
             // Do not call atlas.equals() which would browse all the items and create a stack
             // overflow
-            return this.getAtlas() == that.getAtlas()
-                    && this.getIdentifier() == that.getIdentifier();
+            return this.getAtlas() == otherEntity.getAtlas()
+                    && this.getIdentifier() == otherEntity.getIdentifier();
         }
         return false;
     }
@@ -123,7 +123,7 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
     @Override
     public int hashCode()
     {
-        return new HashCodeBuilder().append(getIdentifier()).append(getClass()).hashCode();
+        return new HashCodeBuilder().append(getIdentifier()).append(getType()).hashCode();
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -132,8 +132,7 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
     public int hashCode()
     {
         /*
-         * Here we hash the ItemType, not the class. This is because if the AtlasEntities being
-         * compared are coming from a DynamicAtlas, they are not guaranteed to have the same class.
+         * Here we hash the ItemType, not the class. See the notes in equals() for details.
          */
         return new HashCodeBuilder().append(getIdentifier()).append(getType()).hashCode();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -143,6 +143,30 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
     public abstract boolean intersects(GeometricSurface surface);
 
     /**
+     * Check if this {@link AtlasEntity} is congruent with another {@link AtlasEntity}. Two
+     * {@link AtlasEntity} are considered congruent if and only if they have the same identifier and
+     * the same {@link ItemType}. This differs from the equality check, which also takes into
+     * account the parent {@link Atlas} of the entity.
+     *
+     * @param otherEntity
+     *            the {@link AtlasEntity} with which to compare
+     * @return if the two entities are congruent
+     */
+    public boolean isCongruentWith(final AtlasEntity otherEntity)
+    {
+        if (this == otherEntity)
+        {
+            return true;
+        }
+        if (otherEntity != null)
+        {
+            return this.getType() == otherEntity.getType()
+                    && this.getIdentifier() == otherEntity.getIdentifier();
+        }
+        return false;
+    }
+
+    /**
      * @return If available, the {@link Time} at which the entity was last edited.
      */
     public Optional<Time> lastEdit()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -94,6 +94,10 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
         {
             return true;
         }
+        /*
+         * Here we check the ItemType, not the class. This is because if the AtlasEntities being
+         * compared are coming from a DynamicAtlas, they are not guaranteed to have the same class.
+         */
         if (otherEntity != null && this.getType() == otherEntity.getType())
         {
             // Do not call atlas.equals() which would browse all the items and create a stack
@@ -127,6 +131,10 @@ public abstract class AtlasEntity implements AtlasObject, DiffViewFriendlyItem
     @Override
     public int hashCode()
     {
+        /*
+         * Here we hash the ItemType, not the class. This is because if the AtlasEntities being
+         * compared are coming from a DynamicAtlas, they are not guaranteed to have the same class.
+         */
         return new HashCodeBuilder().append(getIdentifier()).append(getType()).hashCode();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -1,8 +1,10 @@
 package org.openstreetmap.atlas.geography.atlas.dynamic;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.junit.Assert;
@@ -11,21 +13,28 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.BareAtlas;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
 import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasTestRule;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiRelation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
  */
 public class DynamicAtlasTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(DynamicAtlasTest.class);
+
     @Rule
     public DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
 
@@ -241,6 +250,60 @@ public class DynamicAtlasTest
         Assert.assertEquals(2, relation3.members().size());
         Assert.assertEquals(8, this.dynamicAtlas.numberOfEdges());
 
+    }
+
+    /**
+     * Check to make sure that {@link Atlas#relationsLowerOrderFirst()} works when the {@link Atlas}
+     * is a {@link DynamicAtlas}. In older versions of the code, any relations that had members
+     * which were also relations would be dropped from the set returned by
+     * {@link BareAtlas#relationsLowerOrderFirst()}. This was due to a flaw in the membership
+     * assumptions made by {@link BareAtlas#relationsLowerOrderFirst()}, which assumed that
+     * relations in the main {@link DynamicAtlas} and their equivalent representation as a member
+     * {@link AtlasEntity} of another relation in the same {@link DynamicAtlas} were of consistent
+     * types. However, this was not the case. (The former representation would be of type
+     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation}). This has now
+     * been fixed, so this test should always pass.
+     */
+    @Test
+    public void testRelationsLowerOrderFirstConsistency()
+    {
+        final DynamicAtlas localDynamicAtlas;
+        final Map<Shard, Atlas> localStore = new HashMap<>();
+        localStore.put(new SlippyTile(0, 0, 0), this.rule.getAtlasForRelationsTest());
+        final Supplier<DynamicAtlasPolicy> localPolicySupplier = () -> new DynamicAtlasPolicy(
+                shard ->
+                {
+                    if (localStore.containsKey(shard))
+                    {
+                        return Optional.of(localStore.get(shard));
+                    }
+                    else
+                    {
+                        return Optional.empty();
+                    }
+                }, new SlippyTileSharding(0), new SlippyTile(0, 0, 0), Rectangle.MAXIMUM);
+        localDynamicAtlas = new DynamicAtlas(localPolicySupplier.get());
+
+        final Set<Relation> returnedByRelations = new HashSet<>();
+        final Set<Relation> returnedByRelationsLowerOrderFirst = new HashSet<>();
+
+        for (final Relation relation : localDynamicAtlas.relations())
+        {
+            returnedByRelations.add(relation);
+        }
+
+        for (final Relation relation : localDynamicAtlas.relationsLowerOrderFirst())
+        {
+            returnedByRelationsLowerOrderFirst.add(relation);
+        }
+
+        // Assert that their sizes equal, if not then we can fail fast
+        Assert.assertEquals(returnedByRelations.size(),
+                returnedByRelationsLowerOrderFirst.size());
+
+        // Now that we know they have equal sizes, check member equality
+        Assert.assertEquals(returnedByRelations,
+                returnedByRelationsLowerOrderFirst);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -21,6 +21,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiRelation;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedRelation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -261,8 +262,8 @@ public class DynamicAtlasTest
      * relations in the main {@link DynamicAtlas} and their equivalent representation as a member
      * {@link AtlasEntity} of another relation in the same {@link DynamicAtlas} were of consistent
      * types. However, this was not the case. (The former representation would be of type
-     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation}). This has now
-     * been fixed, so this test should always pass.
+     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation} or
+     * {@link PackedRelation}). This has now been fixed, so this test should always pass.
      */
     @Test
     public void testRelationsLowerOrderFirstConsistency()
@@ -298,12 +299,10 @@ public class DynamicAtlasTest
         }
 
         // Assert that their sizes equal, if not then we can fail fast
-        Assert.assertEquals(returnedByRelations.size(),
-                returnedByRelationsLowerOrderFirst.size());
+        Assert.assertEquals(returnedByRelations.size(), returnedByRelationsLowerOrderFirst.size());
 
         // Now that we know they have equal sizes, check member equality
-        Assert.assertEquals(returnedByRelations,
-                returnedByRelationsLowerOrderFirst);
+        Assert.assertEquals(returnedByRelations, returnedByRelationsLowerOrderFirst);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasTestRule.java
@@ -349,9 +349,80 @@ public class DynamicAtlasTestRule extends CoreTestRule
     )
     private Atlas atlasz12x1349y1870;
 
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "10", coordinates = @Loc(value = ONE)),
+                    @Node(id = "11", coordinates = @Loc(value = SIX)),
+                    @Node(id = "12", coordinates = @Loc(value = SEVEN)),
+                    @Node(id = "13", coordinates = @Loc(value = EIGHT))
+
+            },
+
+            relations = {
+
+                    @Relation(id = "31", tags = { "type=relation" }, members = {
+
+                            @Member(id = "11", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "32", tags = { "type=relation" }, members = {
+
+                            @Member(id = "12", role = "a", type = "node"),
+
+                            @Member(id = "13", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "33", tags = { "type=relation" }, members = {
+
+                            @Member(id = "10", role = "a", type = "node"),
+
+                            @Member(id = "11", role = "a", type = "node"),
+
+                            @Member(id = "31", role = "b", type = "relation")
+
+                    }),
+
+                    @Relation(id = "34", tags = { "type=relation" }, members = {
+
+                            @Member(id = "10", role = "a", type = "node"),
+
+                            @Member(id = "13", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "35", tags = { "type=relation" }, members = {
+
+                            @Member(id = "11", role = "a", type = "node"),
+
+                            @Member(id = "12", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "36", tags = { "type=relation" }, members = {
+
+                            @Member(id = "12", role = "a", type = "node"),
+
+                            @Member(id = "34", role = "a", type = "relation")
+
+                    }),
+
+            }
+
+    )
+    private Atlas atlasForRelationsTest;
+
     public Atlas getAtlas()
     {
         return this.atlas;
+    }
+
+    public Atlas getAtlasForRelationsTest()
+    {
+        return this.atlasForRelationsTest;
     }
 
     public Atlas getAtlasz12x1349y1869()


### PR DESCRIPTION
### Description:

Previously, the interaction between `BareAtlas`, `AtlasEntity`, and `DynamicAtlas` was broken in the following way:

If you had a `DynamicAtlas` containing some relation `R` that contained at least one other relation `R'` as a member, calling `DynamicAtlas.relationsLowerOrderFirst()` (which used the implementation in `BareAtlas`) would drop relation `R` from the returned set.

This was due to a faulty `AtlasEntity` equality assumption made by `relationsLowerOrderFirst()` which did not hold in the case of `DynamicAtlas`. This has now been fixed using a new "congruency" concept. See `AtlasEntity.isCongruentWith()` for more details.

### Potential Impact:

The broken version of `BareAtlas.relationsLowerOrderFirst()` was negatively impacting the functionality of `WaySectionProcessor` (the raw atlas version), which depends on `DynamicAtlas` and proper functionality of this method to work. Before the bug fix, the `WaySectionProcessor` would drop any relation which had at least one relation as a member (in the case that it had utilized a `DynamicAtlas` to expand into neighboring shards). I was able to detect this near shard boundaries using a `MultiAtlas`, but it presumably was occurring in shard interiors as well.

### Unit Test Approach:

I have added `DynamicAtlasTest.testRelationsLowerOrderFirstConsistency()`, which demonstrates the case in which the bug would occur. It utilizes a new test atlas, `DynamicAtlasTestRule.atlasForRelationsTest`, which is designed to trigger the bug. With the fix, this unit test now passes.

`RawAtlasIntegrationTest.testSectioningFromShard()` was also affected. In the previous code version, it was dropping two relations from the build, and the test was assuming that those two relations did not exist (when in reality they had actually just been dropped by the `WaySectionProcessor`). The test is updated, and passes with the bug fix in place.

### Test Results:

I am planning on doing more extensive testing before deciding this is ready for merge. Please reach out to me to discuss.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)