### PR TITLE
Pool can have a companion ticker thread

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -101,6 +101,15 @@ public final class Duration implements Serializable
         return Long.hashCode(this.milliseconds);
     }
 
+    public Duration highest(final Duration other)
+    {
+        if (other == null || this.isMoreThanOrEqualsTo(other))
+        {
+            return this;
+        }
+        return other;
+    }
+
     public boolean isCloseTo(final Duration that, final Duration safe)
     {
         return difference(that).isLessThanOrEqualsTo(safe);
@@ -124,6 +133,15 @@ public final class Duration implements Serializable
     public boolean isMoreThanOrEqualsTo(final Duration that)
     {
         return this.milliseconds >= that.milliseconds;
+    }
+
+    public Duration lowest(final Duration other)
+    {
+        if (other == null || this.isLessThanOrEqualsTo(other))
+        {
+            return this;
+        }
+        return other;
     }
 
     public long millisecondsOfSecond()

--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/LogTicker.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/LogTicker.java
@@ -1,0 +1,24 @@
+package org.openstreetmap.atlas.utilities.threads;
+
+import org.openstreetmap.atlas.utilities.scalars.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author matthieun
+ */
+public class LogTicker extends Ticker
+{
+    private static final Logger logger = LoggerFactory.getLogger(LogTicker.class);
+
+    public LogTicker(final String name, final Duration tickerTime)
+    {
+        super(name, tickerTime);
+    }
+
+    @Override
+    protected void tickAction(final Duration sinceStart)
+    {
+        logger.info("{}: {}", getName(), sinceStart);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
@@ -74,5 +74,5 @@ public abstract class Ticker implements Runnable, Closeable
      * @param sinceStart
      *            The duration elapsed since the start of the ticker.
      */
-    protected abstract void tickAction(final Duration sinceStart);
+    protected abstract void tickAction(Duration sinceStart);
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
@@ -53,7 +53,7 @@ public abstract class Ticker implements Runnable, Closeable
         {
             // Sleep small, to check regularly. If the thread is "closed" it will then die fairly
             // soon even if the ticker time is really long.
-            CHECK_TIME.sleep();
+            CHECK_TIME.lowest(this.tickerTime).sleep();
             if (lastCheck.elapsedSince().isMoreThan(this.tickerTime))
             {
                 tickAction(start.elapsedSince());

--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/Ticker.java
@@ -1,0 +1,78 @@
+package org.openstreetmap.atlas.utilities.threads;
+
+import java.io.Closeable;
+
+import org.openstreetmap.atlas.utilities.scalars.Duration;
+import org.openstreetmap.atlas.utilities.time.Time;
+
+/**
+ * Ticker companion.
+ *
+ * @author matthieun
+ */
+public abstract class Ticker implements Runnable, Closeable
+{
+    private static final Duration CHECK_TIME = Duration.milliseconds(500);
+
+    private final String name;
+    private final Duration tickerTime;
+
+    // This tells the ticker it is time to stop ticking.
+    private volatile boolean stop;
+
+    /**
+     * @param name
+     *            The name of the ticker companion
+     * @param tickerTime
+     *            The duration between each tick. It is indicative only.
+     */
+    public Ticker(final String name, final Duration tickerTime)
+    {
+        this.name = name;
+        this.tickerTime = tickerTime;
+        this.stop = false;
+    }
+
+    @Override
+    public void close()
+    {
+        this.stop = true;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    @Override
+    public void run()
+    {
+        final Time start = Time.now();
+        Time lastCheck = Time.now();
+        while (!this.stop)
+        {
+            // Sleep small, to check regularly. If the thread is "closed" it will then die fairly
+            // soon even if the ticker time is really long.
+            CHECK_TIME.sleep();
+            if (lastCheck.elapsedSince().isMoreThan(this.tickerTime))
+            {
+                tickAction(start.elapsedSince());
+                lastCheck = Time.now();
+            }
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Ticker [name=" + this.name + ", tickerTime=" + this.tickerTime + "]";
+    }
+
+    /**
+     * Act upon a tick event.
+     *
+     * @param sinceStart
+     *            The duration elapsed since the start of the ticker.
+     */
+    protected abstract void tickAction(final Duration sinceStart);
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/DurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/DurationTest.java
@@ -27,4 +27,17 @@ public class DurationTest
         Assert.assertTrue(Duration.seconds(3600).equals(Duration.hours(1)));
         Assert.assertFalse(Duration.seconds(1.001).equals(Duration.seconds(1.002)));
     }
+
+    @Test
+    public void testLowestAndHighest()
+    {
+        final Duration lowest = Duration.seconds(5);
+        final Duration highest = Duration.seconds(10);
+        Assert.assertEquals(lowest, lowest.lowest(highest));
+        Assert.assertEquals(lowest, highest.lowest(lowest));
+        Assert.assertEquals(highest, highest.lowest(null));
+        Assert.assertEquals(highest, lowest.highest(highest));
+        Assert.assertEquals(highest, highest.highest(lowest));
+        Assert.assertEquals(lowest, lowest.highest(null));
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
@@ -60,7 +60,7 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(5), () ->
         {
-            try (final Pool pool = new Pool(2, "testPoolQueue", Duration.ONE_SECOND))
+            try (Pool pool = new Pool(2, "testPoolQueue", Duration.ONE_SECOND))
             {
                 pool.queue(() -> System.out.println("1"));
                 pool.queue(() -> System.out.println("2"));
@@ -76,7 +76,7 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(5), () ->
         {
-            try (final Pool pool = new Pool(2, "testTickerCallable", Duration.seconds(10)))
+            try (Pool pool = new Pool(2, "testTickerCallable", Duration.seconds(10)))
             {
                 final List<Result<Boolean>> results = new ArrayList<>();
                 for (int index = 0; index < 5; index++)
@@ -106,8 +106,7 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(500000), () ->
         {
-            try (final Pool pool = new Pool(2, "testTickerCallableWithErrors",
-                    Duration.seconds(10)))
+            try (Pool pool = new Pool(2, "testTickerCallableWithErrors", Duration.seconds(10)))
             {
                 final List<Result<Boolean>> results = new ArrayList<>();
                 for (int index = 0; index < 5; index++)
@@ -144,7 +143,7 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(5), () ->
         {
-            try (final Pool pool = new Pool(2, "testTickerRunnable", Duration.seconds(10)))
+            try (Pool pool = new Pool(2, "testTickerRunnable", Duration.seconds(10)))
             {
                 for (int index = 0; index < 5; index++)
                 {
@@ -167,8 +166,7 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(5), () ->
         {
-            try (final Pool pool = new Pool(2, "testTickerRunnableWithErrors",
-                    Duration.seconds(10)))
+            try (Pool pool = new Pool(2, "testTickerRunnableWithErrors", Duration.seconds(10)))
             {
                 for (int index = 0; index < 5; index++)
                 {
@@ -214,7 +212,7 @@ public class PoolTest
 
     private void runWithTimer(final Duration maximum, final Runnable test)
     {
-        try (final Pool pool = new Pool(1, "RunWithTimer", maximum))
+        try (Pool pool = new Pool(1, "RunWithTimer", maximum))
         {
             pool.queue(() ->
             {

--- a/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
@@ -21,30 +21,6 @@ public class PoolTest
 {
     private static final Logger logger = LoggerFactory.getLogger(PoolTest.class);
 
-    public static void main(final String[] args)
-    {
-        new PoolTest().mainTest();
-    }
-
-    public void mainTest()
-    {
-        final Pool pool = new Pool(10, "test", Duration.milliseconds(100));
-        for (int index = 0; index < 1000; index++)
-        {
-            final int idx = index;
-            final Callable<Boolean> runnable = () ->
-            {
-                Duration.milliseconds(100).sleep();
-                System.out.println("Thread " + idx + " done.");
-                return true;
-            };
-            pool.queue(runnable);
-        }
-        System.out.println("All submitted to pool!");
-        pool.close();
-        System.out.println("Pool Ended.");
-    }
-
     @Test
     public void testCallable()
     {
@@ -82,16 +58,143 @@ public class PoolTest
     @Test
     public void testQueue()
     {
-        final Pool pool = new Pool(2, "testPoolQueue", Duration.ONE_SECOND);
-        pool.queue(() -> System.out.println("1"));
-        pool.queue(() -> System.out.println("2"));
-        pool.queue(() -> System.out.println("3"));
-        pool.queue(() -> System.out.println("4"));
-        pool.close();
+        runWithTimer(Duration.seconds(5), () ->
+        {
+            try (final Pool pool = new Pool(2, "testPoolQueue", Duration.ONE_SECOND))
+            {
+                pool.queue(() -> System.out.println("1"));
+                pool.queue(() -> System.out.println("2"));
+                pool.queue(() -> System.out.println("3"));
+                pool.queue(() -> System.out.println("4"));
+                pool.close();
+            }
+        });
     }
 
     @Test
-    public void testTimeout()
+    public void testTickerCallable()
+    {
+        runWithTimer(Duration.seconds(5), () ->
+        {
+            try (final Pool pool = new Pool(2, "testTickerCallable", Duration.seconds(10)))
+            {
+                final List<Result<Boolean>> results = new ArrayList<>();
+                for (int index = 0; index < 5; index++)
+                {
+                    final int idx = index;
+                    final Callable<Boolean> callable = () ->
+                    {
+                        Duration.milliseconds(100).sleep();
+                        System.out.println("Thread " + idx + " done.");
+                        return true;
+                    };
+                    results.add(pool.queue(callable,
+                            new LogTicker("Ticker " + idx, Duration.milliseconds(50))));
+                }
+                System.out.println("All submitted to pool!");
+                for (final Result<Boolean> result : results)
+                {
+                    Assert.assertTrue(result.get());
+                }
+            }
+            System.out.println("Pool Ended.");
+        });
+    }
+
+    @Test(expected = CoreException.class)
+    public void testTickerCallableWithErrors()
+    {
+        runWithTimer(Duration.seconds(500000), () ->
+        {
+            try (final Pool pool = new Pool(2, "testTickerCallableWithErrors",
+                    Duration.seconds(10)))
+            {
+                final List<Result<Boolean>> results = new ArrayList<>();
+                for (int index = 0; index < 5; index++)
+                {
+                    final int idx = index;
+                    final Callable<Boolean> callable = () ->
+                    {
+                        Duration.milliseconds(100).sleep();
+                        if (idx != 3)
+                        {
+                            System.out.println("Thread " + idx + " done.");
+                        }
+                        else
+                        {
+                            throw new CoreException("Failing task {} on purpose.", idx);
+                        }
+                        return true;
+                    };
+                    results.add(pool.queue(callable,
+                            new LogTicker("Ticker " + idx, Duration.milliseconds(50))));
+                }
+                System.out.println("All submitted to pool!");
+                for (final Result<Boolean> result : results)
+                {
+                    Assert.assertTrue(result.get());
+                }
+            }
+            System.out.println("Pool Ended.");
+        });
+    }
+
+    @Test
+    public void testTickerRunnable()
+    {
+        runWithTimer(Duration.seconds(5), () ->
+        {
+            try (final Pool pool = new Pool(2, "testTickerRunnable", Duration.seconds(10)))
+            {
+                for (int index = 0; index < 5; index++)
+                {
+                    final int idx = index;
+                    final Runnable runnable = () ->
+                    {
+                        Duration.milliseconds(100).sleep();
+                        System.out.println("Thread " + idx + " done.");
+                    };
+                    pool.queue(runnable, new LogTicker("Ticker " + idx, Duration.milliseconds(50)));
+                }
+                System.out.println("All submitted to pool!");
+            }
+            System.out.println("Pool Ended.");
+        });
+    }
+
+    @Test(expected = CoreException.class)
+    public void testTickerRunnableWithErrors()
+    {
+        runWithTimer(Duration.seconds(5), () ->
+        {
+            try (final Pool pool = new Pool(2, "testTickerRunnableWithErrors",
+                    Duration.seconds(10)))
+            {
+                for (int index = 0; index < 5; index++)
+                {
+                    final int idx = index;
+                    final Runnable runnable = () ->
+                    {
+                        Duration.milliseconds(100).sleep();
+                        if (idx != 3)
+                        {
+                            System.out.println("Thread " + idx + " done.");
+                        }
+                        else
+                        {
+                            throw new CoreException("Failing task {} on purpose.", idx);
+                        }
+                    };
+                    pool.queue(runnable, new LogTicker("Ticker " + idx, Duration.milliseconds(50)));
+                }
+                System.out.println("All submitted to pool!");
+            }
+            System.out.println("Pool Ended.");
+        });
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testTimeout() throws TimeoutException
     {
         try (Pool pool = new Pool(1, "testPoolTimeout", Duration.ONE_SECOND))
         {
@@ -105,7 +208,24 @@ public class PoolTest
         }
         catch (final TimeoutException e)
         {
-            // Normal
+            throw e;
+        }
+    }
+
+    private void runWithTimer(final Duration maximum, final Runnable test)
+    {
+        try (final Pool pool = new Pool(1, "RunWithTimer", maximum))
+        {
+            pool.queue(() ->
+            {
+                test.run();
+                return true;
+            }).get(maximum);
+        }
+        catch (final TimeoutException e)
+        {
+            throw new RuntimeException(
+                    "Timeout while running unit test (Max allowed time was " + maximum + ").", e);
         }
     }
 }


### PR DESCRIPTION
### Description:

This change brings the ability to schedule a companion ticker thread that allows time-based reporting on the initial Runnable or Callable execution.

### Potential Impact:

No impact, it is a new feature.

### Unit Test Approach:

Tested the new option with Callable and Runnable, and made sure they still report errors properly.

### Test Results:

Companion thread has the same lifespan as other thread.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
