### PR TITLE
Fixed a small typo in the trigger-release script

### DIFF
--- a/.travis/trigger-release.sh
+++ b/.travis/trigger-release.sh
@@ -12,7 +12,7 @@ GITHUB_REPOSITORY_NAME=atlas
 
 TRAVIS_PERSONAL_TOKEN=$(travis token)
 
-:${TRAVIS_PERSONAL_TOKEN:?"TRAVIS_PERSONAL_TOKEN needs to be set to access the Travis API to trigger the build"}
+: ${TRAVIS_PERSONAL_TOKEN:?"TRAVIS_PERSONAL_TOKEN needs to be set to access the Travis API to trigger the build"}
 
 body='
 {


### PR DESCRIPTION
### Description:

`trigger-release.sh` tries to check if your `TRAVIS_PERSONAL_TOKEN` environment variable is set. However, the check would always fail and simply dump the token to the screen. This was due to a syntax error with the `:` operator. This is now fixed.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

I tested the syntax change in a local dummy script.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)