### PR TITLE
Added parallelization support to StreamIterator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/Iterables.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/Iterables.java
@@ -632,6 +632,20 @@ public final class Iterables
         return Optional.ofNullable(result);
     }
 
+    /**
+     * Create a {@link StreamIterable} that uses parallelization
+     *
+     * @param source
+     *            The {@link Iterable} to use as source
+     * @param <Type>
+     *            The type of the source {@link Iterable}
+     * @return The corresponding {@link StreamIterable}
+     */
+    public static <Type> StreamIterable<Type> parallelStream(final Iterable<Type> source)
+    {
+        return new StreamIterable<>(source, true);
+    }
+
     public static <T> void print(final Iterable<T> input, final String name)
     {
         System.out.println(toString(input, name));

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
@@ -106,18 +106,24 @@ public class StreamIterable<T> implements Iterable<T>
 
     /**
      * Disable parallelization in streams from this StreamIterator
+     *
+     * @return The StreamIterator with parallelization disabled
      */
-    public void disableParallelization()
+    public StreamIterable<T> disableParallelization()
     {
         this.parallel = false;
+        return this;
     }
 
     /**
      * Enable parallelization in streams from this StreamIterator
+     *
+     * @return The StreamIterator with parallelization enabled
      */
-    public void enableParallelization()
+    public StreamIterable<T> enableParallelization()
     {
         this.parallel = true;
+        return this;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
@@ -24,6 +24,7 @@ import java.util.stream.StreamSupport;
 public class StreamIterable<T> implements Iterable<T>
 {
     private final Iterable<T> source;
+    private boolean parallel = false;
 
     protected StreamIterable(final Iterable<T> source)
     {
@@ -31,7 +32,21 @@ public class StreamIterable<T> implements Iterable<T>
     }
 
     /**
-     * Test whether all elements from iterable match the given predicate
+     * Construct a new StreamIterable.
+     *
+     * @param source
+     *            The source iterable to construct the StreamIterable from
+     * @param parallel
+     *            Controls whether to use parallelization or not when streaming
+     */
+    protected StreamIterable(final Iterable<T> source, final boolean parallel)
+    {
+        this.source = source;
+        this.parallel = parallel;
+    }
+
+    /**
+     * Test whether all elements from iterable match the given predicate.
      *
      * @param predicate
      *            Predicate to test
@@ -39,7 +54,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public boolean allMatch(final Predicate<T> predicate)
     {
-        return StreamSupport.stream(this.source.spliterator(), false).allMatch(predicate);
+        return StreamSupport.stream(this.source.spliterator(), this.parallel).allMatch(predicate);
     }
 
     /**
@@ -51,7 +66,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public boolean anyMatch(final Predicate<T> predicate)
     {
-        return StreamSupport.stream(this.source.spliterator(), false).anyMatch(predicate);
+        return StreamSupport.stream(this.source.spliterator(), this.parallel).anyMatch(predicate);
     }
 
     /**
@@ -90,6 +105,22 @@ public class StreamIterable<T> implements Iterable<T>
     }
 
     /**
+     * Disable parallelization in streams from this StreamIterator
+     */
+    public void disableParallelization()
+    {
+        this.parallel = false;
+    }
+
+    /**
+     * Enable parallelization in streams from this StreamIterator
+     */
+    public void enableParallelization()
+    {
+        this.parallel = true;
+    }
+
+    /**
      * Filter an {@link Iterable}
      *
      * @param filter
@@ -98,7 +129,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public StreamIterable<T> filter(final Predicate<T> filter)
     {
-        return new StreamIterable<>(Iterables.filter(this.source, filter));
+        return new StreamIterable<>(Iterables.filter(this.source, filter), this.parallel);
     }
 
     /**
@@ -116,7 +147,8 @@ public class StreamIterable<T> implements Iterable<T>
             final Function<T, IdentifierType> identifier)
     {
         return new StreamIterable<>(
-                new FilteredIterable<T, IdentifierType>(this.source, filterSet, identifier));
+                new FilteredIterable<T, IdentifierType>(this.source, filterSet, identifier),
+                this.parallel);
     }
 
     /**
@@ -130,7 +162,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public <V> StreamIterable<V> flatMap(final Function<T, Iterable<? extends V>> flatMap)
     {
-        return new StreamIterable<>(Iterables.translateMulti(this.source, flatMap));
+        return new StreamIterable<>(Iterables.translateMulti(this.source, flatMap), this.parallel);
     }
 
     @Override
@@ -150,7 +182,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public <V> StreamIterable<V> map(final Function<T, V> map)
     {
-        return new StreamIterable<>(Iterables.translate(this.source, map));
+        return new StreamIterable<>(Iterables.translate(this.source, map), this.parallel);
     }
 
     /**
@@ -164,6 +196,7 @@ public class StreamIterable<T> implements Iterable<T>
      */
     public StreamIterable<T> truncate(final int startIndex, final int indexFromEnd)
     {
-        return new StreamIterable<>(Iterables.truncate(this.source, startIndex, indexFromEnd));
+        return new StreamIterable<>(Iterables.truncate(this.source, startIndex, indexFromEnd),
+                this.parallel);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/StreamIterable.java
@@ -15,7 +15,7 @@ import java.util.stream.StreamSupport;
  * <p>
  * <code>
  * Iterables.stream(someIterable).map(...).filter(...).collect();
- * </code>
+ * </code> Note: StreamIterable is not thread safe with parallelization usage.
  *
  * @author matthieun
  * @param <T>

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/StreamIterableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/StreamIterableTest.java
@@ -2,8 +2,16 @@ package org.openstreetmap.atlas.utilities.collections;
 
 import static java.util.Arrays.asList;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.utilities.scalars.Duration;
+import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Sagar Rohankar
@@ -11,6 +19,8 @@ import org.junit.Test;
  */
 public class StreamIterableTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(StreamIterableTest.class);
+
     @Test
     public void testAllMatch() throws Exception
     {
@@ -25,7 +35,8 @@ public class StreamIterableTest
     @Test
     public void testAllMatchParallel() throws Exception
     {
-        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(1, 2, 3, 4));
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(1, 2, 3, 4),
+                true);
 
         // true -> all numbers are less than 5
         Assert.assertTrue(streamIterable.allMatch(n -> n < 5));
@@ -36,8 +47,7 @@ public class StreamIterableTest
     @Test
     public void testAnyMatch()
     {
-        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(6, 12, 18),
-                true);
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(6, 12, 18));
 
         // true -> any number that is divisible by 9
         Assert.assertTrue(streamIterable.anyMatch(n -> n % 9 == 0));
@@ -55,6 +65,29 @@ public class StreamIterableTest
         Assert.assertTrue(streamIterable.anyMatch(n -> n % 9 == 0));
         // false -> any number that is divisible by 5
         Assert.assertFalse(streamIterable.allMatch(n -> n % 5 == 0));
+    }
+
+    @Test
+    public void testParallelPerformance()
+    {
+        final List<Integer> numbers = new ArrayList<>();
+        IntStream.range(0, 10000000).forEach(number ->
+        {
+            numbers.add(number);
+        });
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(numbers)
+                .disableParallelization();
+        Time currentTime = Time.now();
+        streamIterable.anyMatch(n -> n > 100000);
+        final Duration sequentialDuration = currentTime.elapsedSince();
+        logger.debug("Sequential duration was {} ms", sequentialDuration.asMilliseconds());
+
+        currentTime = Time.now();
+        streamIterable.enableParallelization();
+        streamIterable.anyMatch(n -> n > 100000);
+        final Duration parallelDuration = currentTime.elapsedSince();
+        logger.debug("Parallel duration was {} ms", parallelDuration.asMilliseconds());
+        Assert.assertTrue(parallelDuration.isLessThan(sequentialDuration));
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/collections/StreamIterableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/collections/StreamIterableTest.java
@@ -23,9 +23,33 @@ public class StreamIterableTest
     }
 
     @Test
+    public void testAllMatchParallel() throws Exception
+    {
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(1, 2, 3, 4));
+
+        // true -> all numbers are less than 5
+        Assert.assertTrue(streamIterable.allMatch(n -> n < 5));
+        // false -> all numbers are even
+        Assert.assertFalse(streamIterable.allMatch(n -> n % 2 == 0));
+    }
+
+    @Test
     public void testAnyMatch()
     {
-        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(6, 12, 18));
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(6, 12, 18),
+                true);
+
+        // true -> any number that is divisible by 9
+        Assert.assertTrue(streamIterable.anyMatch(n -> n % 9 == 0));
+        // false -> any number that is divisible by 5
+        Assert.assertFalse(streamIterable.allMatch(n -> n % 5 == 0));
+    }
+
+    @Test
+    public void testAnyMatchParallel()
+    {
+        final StreamIterable<Integer> streamIterable = new StreamIterable<>(asList(6, 12, 18),
+                true);
 
         // true -> any number that is divisible by 9
         Assert.assertTrue(streamIterable.anyMatch(n -> n % 9 == 0));


### PR DESCRIPTION
### Description:

Per issue #124, adds in a new method `Iterables.parallelStream()` that replicates the functionality of `Iterables.stream()` but with parallelization enabled. 

### Potential Impact:

Minimal. While StreamIterable was changed, the default value for the parallelization is set to false, and is only changed through either explicit calls to `enableParallelization()` or through a different constructor.

### Unit Test Approach:

It's difficult in unit tests to verify that parallelization was actually used (open to suggestions!!). As such, the existing tests were duplicated but with parallelization enabled; correct expected results were considered sufficient. 

Manual debug checking did show thread pools, so parallelization has been confirmed / sanity tested.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)