### PR TITLE
Added in Relation flattening

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -127,12 +127,12 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
             {
                 ((Relation) polledMember).members()
                         .forEach(member -> toProcess.add(member.getEntity()));
+                relationsSeen.add(polledMember.getIdentifier());
             }
             else
             {
                 relationMembers.add(polledMember);
             }
-            relationsSeen.add(this.getIdentifier());
         }
         return relationMembers;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -118,13 +118,12 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
         while (!toProcess.isEmpty())
         {
             polledMember = toProcess.poll();
-            if (relationsSeen.contains(polledMember.getIdentifier()))
-            {
-                continue;
-            }
-
             if (polledMember instanceof Relation)
             {
+                if (relationsSeen.contains(polledMember.getIdentifier()))
+                {
+                    continue;
+                }
                 ((Relation) polledMember).members()
                         .forEach(member -> toProcess.add(member.getEntity()));
                 relationsSeen.add(polledMember.getIdentifier());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -45,8 +45,8 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
      */
     public enum Ring
     {
-    OUTER,
-    INNER
+        OUTER,
+        INNER
     }
 
     private static final Logger logger = LoggerFactory.getLogger(Relation.class);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -2,8 +2,11 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,6 +27,8 @@ import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An OSM relation
@@ -40,10 +45,11 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
      */
     public enum Ring
     {
-        OUTER,
-        INNER
+    OUTER,
+    INNER
     }
 
+    private static final Logger logger = LoggerFactory.getLogger(Relation.class);
     private static final long serialVersionUID = -9013894610780915685L;
 
     public static final Comparator<Relation> RELATION_ID_COMPARATOR = (final Relation relation1,
@@ -91,6 +97,44 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
         builder.append(tagString());
         builder.append("]");
         return builder.toString();
+    }
+
+    /**
+     * "Flattens" the relation by returning the set of non-Relation members. Adds any non-Relation
+     * members to the set, then loops on any Relation members to add their non-Relation members as
+     * well. Keeps track of Relations whose identifiers have already been operated on, so that
+     * recursively defined relations don't cause problems.
+     *
+     * @return a Set of AtlasObjects all related to this Relation, with no Relations.
+     */
+    public Set<AtlasObject> flatten()
+    {
+        final Set<AtlasObject> relationMembers = new HashSet<>();
+        final Deque<AtlasObject> toProcess = new LinkedList<>();
+        final Set<Long> relationsSeen = new HashSet<>();
+        AtlasObject polledMember;
+
+        toProcess.add(this);
+        while (!toProcess.isEmpty())
+        {
+            polledMember = toProcess.poll();
+            if (relationsSeen.contains(polledMember.getIdentifier()))
+            {
+                continue;
+            }
+
+            if (polledMember instanceof Relation)
+            {
+                ((Relation) polledMember).members()
+                        .forEach(member -> toProcess.add(member.getEntity()));
+            }
+            else
+            {
+                relationMembers.add(polledMember);
+            }
+            relationsSeen.add(this.getIdentifier());
+        }
+        return relationMembers;
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
@@ -12,13 +12,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
  */
 public class RelationFlatteningRule extends CoreTestRule
 {
-
-    @TestAtlas(
-
-            nodes = { @Node(id = "1"), @Node(id = "2"), @Node(id = "3"), @Node(id = "4"),
-                    @Node(id = "5") },
-
-            relations = {
+    @TestAtlas(nodes = { @Node(id = "1"), @Node(id = "2"), @Node(id = "3"), @Node(id = "4"),
+            @Node(id = "5") }, relations = {
 
                     @Relation(id = "6", members = {
                             @Member(id = "1", role = "outside", type = "node") }),
@@ -28,14 +23,21 @@ public class RelationFlatteningRule extends CoreTestRule
                     @Relation(id = "8", members = {
                             @Member(id = "4", role = "outside", type = "node"),
                             @Member(id = "5", role = "outside", type = "node"),
-                            @Member(id = "8", role = "outside", type = "relation") }) }
+                            @Member(id = "8", role = "outside", type = "relation") }),
+                    @Relation(id = "9", members = {
+                            @Member(id = "4", role = "outside", type = "node"),
+                            @Member(id = "5", role = "outside", type = "node"),
+                            @Member(id = "7", role = "outside", type = "relation"),
+                            @Member(id = "6", role = "outside", type = "relation") }),
+                    @Relation(id = "10", members = {
+                            @Member(id = "3", role = "outside", type = "node"),
+                            @Member(id = "9", role = "outside", type = "relation"),
+                            @Member(id = "6", role = "outside", type = "relation") }) })
+    private Atlas atlas;
 
-    )
-    private Atlas atlas1;
-
-    public Atlas getAtlas1()
+    public Atlas getAtlas()
     {
-        return this.atlas1;
+        return this.atlas;
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
@@ -1,0 +1,41 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * @author samuelgass
+ */
+public class RelationFlatteningRule extends CoreTestRule
+{
+
+    @TestAtlas(
+
+            nodes = { @Node(id = "1"), @Node(id = "2"), @Node(id = "3"), @Node(id = "4"),
+                    @Node(id = "5") },
+
+            relations = {
+
+                    @Relation(id = "6", members = {
+                            @Member(id = "1", role = "outside", type = "node") }),
+                    @Relation(id = "7", members = {
+                            @Member(id = "1", role = "outside", type = "node"),
+                            @Member(id = "2", role = "outside", type = "node") }),
+                    @Relation(id = "8", members = {
+                            @Member(id = "4", role = "outside", type = "node"),
+                            @Member(id = "5", role = "outside", type = "node"),
+                            @Member(id = "8", role = "outside", type = "relation") }) }
+
+    )
+    private Atlas atlas1;
+
+    public Atlas getAtlas1()
+    {
+        return this.atlas1;
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningRule.java
@@ -13,13 +13,14 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 public class RelationFlatteningRule extends CoreTestRule
 {
     @TestAtlas(nodes = { @Node(id = "1"), @Node(id = "2"), @Node(id = "3"), @Node(id = "4"),
-            @Node(id = "5") }, relations = {
+            @Node(id = "5"), @Node(id = "6") }, relations = {
 
                     @Relation(id = "6", members = {
                             @Member(id = "1", role = "outside", type = "node") }),
                     @Relation(id = "7", members = {
                             @Member(id = "1", role = "outside", type = "node"),
-                            @Member(id = "2", role = "outside", type = "node") }),
+                            @Member(id = "2", role = "outside", type = "node"),
+                            @Member(id = "6", role = "outside", type = "node") }),
                     @Relation(id = "8", members = {
                             @Member(id = "4", role = "outside", type = "node"),
                             @Member(id = "5", role = "outside", type = "node"),
@@ -30,9 +31,17 @@ public class RelationFlatteningRule extends CoreTestRule
                             @Member(id = "7", role = "outside", type = "relation"),
                             @Member(id = "6", role = "outside", type = "relation") }),
                     @Relation(id = "10", members = {
+                            @Member(id = "6", role = "outside", type = "relation"),
                             @Member(id = "3", role = "outside", type = "node"),
-                            @Member(id = "9", role = "outside", type = "relation"),
-                            @Member(id = "6", role = "outside", type = "relation") }) })
+                            @Member(id = "9", role = "outside", type = "relation") }),
+                    @Relation(id = "2", members = {
+                            @Member(id = "3", role = "outside", type = "node"),
+                            @Member(id = "4", role = "outside", type = "node"),
+                            @Member(id = "6", role = "outside", type = "relation") }),
+                    @Relation(id = "1", members = {
+                            @Member(id = "5", role = "outside", type = "node"),
+                            @Member(id = "2", role = "outside", type = "node"),
+                            @Member(id = "2", role = "outside", type = "relation") }) })
     private Atlas atlas;
 
     public Atlas getAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
