### PR TITLE
Fixed a bug in DynamicRelation.members() that broke BareAtlas.relationsLowerOrderFirst()

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -287,7 +287,15 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(5126, finalAtlas.numberOfAreas());
         Assert.assertEquals(184, finalAtlas.numberOfPoints());
         Assert.assertEquals(271, finalAtlas.numberOfLines());
-        Assert.assertEquals(14, finalAtlas.numberOfRelations());
+
+        /*
+         * This has been updated to 16 instead of 14. This is because two of the relations in
+         * 8-122-122-trimmed.osm.pbf have subrelations, and so the WaySectionProcessor was simply
+         * dropping them when using the old BareAtlas.relationsLowerOrderFirstCode (We have now
+         * fixed BareAtlas.relationsLowerOrderFirst to not drop relations when the BareAtlas is a
+         * DynamicAtlas). In reality, we should process them and include then in the final atlas.
+         */
+        Assert.assertEquals(16, finalAtlas.numberOfRelations());
     }
 
     @Test

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
@@ -7,12 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
-import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
-import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.geography.atlas.items.Line;
-import org.openstreetmap.atlas.geography.atlas.items.Node;
-import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
@@ -73,33 +68,28 @@ public class DynamicRelation extends Relation
         {
             final AtlasEntity entity = member.getEntity();
             AtlasEntity dynamicEntity = null;
-            if (entity instanceof Node)
+            switch (entity.getType())
             {
-                dynamicEntity = new DynamicNode(dynamicAtlas(), entity.getIdentifier());
-            }
-            else if (entity instanceof Edge)
-            {
-                dynamicEntity = new DynamicEdge(dynamicAtlas(), entity.getIdentifier());
-            }
-            else if (entity instanceof Point)
-            {
-                dynamicEntity = new DynamicPoint(dynamicAtlas(), entity.getIdentifier());
-            }
-            else if (entity instanceof Line)
-            {
-                dynamicEntity = new DynamicLine(dynamicAtlas(), entity.getIdentifier());
-            }
-            else if (entity instanceof Area)
-            {
-                dynamicEntity = new DynamicArea(dynamicAtlas(), entity.getIdentifier());
-            }
-            else if (entity instanceof Relation)
-            {
-                dynamicEntity = new DynamicRelation(dynamicAtlas(), entity.getIdentifier());
-            }
-            else
-            {
-                throw new CoreException("Invalid entity type {}", entity.getClass().getName());
+                case NODE:
+                    dynamicEntity = new DynamicNode(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                case EDGE:
+                    dynamicEntity = new DynamicEdge(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                case POINT:
+                    dynamicEntity = new DynamicPoint(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                case LINE:
+                    dynamicEntity = new DynamicLine(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                case AREA:
+                    dynamicEntity = new DynamicArea(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                case RELATION:
+                    dynamicEntity = new DynamicRelation(dynamicAtlas(), entity.getIdentifier());
+                    break;
+                default:
+                    throw new CoreException("Invalid entity type {}", entity.getType());
             }
             newMemberList.add(new RelationMember(member.getRole(), dynamicEntity,
                     member.getRelationIdentifier()));

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -1,8 +1,10 @@
 package org.openstreetmap.atlas.geography.atlas.dynamic;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.junit.Assert;
@@ -11,21 +13,28 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.BareAtlas;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
 import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasTestRule;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiRelation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
  */
 public class DynamicAtlasTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(DynamicAtlasTest.class);
+
     @Rule
     public DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
 
@@ -241,6 +250,60 @@ public class DynamicAtlasTest
         Assert.assertEquals(2, relation3.members().size());
         Assert.assertEquals(8, this.dynamicAtlas.numberOfEdges());
 
+    }
+
+    /**
+     * Check to make sure that {@link Atlas#relationsLowerOrderFirst()} works when the {@link Atlas}
+     * is a {@link DynamicAtlas}. In older versions of the code, any relations that had members
+     * which were also relations would be dropped from the set returned by
+     * {@link BareAtlas#relationsLowerOrderFirst()}. This was due to a flaw in the membership
+     * assumptions made by {@link BareAtlas#relationsLowerOrderFirst()}, which assumed that
+     * relations in the main {@link DynamicAtlas} and their equivalent representation as a member
+     * {@link AtlasEntity} of another relation in the same {@link DynamicAtlas} were of consistent
+     * types. However, this was not the case. (The former representation would be of type
+     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation}). This has now
+     * been fixed, so this test should always pass.
+     */
+    @Test
+    public void testRelationsLowerOrderFirstConsistency()
+    {
+        final DynamicAtlas localDynamicAtlas;
+        final Map<Shard, Atlas> localStore = new HashMap<>();
+        localStore.put(new SlippyTile(0, 0, 0), this.rule.getAtlasForRelationsTest());
+        final Supplier<DynamicAtlasPolicy> localPolicySupplier = () -> new DynamicAtlasPolicy(
+                shard ->
+                {
+                    if (localStore.containsKey(shard))
+                    {
+                        return Optional.of(localStore.get(shard));
+                    }
+                    else
+                    {
+                        return Optional.empty();
+                    }
+                }, new SlippyTileSharding(0), new SlippyTile(0, 0, 0), Rectangle.MAXIMUM);
+        localDynamicAtlas = new DynamicAtlas(localPolicySupplier.get());
+
+        final Set<Relation> returnedByRelations = new HashSet<>();
+        final Set<Relation> returnedByRelationsLowerOrderFirst = new HashSet<>();
+
+        for (final Relation relation : localDynamicAtlas.relations())
+        {
+            returnedByRelations.add(relation);
+        }
+
+        for (final Relation relation : localDynamicAtlas.relationsLowerOrderFirst())
+        {
+            returnedByRelationsLowerOrderFirst.add(relation);
+        }
+
+        // Assert that their sizes equal, if not then we can fail fast
+        Assert.assertEquals(returnedByRelations.size(),
+                returnedByRelationsLowerOrderFirst.size());
+
+        // Now that we know they have equal sizes, check member equality
+        Assert.assertEquals(returnedByRelations,
+                returnedByRelationsLowerOrderFirst);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -21,6 +21,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiRelation;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedRelation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -261,8 +262,8 @@ public class DynamicAtlasTest
      * relations in the main {@link DynamicAtlas} and their equivalent representation as a member
      * {@link AtlasEntity} of another relation in the same {@link DynamicAtlas} were of consistent
      * types. However, this was not the case. (The former representation would be of type
-     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation}). This has now
-     * been fixed, so this test should always pass.
+     * {@link DynamicRelation} and the latter would be of type {@link MultiRelation} or
+     * {@link PackedRelation}). This has now been fixed, so this test should always pass.
      */
     @Test
     public void testRelationsLowerOrderFirstConsistency()
@@ -298,12 +299,10 @@ public class DynamicAtlasTest
         }
 
         // Assert that their sizes equal, if not then we can fail fast
-        Assert.assertEquals(returnedByRelations.size(),
-                returnedByRelationsLowerOrderFirst.size());
+        Assert.assertEquals(returnedByRelations.size(), returnedByRelationsLowerOrderFirst.size());
 
         // Now that we know they have equal sizes, check member equality
-        Assert.assertEquals(returnedByRelations,
-                returnedByRelationsLowerOrderFirst);
+        Assert.assertEquals(returnedByRelations, returnedByRelationsLowerOrderFirst);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasTestRule.java
@@ -349,9 +349,80 @@ public class DynamicAtlasTestRule extends CoreTestRule
     )
     private Atlas atlasz12x1349y1870;
 
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "10", coordinates = @Loc(value = ONE)),
+                    @Node(id = "11", coordinates = @Loc(value = SIX)),
+                    @Node(id = "12", coordinates = @Loc(value = SEVEN)),
+                    @Node(id = "13", coordinates = @Loc(value = EIGHT))
+
+            },
+
+            relations = {
+
+                    @Relation(id = "31", tags = { "type=relation" }, members = {
+
+                            @Member(id = "11", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "32", tags = { "type=relation" }, members = {
+
+                            @Member(id = "12", role = "a", type = "node"),
+
+                            @Member(id = "13", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "33", tags = { "type=relation" }, members = {
+
+                            @Member(id = "10", role = "a", type = "node"),
+
+                            @Member(id = "11", role = "a", type = "node"),
+
+                            @Member(id = "31", role = "b", type = "relation")
+
+                    }),
+
+                    @Relation(id = "34", tags = { "type=relation" }, members = {
+
+                            @Member(id = "10", role = "a", type = "node"),
+
+                            @Member(id = "13", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "35", tags = { "type=relation" }, members = {
+
+                            @Member(id = "11", role = "a", type = "node"),
+
+                            @Member(id = "12", role = "a", type = "node")
+
+                    }),
+
+                    @Relation(id = "36", tags = { "type=relation" }, members = {
+
+                            @Member(id = "12", role = "a", type = "node"),
+
+                            @Member(id = "34", role = "a", type = "relation")
+
+                    }),
+
+            }
+
+    )
+    private Atlas atlasForRelationsTest;
+
     public Atlas getAtlas()
     {
         return this.atlas;
+    }
+
+    public Atlas getAtlasForRelationsTest()
+    {
+        return this.atlasForRelationsTest;
     }
 
     public Atlas getAtlasz12x1349y1869()


### PR DESCRIPTION
### Description:

Previously, the interaction between `BareAtlas`, `AtlasEntity`, and `DynamicAtlas`/`DynamicRelation` was broken in the following way:

If you had a `DynamicAtlas` containing some relation `R` that contained at least one other relation `R'` as a member, calling `DynamicAtlas.relationsLowerOrderFirst()` (which used the implementation in `BareAtlas`) would drop relation `R` from the returned set.

This was due to a faulty `AtlasEntity` equality assumption made by `relationsLowerOrderFirst()` which did not hold in the case of `DynamicAtlas`.

This has now been fixed in `DynamicRelation`. The `members` function now returns entities of the correct type, so that the equality assumptions made in `relationsLowerOrderFirst()` are correct.

### Potential Impact:

The broken version of `DynamicAtlas.members()` (and `BareAtlas.relationsLowerOrderFirst()`) was negatively impacting the functionality of `WaySectionProcessor` (the raw atlas version), which depends on `DynamicAtlas` and proper functionality of this method to work. Before the bug fix, the `WaySectionProcessor` would drop any relation which had at least one relation as a member.

### Unit Test Approach:

I have added `DynamicAtlasTest.testRelationsLowerOrderFirstConsistency()`, which demonstrates the case in which the bug would occur. It utilizes a new test atlas, `DynamicAtlasTestRule.atlasForRelationsTest`, which is designed to trigger the bug. With the fix, this unit test now passes.

`RawAtlasIntegrationTest.testSectioningFromShard()` was also affected. In the previous code version, it was dropping two relations from the build, and the test was assuming that those two relations did not exist (when in reality they had actually just been dropped by the `WaySectionProcessor`). The test is updated, and passes with the bug fix in place.

### Test Results:

I am planning on doing more extensive testing. Please reach out to me to discuss.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)