### PR TITLE
Fix for edge case in PyAtlas package.sh

### DIFF
--- a/pyatlas/package.sh
+++ b/pyatlas/package.sh
@@ -58,7 +58,7 @@ fi
 #####################################################################
 echo "Preparing protoc..."
 # hack to grab the protoc version from dependencies.gradle
-protoc_version=$(grep 'protoc' "$gradle_project_root_dir/dependencies.gradle" | awk -F':' '{print $2; exit}' | tr -d "'")
+protoc_version=$(grep 'protoc' "$gradle_project_root_dir/dependencies.gradle" | awk -F':' '{print $2; exit}' | tr -d "'" | tr -d ',')
 protoc_path="$pyatlas_root_dir/protoc"
 # detemine what platform we are on
 if [ ! -f "$protoc_path" ];


### PR DESCRIPTION
### Description:

Previously if `dependencies.gradle` was modified so the `protoc` declaration had a trailing comma, this would break the `pyatlas/package.sh` script. This is fixed.

### Potential Impact:

N/A

### Unit Test Approach:

Travis passes.

### Test Results:

Travis passes.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)