### PR TITLE
Initialize in Construction of AtlasEntityPolygonsFilter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilter.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.converters.PolygonStringFormat;
 import org.openstreetmap.atlas.geography.index.RTree;
@@ -159,6 +160,8 @@ public final class AtlasEntityPolygonsFilter implements Predicate<AtlasEntity>, 
         this.intersectionPolicy = intersectionPolicy;
         this.geometricSurfaces = (RTree<GeometricSurface>) RTree
                 .forLocated(geometricSurfaces == null ? Collections.EMPTY_SET : geometricSurfaces);
+        // initialize underlying STR tree
+        this.geometricSurfaces.get(Rectangle.MAXIMUM);
     }
 
     @Override


### PR DESCRIPTION
### Description:
Initialize the underlying STRtree in the Rtree class, which lazily constructs its index, when first queried. 
This means without querying the Rtree during construction, the filter isn't thread safe despite being read only. 

### Potential Impact:

Slightly higher memory usage when the filter is never used. 

### Unit Test Approach:

Standard unit tests should cover because the problem is itself a race condition and cannot be reliably reproduced.

### Test Results:

Passes all unit tests.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)