### PR TITLE
Fixed relation return types in DynamicRelation.allKnownOsmMembers()

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
@@ -31,11 +31,7 @@ public class DynamicRelation extends Relation
     @Override
     public RelationMemberList allKnownOsmMembers()
     {
-        /*
-         * TODO this will return AtlasEntities which are not of type DynamicX. Ideally, we should be
-         * recreating returned entities as DynamicX instead of the underlying PackedX or MultiX.
-         */
-        return subRelation().allKnownOsmMembers();
+        return getRelationMembersAsDynamicEntities(subRelation().allKnownOsmMembers());
     }
 
     @Override
@@ -61,10 +57,34 @@ public class DynamicRelation extends Relation
     @Override
     public RelationMemberList members()
     {
-        final RelationMemberList subRelationMemberList = subRelation().members();
+        return getRelationMembersAsDynamicEntities(subRelation().members());
+    }
+
+    @Override
+    public long osmRelationIdentifier()
+    {
+        return subRelation().osmRelationIdentifier();
+    }
+
+    @Override
+    public Set<Relation> relations()
+    {
+        return subRelation().relations().stream()
+                .map(relation -> new DynamicRelation(dynamicAtlas(), relation.getIdentifier()))
+                .collect(Collectors.toSet());
+    }
+
+    private DynamicAtlas dynamicAtlas()
+    {
+        return (DynamicAtlas) this.getAtlas();
+    }
+
+    private RelationMemberList getRelationMembersAsDynamicEntities(
+            final RelationMemberList memberList)
+    {
         final List<RelationMember> newMemberList = new ArrayList<>();
 
-        for (final RelationMember member : subRelationMemberList)
+        for (final RelationMember member : memberList)
         {
             final AtlasEntity entity = member.getEntity();
             AtlasEntity dynamicEntity = null;
@@ -96,25 +116,6 @@ public class DynamicRelation extends Relation
         }
 
         return new RelationMemberList(newMemberList);
-    }
-
-    @Override
-    public long osmRelationIdentifier()
-    {
-        return subRelation().osmRelationIdentifier();
-    }
-
-    @Override
-    public Set<Relation> relations()
-    {
-        return subRelation().relations().stream()
-                .map(relation -> new DynamicRelation(dynamicAtlas(), relation.getIdentifier()))
-                .collect(Collectors.toSet());
-    }
-
-    private DynamicAtlas dynamicAtlas()
-    {
-        return (DynamicAtlas) this.getAtlas();
     }
 
     private Relation subRelation()


### PR DESCRIPTION
### Description:

`DynamicRelation.allKnownOsmMembers()` now returns entities of type `DynamicX` instead of `PackedX` or `MultiX`.

### Potential Impact:

Downstream impact should be negligible.

### Unit Test Approach:

I added `DynamicAtlasTest.testTypeOfReturnedRelationMembers()` to confirm that these changes and the changes from PR #216 are working correctly.

### Test Results:

All tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)