### PR TITLE
Adding check in closedLoop method to ensure no duplicate locations.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -152,7 +152,11 @@ public class Polygon extends PolyLine implements GeometricSurface
      */
     public Iterable<Location> closedLoop()
     {
-        return new MultiIterable<>(this, Iterables.from(this.first()));
+        if (this.first() != this.last())
+        {
+            return new MultiIterable<>(this, Iterables.from(this.first()));
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -152,7 +152,7 @@ public class Polygon extends PolyLine implements GeometricSurface
      */
     public Iterable<Location> closedLoop()
     {
-        if (this.first() != this.last())
+        if (!this.first().equals(this.last()))
         {
             return new MultiIterable<>(this, Iterables.from(this.first()));
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -730,4 +730,17 @@ public class PolygonTest
             Assert.assertEquals(3, triangle.size());
         }
     }
+
+    @Test
+    public void testClosedLoop()
+    {
+        final Polygon polygon = Polygon.SILICON_VALLEY;
+        final Polygon initialClosedLoop = new Polygon(polygon.closedLoop());
+        Assert.assertNotEquals(
+                "Last and Last - 1 locations for the polygon should not be duplicate.",
+                initialClosedLoop.last(), initialClosedLoop.get(initialClosedLoop.size() - 2));
+        final Polygon doubleClosedLoop = new Polygon(initialClosedLoop.closedLoop());
+        Assert.assertNotEquals("Last and Last - 1 locations for polygon should not be duplicate.",
+                doubleClosedLoop.last(), doubleClosedLoop.get(doubleClosedLoop.size() - 2));
+    }
 }


### PR DESCRIPTION
### Description:

This is a very minor update to how the closedLoop function on the polygon object works. Previously it was simply adding the first location to the end of the iteration. This update now just checks to make sure that the last object isn't already equal to the first object, that way we are not simply adding a duplicate location at the end of the iteration. 

### Potential Impact:

I am not sure if there would be any impact, it is unlikely that this scenario would even be hit under normal circumstances.

### Unit Test Approach:

Added a unit test that makes sure that we aren't adding the location at the end if the polygon is already closed.

### Test Results:

Test cases passed correctly, and also failed correctly when the update is not included.