### PR TITLE
Tentative fix for release failures

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -8,6 +8,8 @@ then
 	./gradlew uploadArchives
 	if [ "$MANUAL_RELEASE_TRIGGERED" = "true" ];
 	then
+		## Sleep 20s to give Travis enough time to wrap the upload step
+		sleep 20
 		echo "Promote repository"
 		./gradlew closeAndReleaseRepository
 		#python -m pip install --user --upgrade twine

--- a/gradle/deployment.gradle
+++ b/gradle/deployment.gradle
@@ -1,7 +1,7 @@
 import org.gradle.plugins.signing.Sign
 
 nexusStaging {
-    delayBetweenRetriesInMillis = 20000
+    delayBetweenRetriesInMillis = 5000
 }
 
 gradle.taskGraph.whenReady { taskGraph ->

--- a/gradle/deployment.gradle
+++ b/gradle/deployment.gradle
@@ -1,5 +1,9 @@
 import org.gradle.plugins.signing.Sign
 
+nexusStaging {
+    delayBetweenRetriesInMillis = 20000
+}
+
 gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.allTasks.any { it instanceof Sign }) {
         allprojects { ext."signing.keyId" = System.getenv('GPG_KEY_ID') }


### PR DESCRIPTION
### Description:

The nexus plugin failed multiple times uploading full staged repositories.
https://travis-ci.org/osmlab/atlas/builds/440233428

```
> Task :uploadArchives
Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.8.1/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 1m 44s
11 actionable tasks: 1 executed, 10 up-to-date
Promote repository
> Task :closeRepository
Requested operation wasn't successful in first try. Retrying maximum 20 times with 2 seconds delay between.
Attempt 21/21 failed. WrongNumberOfRepositories was thrown with message 'Wrong number of received repositories in state 'open'. Expected 1, received 8'. Giving up. Configure longer timeout if necessary.
> Task :closeRepository FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':closeRepository'.
> Wrong number of received repositories in state 'open'. Expected 1, received 8
```

idea comes from: https://github.com/Codearte/gradle-nexus-staging-plugin#1-why-do-i-get-wrong-number-of-received-repositories-in-state-open-expected-1-received-2

Also tried uploading archives from laptop and only one staging repo showed up. Increasing the time travis waits before trying to promote a repository may help. 

### Potential Impact:

Hopefully that helps resuming releases

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)