@@ -37,6 +37,17 @@ public class RelationFlatteningTest
         logger.info("Nested Relation: {}", nestedRelation);
         final Set<AtlasObject> flattened = nestedRelation.flatten();
         logger.info("Flattened: {}", flattened);
+        assertEquals(6, flattened.size());
+    }
+
+    @Test
+    public void testNodesAndRelationsWithSameId()
+    {
+        final Relation relation = this.rule.getAtlas().relation(1);
+        logger.info("Relation containing nodes and relations with the same numeric id: {}",
+                relation);
+        final Set<AtlasObject> flattened = relation.flatten();
+        logger.info("Flattened: {}", flattened);
         assertEquals(5, flattened.size());
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
@@ -1,0 +1,76 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RelationFlatteningTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(RelationFlatteningTest.class);
+
+    @Rule
+    public final RelationFlatteningRule rule = new RelationFlatteningRule();
+
+    @Test
+    public void testComplexRelation()
+    {
+        final Relation complexRelation = this.rule.getAtlas1().relation(7);
+        logger.info("Relation 7: {}", complexRelation);
+        final Set<AtlasObject> flattened = complexRelation.flatten();
+        logger.info("Flattened: {}", flattened);
+        assertEquals(2, flattened.size());
+        final AtlasObject memberNode = flattened.stream().findFirst().get();
+        if (memberNode instanceof Node)
+        {
+            assertEquals(1, ((Node) memberNode).getIdentifier());
+        }
+        else
+        {
+            Assert.fail("Member was not the expected type of 'Node'!");
+        }
+    }
+
+    @Test
+    public void testRecursiveRelation()
+    {
+        final Relation recursiveRelation = this.rule.getAtlas1().relation(8);
+        logger.info("Relation 8: {}", recursiveRelation);
+        final Set<AtlasObject> flattened = recursiveRelation.flatten();
+        logger.info("Flattened: {}", flattened);
+        assertEquals(2, flattened.size());
+        final AtlasObject memberNode = flattened.stream().findFirst().get();
+        if (memberNode instanceof Node)
+        {
+            assertEquals(4, ((Node) memberNode).getIdentifier());
+        }
+        else
+        {
+            Assert.fail("Member was not the expected type of 'Node'!");
+        }
+    }
+
+    @Test
+    public void testSimpleRelation()
+    {
+        final Relation simpleRelation = this.rule.getAtlas1().relation(6);
+        logger.info("Relation 6: {}", simpleRelation);
+        final Set<AtlasObject> flattened = simpleRelation.flatten();
+        logger.info("Flattened: {}", flattened);
+        assertEquals(1, flattened.size());
+        final AtlasObject memberNode = flattened.stream().findFirst().get();
+        if (memberNode instanceof Node)
+        {
+            assertEquals(1, ((Node) memberNode).getIdentifier());
+        }
+        else
+        {
+            Assert.fail("Member was not the expected type of 'Node'!");
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
@@ -21,31 +21,31 @@ public class RelationFlatteningTest
     public final RelationFlatteningRule rule = new RelationFlatteningRule();
 
     @Test
-    public void testComplexRelation()
+    public void testLoopingRelation()
     {
-        final Relation complexRelation = this.rule.getAtlas1().relation(7);
-        logger.info("Relation 7: {}", complexRelation);
-        final Set<AtlasObject> flattened = complexRelation.flatten();
+        final Relation loopingRelation = this.rule.getAtlas().relation(8);
+        logger.info("Looping (self-containing) Relation: {}", loopingRelation);
+        final Set<AtlasObject> flattened = loopingRelation.flatten();
         logger.info("Flattened: {}", flattened);
         assertEquals(2, flattened.size());
     }
 
     @Test
-    public void testRecursiveRelation()
+    public void testNestedRelation()
     {
-        final Relation recursiveRelation = this.rule.getAtlas1().relation(8);
-        logger.info("Relation 8: {}", recursiveRelation);
-        final Set<AtlasObject> flattened = recursiveRelation.flatten();
+        final Relation nestedRelation = this.rule.getAtlas().relation(10);
+        logger.info("Nested Relation: {}", nestedRelation);
+        final Set<AtlasObject> flattened = nestedRelation.flatten();
         logger.info("Flattened: {}", flattened);
-        assertEquals(2, flattened.size());
+        assertEquals(5, flattened.size());
     }
 
     @Test
-    public void testSimpleRelation()
+    public void testShallowRelation()
     {
-        final Relation simpleRelation = this.rule.getAtlas1().relation(6);
-        logger.info("Relation 6: {}", simpleRelation);
-        final Set<AtlasObject> flattened = simpleRelation.flatten();
+        final Relation shallowRelation = this.rule.getAtlas().relation(6);
+        logger.info("Shallow (1-node) relation: {}", shallowRelation);
+        final Set<AtlasObject> flattened = shallowRelation.flatten();
         logger.info("Flattened: {}", flattened);
         assertEquals(1, flattened.size());
         final AtlasObject memberNode = flattened.stream().findFirst().get();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RelationFlatteningTest.java
@@ -10,6 +10,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @author samuelgass
+ */
 public class RelationFlatteningTest
 {
     private static final Logger logger = LoggerFactory.getLogger(RelationFlatteningTest.class);
@@ -25,15 +28,6 @@ public class RelationFlatteningTest
         final Set<AtlasObject> flattened = complexRelation.flatten();
         logger.info("Flattened: {}", flattened);
         assertEquals(2, flattened.size());
-        final AtlasObject memberNode = flattened.stream().findFirst().get();
-        if (memberNode instanceof Node)
-        {
-            assertEquals(1, ((Node) memberNode).getIdentifier());
-        }
-        else
-        {
-            Assert.fail("Member was not the expected type of 'Node'!");
-        }
     }
 
     @Test
@@ -44,15 +38,6 @@ public class RelationFlatteningTest
         final Set<AtlasObject> flattened = recursiveRelation.flatten();
         logger.info("Flattened: {}", flattened);
         assertEquals(2, flattened.size());
-        final AtlasObject memberNode = flattened.stream().findFirst().get();
-        if (memberNode instanceof Node)
-        {
-            assertEquals(4, ((Node) memberNode).getIdentifier());
-        }
-        else
-        {
-            Assert.fail("Member was not the expected type of 'Node'!");
-        }
     }
 
     @Test


### PR DESCRIPTION
### Description:

This PR adds in a function to Relation.java that "flattens" the Relation into a set of its non-Relation child members. 
### Potential Impact:

Probably nothing, giving it's a new API addition.

### Unit Test Approach:

Unit tests cover basic relation (one node), nested relations (several nodes and one nested relation), and recursive relations (relation with itself as a child).

### Test Results:

```
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:62 - Relation 6: [Relation: id=6, [Members: 
				{Member: ID = 1, Type = NODE, Role = outside}
			], [Tags: ]]
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:64 - Flattened: [[Node: id=1, location=POINT (-122.009566 37.33531), inEdges=[], outEdges=[], [Tags: ]]]
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:43 - Relation 8: [Relation: id=8, [Members: 
				{Member: ID = 4, Type = NODE, Role = outside}, 
				{Member: ID = 5, Type = NODE, Role = outside}, 
				{Member: ID = 8, Type = RELATION, Role = outside}
			], [Tags: ]]
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:45 - Flattened: [[Node: id=4, location=POINT (-122.009566 37.33531), inEdges=[], outEdges=[], [Tags: ]], [Node: id=5, location=POINT (-122.009566 37.33531), inEdges=[], outEdges=[], [Tags: ]]]
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:24 - Relation 7: [Relation: id=7, [Members: 
				{Member: ID = 1, Type = NODE, Role = outside}, 
				{Member: ID = 2, Type = NODE, Role = outside}
			], [Tags: ]]
2018-10-04 13:48:28 INFO  [main] RelationFlatteningTest:26 - Flattened: [[Node: id=1, location=POINT (-122.009566 37.33531), inEdges=[], outEdges=[], [Tags: ]], [Node: id=2, location=POINT (-122.009566 37.33531), inEdges=[], outEdges=[], [Tags: ]]]
```

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
