### PR TITLE
AtlasStatistics: protect from malformed multipolygons

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/coverage/poi/SimpleCoverage.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/coverage/poi/SimpleCoverage.java
@@ -79,8 +79,7 @@ public abstract class SimpleCoverage<T extends AtlasEntity> extends Coverage<T>
                 final StringList sources = StringList.split(split.get(1), VALUES_SEPARATOR);
                 final String type = split.get(0);
                 final String coverageTypes = split.size() > COVERAGE_TYPE_INDEX
-                        ? split.get(COVERAGE_TYPE_INDEX)
-                        : CoverageType.COUNT.name();
+                        ? split.get(COVERAGE_TYPE_INDEX) : CoverageType.COUNT.name();
                 final Set<CoverageType> coverageTypeSet = StringList
                         .split(coverageTypes, VALUES_SEPARATOR).stream().map(CoverageType::forName)
                         .collect(Collectors.toSet());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/coverage/poi/SimpleCoverage.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/statistics/coverage/poi/SimpleCoverage.java
@@ -38,6 +38,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class SimpleCoverage<T extends AtlasEntity> extends Coverage<T>
 {
+    private static final Logger logger = LoggerFactory.getLogger(SimpleCoverage.class);
+
     private static final String TYPE_SEPARATOR = ";";
     private static final String VALUES_SEPARATOR = ",";
     private static final String COMMENTED_LINE = "#";
@@ -77,7 +79,8 @@ public abstract class SimpleCoverage<T extends AtlasEntity> extends Coverage<T>
                 final StringList sources = StringList.split(split.get(1), VALUES_SEPARATOR);
                 final String type = split.get(0);
                 final String coverageTypes = split.size() > COVERAGE_TYPE_INDEX
-                        ? split.get(COVERAGE_TYPE_INDEX) : CoverageType.COUNT.name();
+                        ? split.get(COVERAGE_TYPE_INDEX)
+                        : CoverageType.COUNT.name();
                 final Set<CoverageType> coverageTypeSet = StringList
                         .split(coverageTypes, VALUES_SEPARATOR).stream().map(CoverageType::forName)
                         .collect(Collectors.toSet());
@@ -278,6 +281,11 @@ public abstract class SimpleCoverage<T extends AtlasEntity> extends Coverage<T>
             {
                 // Many features will not be multipolygons.
             }
+            catch (final IllegalArgumentException e)
+            {
+                logger.error("AtlasStatistics cannot compute surface of {}", item, e);
+            }
+            return result;
         }
         if (item instanceof Relation)
         {

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Surface.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Surface.java
@@ -127,7 +127,8 @@ public final class Surface implements Serializable
     {
         if (factor < 0)
         {
-            throw new IllegalArgumentException("Scale factor must not be a negative number");
+            throw new IllegalArgumentException(
+                    "Scale factor must not be a negative number. Was: " + factor);
         }
         return Surface.forDm7Squared((long) (this.asDm7Squared() * factor));
     }
@@ -138,7 +139,8 @@ public final class Surface implements Serializable
         {
             return Surface.forDm7Squared(this.asDm7Squared() - other.asDm7Squared());
         }
-        throw new IllegalArgumentException("Invalid surfaces for performing subtraction");
+        throw new IllegalArgumentException(
+                "Invalid surfaces for performing subtraction: " + this + " minus " + other);
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
@@ -150,7 +150,7 @@ public class AtlasStatisticsTest
                 statistics.get(new StatisticKey("", "wetland_surface", "true")).getCount(), 0.01);
 
         // Lakes2
-        Assert.assertEquals(2.0, statistics.get(new StatisticKey("", "lakes2", "true")).getCount(),
+        Assert.assertEquals(3.0, statistics.get(new StatisticKey("", "lakes2", "true")).getCount(),
                 0.01);
         Assert.assertEquals(2.08,
                 statistics.get(new StatisticKey("", "lakes2_surface", "true")).getCount(), 0.01);

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/statistics/waterAtlas.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/statistics/waterAtlas.josm.osm
@@ -1,405 +1,442 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <osm version='0.6' generator='JOSM'>
-  <node id='-38981' action='modify' lat='41.33596669689' lon='9.14987753446' />
-  <node id='-38983' action='modify' lat='41.31775302928' lon='9.14041255168' />
-  <node id='-38985' action='modify' lat='41.29938612965' lon='9.15599033584' />
-  <node id='-38987' action='modify' lat='41.28620024612' lon='9.14711691448' />
-  <node id='-38989' action='modify' lat='41.33433803962' lon='9.18083591565' />
-  <node id='-38991' action='modify' lat='41.31819732565' lon='9.17215968143' />
-  <node id='-38993' action='modify' lat='41.30205261352' lon='9.18241341278' />
-  <node id='-38995' action='modify' lat='41.28723743465' lon='9.17097655858' />
-  <node id='-38997' action='modify' lat='41.3321170777' lon='9.19937150694' />
-  <node id='-38999' action='modify' lat='41.31790112841' lon='9.18951214987' />
-  <node id='-39001' action='modify' lat='41.30234888278' lon='9.20311806262' />
-  <node id='-39003' action='modify' lat='41.28768193898' lon='9.19049808558' />
-  <node id='-39005' action='modify' lat='41.3300441116' lon='9.22145646676' />
-  <node id='-39007' action='modify' lat='41.31849352155' lon='9.2125830454' />
-  <node id='-39009' action='modify' lat='41.31271745875' lon='9.21987896963' />
-  <node id='-39011' action='modify' lat='41.31464286989' lon='9.22855520385' />
-  <node id='-39013' action='modify' lat='41.32249203442' lon='9.23171019811' />
-  <node id='-39015' action='modify' lat='41.30531795966' lon='9.2131196435' />
-  <node id='-39017' action='modify' lat='41.30801213652' lon='9.21625788157' />
-  <node id='-39019' action='modify' lat='41.30599151431' lon='9.22298267745' />
-  <node id='-39021' action='modify' lat='41.30655280454' lon='9.23120187241' />
-  <node id='-39023' action='modify' lat='41.30419535312' lon='9.23583450957' />
-  <node id='-39025' action='modify' lat='41.30312647207' lon='9.22268903429' />
-  <node id='-39027' action='modify' lat='41.30368196667' lon='9.22875253888' />
-  <node id='-39029' action='modify' lat='41.30220063722' lon='9.23151315886' />
-  <node id='-39031' action='modify' lat='41.30446564732' lon='9.21745375567' />
-  <node id='-39033' action='modify' lat='41.30382755884' lon='9.21558506018' />
-  <node id='-39035' action='modify' lat='41.29285594366' lon='9.20654428753' />
-  <node id='-39037' action='modify' lat='41.29431558215' lon='9.21566012194' />
-  <node id='-39039' action='modify' lat='41.29105942067' lon='9.22432763663' />
-  <node id='-39041' action='modify' lat='41.29476469512' lon='9.23777722838' />
-  <node id='-47976' action='modify' lat='41.34730246891' lon='9.15617862117' />
-  <node id='-47977' action='modify' lat='41.34925794861' lon='9.1573111639' />
-  <node id='-47979' action='modify' lat='41.34925794861' lon='9.16523896297' />
-  <node id='-47981' action='modify' lat='41.3461971718' lon='9.16761730269' />
-  <node id='-47983' action='modify' lat='41.34390149477' lon='9.16773055696' />
-  <node id='-47985' action='modify' lat='41.34262608367' lon='9.16478594588' />
-  <node id='-47987' action='modify' lat='41.34288116789' lon='9.1593497408' />
-  <node id='-47989' action='modify' lat='41.34449667807' lon='9.15674489253' />
-  <node id='-47993' action='modify' lat='41.34669327866' lon='9.17065134265' />
-  <node id='-47994' action='modify' lat='41.34907387714' lon='9.17212364819' />
-  <node id='-47996' action='modify' lat='41.35000908844' lon='9.17744659899' />
-  <node id='-47998' action='modify' lat='41.34873379697' lon='9.1815237528' />
-  <node id='-48000' action='modify' lat='41.34507782297' lon='9.1827695498' />
-  <node id='-48002' action='modify' lat='41.34278210648' lon='9.18118398998' />
-  <node id='-48004' action='modify' lat='41.34167673263' lon='9.17393571655' />
-  <node id='-48006' action='modify' lat='41.34320724527' lon='9.17065134265' />
-  <node id='-48020' action='modify' lat='41.34716086057' lon='9.17365263749' />
-  <node id='-48021' action='modify' lat='41.34465265388' lon='9.17201045054' />
-  <node id='-48023' action='modify' lat='41.34427003759' lon='9.17433216313' />
-  <node id='-48068' action='modify' lat='41.35290979365' lon='9.16362753868' />
-  <node id='-48069' action='modify' lat='41.35458493073' lon='9.16620245934' />
-  <node id='-48071' action='modify' lat='41.35239435818' lon='9.16912070274' />
-  <node id='-48073' action='modify' lat='41.3548426403' lon='9.17332640648' />
-  <node id='-48075' action='modify' lat='41.35168562775' lon='9.17504302025' />
-  <node id='-48077' action='modify' lat='41.35020371192' lon='9.17032233238' />
-  <node id='-48079' action='modify' lat='41.3518144884' lon='9.16671744347' />
-  <node id='-48081' action='modify' lat='41.35059030191' lon='9.16414252281' />
-  <node id='-48107' action='modify' lat='41.34010917606' lon='9.18905981824' />
-  <node id='-48108' action='modify' lat='41.34369946975' lon='9.19996893156' />
-  <node id='-48110' action='modify' lat='41.34010917606' lon='9.20370492927' />
-  <node id='-48112' action='modify' lat='41.34257752423' lon='9.21072860496' />
-  <node id='-48114' action='modify' lat='41.3369675067' lon='9.21042972515' />
-  <node id='-48224' action='modify' lat='41.35256215977' lon='9.19817565266' />
-  <node id='-48225' action='modify' lat='41.34897235475' lon='9.21102748478' />
-  <node id='-48227' action='modify' lat='41.34134336184' lon='9.21715452102' />
-  <node id='-48229' action='modify' lat='41.33707971179' lon='9.23179963205' />
-  <node id='-48231' action='modify' lat='41.32675603472' lon='9.24046714673' />
-  <node id='-48258' action='modify' lat='41.3283271346' lon='9.21297020359'>
+  <node id='-40923' action='modify' lat='41.33596669689' lon='9.14987753446' />
+  <node id='-40925' action='modify' lat='41.31775302928' lon='9.14041255168' />
+  <node id='-40927' action='modify' lat='41.29938612965' lon='9.15599033584' />
+  <node id='-40929' action='modify' lat='41.28620024612' lon='9.14711691448' />
+  <node id='-40931' action='modify' lat='41.33433803962' lon='9.18083591565' />
+  <node id='-40933' action='modify' lat='41.31819732565' lon='9.17215968143' />
+  <node id='-40935' action='modify' lat='41.30205261352' lon='9.18241341278' />
+  <node id='-40937' action='modify' lat='41.28723743465' lon='9.17097655858' />
+  <node id='-40939' action='modify' lat='41.3321170777' lon='9.19937150694' />
+  <node id='-40941' action='modify' lat='41.31790112841' lon='9.18951214987' />
+  <node id='-40943' action='modify' lat='41.30234888278' lon='9.20311806262' />
+  <node id='-40945' action='modify' lat='41.28768193898' lon='9.19049808558' />
+  <node id='-40947' action='modify' lat='41.3300441116' lon='9.22145646676' />
+  <node id='-40949' action='modify' lat='41.31849352155' lon='9.2125830454' />
+  <node id='-40951' action='modify' lat='41.31271745875' lon='9.21987896963' />
+  <node id='-40953' action='modify' lat='41.31464286989' lon='9.22855520385' />
+  <node id='-40955' action='modify' lat='41.32249203442' lon='9.23171019811' />
+  <node id='-40957' action='modify' lat='41.30531795966' lon='9.2131196435' />
+  <node id='-40959' action='modify' lat='41.30801213652' lon='9.21625788157' />
+  <node id='-40961' action='modify' lat='41.30599151431' lon='9.22298267745' />
+  <node id='-40963' action='modify' lat='41.30655280454' lon='9.23120187241' />
+  <node id='-40965' action='modify' lat='41.30419535312' lon='9.23583450957' />
+  <node id='-40967' action='modify' lat='41.30312647207' lon='9.22268903429' />
+  <node id='-40969' action='modify' lat='41.30368196667' lon='9.22875253888' />
+  <node id='-40971' action='modify' lat='41.30220063722' lon='9.23151315886' />
+  <node id='-40973' action='modify' lat='41.30446564732' lon='9.21745375567' />
+  <node id='-40975' action='modify' lat='41.30382755884' lon='9.21558506018' />
+  <node id='-40977' action='modify' lat='41.29285594366' lon='9.20654428753' />
+  <node id='-40979' action='modify' lat='41.29431558215' lon='9.21566012194' />
+  <node id='-40981' action='modify' lat='41.29105942067' lon='9.22432763663' />
+  <node id='-40983' action='modify' lat='41.29476469512' lon='9.23777722838' />
+  <node id='-40985' action='modify' lat='41.34730246891' lon='9.15617862117' />
+  <node id='-40987' action='modify' lat='41.34925794861' lon='9.1573111639' />
+  <node id='-40989' action='modify' lat='41.34925794861' lon='9.16523896297' />
+  <node id='-40991' action='modify' lat='41.3461971718' lon='9.16761730269' />
+  <node id='-40993' action='modify' lat='41.34390149477' lon='9.16773055696' />
+  <node id='-40995' action='modify' lat='41.34262608367' lon='9.16478594588' />
+  <node id='-40997' action='modify' lat='41.34288116789' lon='9.1593497408' />
+  <node id='-40999' action='modify' lat='41.34449667807' lon='9.15674489253' />
+  <node id='-41001' action='modify' lat='41.34669327866' lon='9.17065134265' />
+  <node id='-41003' action='modify' lat='41.34907387714' lon='9.17212364819' />
+  <node id='-41005' action='modify' lat='41.35000908844' lon='9.17744659899' />
+  <node id='-41007' action='modify' lat='41.34873379697' lon='9.1815237528' />
+  <node id='-41009' action='modify' lat='41.34507782297' lon='9.1827695498' />
+  <node id='-41011' action='modify' lat='41.34278210648' lon='9.18118398998' />
+  <node id='-41013' action='modify' lat='41.34167673263' lon='9.17393571655' />
+  <node id='-41015' action='modify' lat='41.34320724527' lon='9.17065134265' />
+  <node id='-41017' action='modify' lat='41.34716086057' lon='9.17365263749' />
+  <node id='-41019' action='modify' lat='41.34465265388' lon='9.17201045054' />
+  <node id='-41021' action='modify' lat='41.34427003759' lon='9.17433216313' />
+  <node id='-41023' action='modify' lat='41.35290979365' lon='9.16362753868' />
+  <node id='-41025' action='modify' lat='41.35458493073' lon='9.16620245934' />
+  <node id='-41027' action='modify' lat='41.35239435818' lon='9.16912070274' />
+  <node id='-41029' action='modify' lat='41.3548426403' lon='9.17332640648' />
+  <node id='-41031' action='modify' lat='41.35168562775' lon='9.17504302025' />
+  <node id='-41033' action='modify' lat='41.35020371192' lon='9.17032233238' />
+  <node id='-41035' action='modify' lat='41.3518144884' lon='9.16671744347' />
+  <node id='-41037' action='modify' lat='41.35059030191' lon='9.16414252281' />
+  <node id='-41039' action='modify' lat='41.34010917606' lon='9.18905981824' />
+  <node id='-41041' action='modify' lat='41.34369946975' lon='9.19996893156' />
+  <node id='-41043' action='modify' lat='41.34010917606' lon='9.20370492927' />
+  <node id='-41045' action='modify' lat='41.34257752423' lon='9.21072860496' />
+  <node id='-41047' action='modify' lat='41.3369675067' lon='9.21042972515' />
+  <node id='-41049' action='modify' lat='41.35256215977' lon='9.19817565266' />
+  <node id='-41051' action='modify' lat='41.34897235475' lon='9.21102748478' />
+  <node id='-41053' action='modify' lat='41.34134336184' lon='9.21715452102' />
+  <node id='-41055' action='modify' lat='41.33707971179' lon='9.23179963205' />
+  <node id='-41057' action='modify' lat='41.32675603472' lon='9.24046714673' />
+  <node id='-41059' action='modify' lat='41.3283271346' lon='9.21297020359'>
     <tag k='seamark:type' v='harbour' />
   </node>
-  <node id='-48265' action='modify' lat='41.34493358749' lon='9.13735360994' />
-  <node id='-48266' action='modify' lat='41.34919672336' lon='9.14363008609' />
-  <node id='-48268' action='modify' lat='41.34358727607' lon='9.14811328334' />
-  <node id='-48279' action='modify' lat='41.35144036697' lon='9.14482560536' />
-  <node id='-48280' action='modify' lat='41.34684081436' lon='9.14796384343' />
-  <node id='-48282' action='modify' lat='41.35166472707' lon='9.15199872096' />
-  <node id='-48300' action='modify' lat='41.3238381212' lon='9.21117699941' />
-  <node id='-48301' action='modify' lat='41.32731709006' lon='9.21580963657' />
-  <node id='-48303' action='modify' lat='41.33130084238' lon='9.21625795629' />
-  <node id='-48313' action='modify' lat='41.34721212447' lon='9.13338420745' />
-  <node id='-48314' action='modify' lat='41.35204635853' lon='9.13949867228' />
-  <node id='-48316' action='modify' lat='41.35434127328' lon='9.14639370709' />
-  <node id='-48318' action='modify' lat='41.35360886247' lon='9.15452464437' />
-  <node id='-48320' action='modify' lat='41.34862825041' lon='9.15400426438' />
-  <node id='-48322' action='modify' lat='41.3419868416' lon='9.15127226946' />
-  <node id='-48324' action='modify' lat='41.33998451929' lon='9.14457237714' />
-  <node id='-48326' action='modify' lat='41.34027754591' lon='9.13819772231' />
-  <node id='-48328' action='modify' lat='41.34311006862' lon='9.13260363747' />
-  <node id='-48404' action='modify' lat='41.35391613251' lon='9.21736498147' />
-  <node id='-48405' action='modify' lat='41.35517426565' lon='9.21820302682' />
-  <node id='-48407' action='modify' lat='41.35510025849' lon='9.2206185693' />
-  <node id='-48409' action='modify' lat='41.35406414944' lon='9.22155520822' />
-  <node id='-48411' action='modify' lat='41.35291700946' lon='9.22155520822' />
-  <node id='-48413' action='modify' lat='41.35199188185' lon='9.22017489824' />
-  <node id='-48415' action='modify' lat='41.35217690842' lon='9.21825232361' />
-  <node id='-48435' action='modify' lat='41.35021559998' lon='9.21832626879' />
-  <node id='-48436' action='modify' lat='41.35147380464' lon='9.21916431414' />
-  <node id='-48437' action='modify' lat='41.35139979328' lon='9.22157985662' />
-  <node id='-48438' action='modify' lat='41.35036362532' lon='9.22251649554' />
-  <node id='-48439' action='modify' lat='41.34921642013' lon='9.22251649554' />
-  <node id='-48440' action='modify' lat='41.34829123993' lon='9.22113618555' />
-  <node id='-48441' action='modify' lat='41.34847627702' lon='9.21921361092' />
-  <node id='-48477' action='modify' lat='41.35336469929' lon='9.21596203896' />
-  <node id='-48479' action='modify' lat='41.3516312877' lon='9.21560427772' />
-  <node id='-48481' action='modify' lat='41.35014198173' lon='9.21609213395' />
-  <node id='-48491' action='modify' lat='41.35624547841' lon='9.20688791296' />
-  <node id='-48492' action='modify' lat='41.35543984964' lon='9.20646510422' />
-  <node id='-48494' action='modify' lat='41.35390180337' lon='9.21160385658' />
-  <node id='-48496' action='modify' lat='41.35470745118' lon='9.21205918907' />
-  <node id='-48504' action='modify' lat='41.35556191524' lon='9.21241695031' />
-  <node id='-48505' action='modify' lat='41.35702668468' lon='9.2072456742' />
-  <node id='-67770' action='modify' lat='41.35617335406' lon='9.140314106' />
-  <node id='-67771' action='modify' lat='41.35532227972' lon='9.13991973172' />
-  <node id='-67773' action='modify' lat='41.35465621377' lon='9.14060988671' />
-  <node id='-67775' action='modify' lat='41.35476722524' lon='9.14317331955' />
-  <node id='-67777' action='modify' lat='41.35621035704' lon='9.14312402276' />
-  <node id='-67781' action='modify' lat='41.35665439115' lon='9.14445503597' />
-  <node id='-67782' action='modify' lat='41.35743144357' lon='9.14687057845' />
-  <node id='-67784' action='modify' lat='41.35691340966' lon='9.14849737236' />
-  <node id='-67786' action='modify' lat='41.35584032629' lon='9.14844807558' />
-  <node id='-67788' action='modify' lat='41.3552112692' lon='9.14682128166' />
-  <node id='-67790' action='modify' lat='41.3552112692' lon='9.14489870704' />
-  <node id='-78349' action='modify' lat='41.31732854172' lon='9.23622692009' />
-  <node id='-78350' action='modify' lat='41.31967148891' lon='9.2385058787' />
-  <node id='-78352' action='modify' lat='41.31631838282' lon='9.24181223667' />
-  <node id='-78354' action='modify' lat='41.31386307022' lon='9.24054199745' />
-  <node id='-78356' action='modify' lat='41.31238983827' lon='9.23701147961' />
-  <node id='-78358' action='modify' lat='41.31491535837' lon='9.23503140083' />
-  <node id='-78367' action='modify' lat='41.33477572311' lon='9.1607309998' />
-  <node id='-78368' action='modify' lat='41.33480220057' lon='9.16460989546' />
-  <node id='-78370' action='modify' lat='41.3330375813' lon='9.1646312599' />
-  <node id='-78372' action='modify' lat='41.33301110313' lon='9.16075236425' />
-  <node id='-78389' action='modify' lat='41.33204380437' lon='9.16077347015' />
-  <node id='-78390' action='modify' lat='41.33207028294' lon='9.16465236581' />
-  <node id='-78391' action='modify' lat='41.33030558967' lon='9.16467373026' />
-  <node id='-78392' action='modify' lat='41.33027911039' lon='9.1607948346' />
-  <way id='-39043' action='modify'>
-    <nd ref='-38981' />
-    <nd ref='-38983' />
-    <nd ref='-38985' />
-    <nd ref='-38987' />
+  <node id='-41061' action='modify' lat='41.34493358749' lon='9.13735360994' />
+  <node id='-41063' action='modify' lat='41.34919672336' lon='9.14363008609' />
+  <node id='-41065' action='modify' lat='41.34358727607' lon='9.14811328334' />
+  <node id='-41067' action='modify' lat='41.35144036697' lon='9.14482560536' />
+  <node id='-41069' action='modify' lat='41.34684081436' lon='9.14796384343' />
+  <node id='-41071' action='modify' lat='41.35166472707' lon='9.15199872096' />
+  <node id='-41073' action='modify' lat='41.3238381212' lon='9.21117699941' />
+  <node id='-41075' action='modify' lat='41.32731709006' lon='9.21580963657' />
+  <node id='-41077' action='modify' lat='41.33130084238' lon='9.21625795629' />
+  <node id='-41079' action='modify' lat='41.34721212447' lon='9.13338420745' />
+  <node id='-41081' action='modify' lat='41.35204635853' lon='9.13949867228' />
+  <node id='-41083' action='modify' lat='41.35434127328' lon='9.14639370709' />
+  <node id='-41085' action='modify' lat='41.35360886247' lon='9.15452464437' />
+  <node id='-41087' action='modify' lat='41.34862825041' lon='9.15400426438' />
+  <node id='-41089' action='modify' lat='41.3419868416' lon='9.15127226946' />
+  <node id='-41091' action='modify' lat='41.33998451929' lon='9.14457237714' />
+  <node id='-41093' action='modify' lat='41.34027754591' lon='9.13819772231' />
+  <node id='-41095' action='modify' lat='41.34311006862' lon='9.13260363747' />
+  <node id='-41097' action='modify' lat='41.35391613251' lon='9.21736498147' />
+  <node id='-41099' action='modify' lat='41.35517426565' lon='9.21820302682' />
+  <node id='-41101' action='modify' lat='41.35510025849' lon='9.2206185693' />
+  <node id='-41103' action='modify' lat='41.35406414944' lon='9.22155520822' />
+  <node id='-41105' action='modify' lat='41.35291700946' lon='9.22155520822' />
+  <node id='-41107' action='modify' lat='41.35199188185' lon='9.22017489824' />
+  <node id='-41109' action='modify' lat='41.35217690842' lon='9.21825232361' />
+  <node id='-41111' action='modify' lat='41.35021559998' lon='9.21832626879' />
+  <node id='-41113' action='modify' lat='41.35147380464' lon='9.21916431414' />
+  <node id='-41115' action='modify' lat='41.35139979328' lon='9.22157985662' />
+  <node id='-41117' action='modify' lat='41.35036362532' lon='9.22251649554' />
+  <node id='-41119' action='modify' lat='41.34921642013' lon='9.22251649554' />
+  <node id='-41121' action='modify' lat='41.34829123993' lon='9.22113618555' />
+  <node id='-41123' action='modify' lat='41.34847627702' lon='9.21921361092' />
+  <node id='-41125' action='modify' lat='41.35336469929' lon='9.21596203896' />
+  <node id='-41127' action='modify' lat='41.3516312877' lon='9.21560427772' />
+  <node id='-41129' action='modify' lat='41.35014198173' lon='9.21609213395' />
+  <node id='-41131' action='modify' lat='41.35624547841' lon='9.20688791296' />
+  <node id='-41133' action='modify' lat='41.35543984964' lon='9.20646510422' />
+  <node id='-41135' action='modify' lat='41.35390180337' lon='9.21160385658' />
+  <node id='-41137' action='modify' lat='41.35470745118' lon='9.21205918907' />
+  <node id='-41139' action='modify' lat='41.35556191524' lon='9.21241695031' />
+  <node id='-41141' action='modify' lat='41.35702668468' lon='9.2072456742' />
+  <node id='-41143' action='modify' lat='41.35617335406' lon='9.140314106' />
+  <node id='-41145' action='modify' lat='41.35532227972' lon='9.13991973172' />
+  <node id='-41147' action='modify' lat='41.35465621377' lon='9.14060988671' />
+  <node id='-41149' action='modify' lat='41.35476722524' lon='9.14317331955' />
+  <node id='-41151' action='modify' lat='41.35621035704' lon='9.14312402276' />
+  <node id='-41153' action='modify' lat='41.35665439115' lon='9.14445503597' />
+  <node id='-41155' action='modify' lat='41.35743144357' lon='9.14687057845' />
+  <node id='-41157' action='modify' lat='41.35691340966' lon='9.14849737236' />
+  <node id='-41159' action='modify' lat='41.35584032629' lon='9.14844807558' />
+  <node id='-41161' action='modify' lat='41.3552112692' lon='9.14682128166' />
+  <node id='-41163' action='modify' lat='41.3552112692' lon='9.14489870704' />
+  <node id='-41165' action='modify' lat='41.31732854172' lon='9.23622692009' />
+  <node id='-41167' action='modify' lat='41.31967148891' lon='9.2385058787' />
+  <node id='-41169' action='modify' lat='41.31631838282' lon='9.24181223667' />
+  <node id='-41171' action='modify' lat='41.31386307022' lon='9.24054199745' />
+  <node id='-41173' action='modify' lat='41.31238983827' lon='9.23701147961' />
+  <node id='-41175' action='modify' lat='41.31491535837' lon='9.23503140083' />
+  <node id='-41177' action='modify' lat='41.33477572311' lon='9.1607309998' />
+  <node id='-41179' action='modify' lat='41.33480220057' lon='9.16460989546' />
+  <node id='-41181' action='modify' lat='41.3330375813' lon='9.1646312599' />
+  <node id='-41183' action='modify' lat='41.33301110313' lon='9.16075236425' />
+  <node id='-41185' action='modify' lat='41.33204380437' lon='9.16077347015' />
+  <node id='-41187' action='modify' lat='41.33207028294' lon='9.16465236581' />
+  <node id='-41189' action='modify' lat='41.33030558967' lon='9.16467373026' />
+  <node id='-41191' action='modify' lat='41.33027911039' lon='9.1607948346' />
+  <node id='-41297' action='modify' lat='41.34973868638' lon='9.23145267945' />
+  <node id='-41298' action='modify' lat='41.35143944045' lon='9.23618987368' />
+  <node id='-41300' action='modify' lat='41.3486563652' lon='9.24000022556' />
+  <node id='-41302' action='modify' lat='41.34394032721' lon='9.24133899785' />
+  <node id='-41304' action='modify' lat='41.34285790964' lon='9.23660180362' />
+  <node id='-41306' action='modify' lat='41.34548660681' lon='9.23207057435' />
+  <node id='-41310' action='modify' lat='41.34796057779' lon='9.2367047861' />
+  <node id='-41311' action='modify' lat='41.34811519786' lon='9.2354689963' />
+  <node id='-41313' action='modify' lat='41.34726478296' lon='9.2348511014' />
+  <node id='-41315' action='modify' lat='41.34610510837' lon='9.23526303133' />
+  <node id='-41317' action='modify' lat='41.34595048353' lon='9.2367047861' />
+  <node id='-41319' action='modify' lat='41.34664629241' lon='9.23763162845' />
+  <way id='-41193' action='modify'>
+    <nd ref='-40923' />
+    <nd ref='-40925' />
+    <nd ref='-40927' />
+    <nd ref='-40929' />
     <tag k='waterway' v='stream' />
   </way>
-  <way id='-39045' action='modify'>
-    <nd ref='-38989' />
-    <nd ref='-38991' />
-    <nd ref='-38993' />
-    <nd ref='-38995' />
+  <way id='-41195' action='modify'>
+    <nd ref='-40931' />
+    <nd ref='-40933' />
+    <nd ref='-40935' />
+    <nd ref='-40937' />
     <tag k='natural' v='stream' />
   </way>
-  <way id='-39047' action='modify'>
-    <nd ref='-38997' />
-    <nd ref='-38999' />
-    <nd ref='-39001' />
-    <nd ref='-39003' />
+  <way id='-41197' action='modify'>
+    <nd ref='-40939' />
+    <nd ref='-40941' />
+    <nd ref='-40943' />
+    <nd ref='-40945' />
     <tag k='stream' v='something' />
   </way>
-  <way id='-39049' action='modify'>
-    <nd ref='-39005' />
-    <nd ref='-39007' />
-    <nd ref='-39009' />
-    <nd ref='-39011' />
-    <nd ref='-39013' />
-    <nd ref='-39005' />
+  <way id='-41199' action='modify'>
+    <nd ref='-40947' />
+    <nd ref='-40949' />
+    <nd ref='-40951' />
+    <nd ref='-40953' />
+    <nd ref='-40955' />
+    <nd ref='-40947' />
     <tag k='salt' v='yes' />
     <tag k='water' v='cove' />
     <tag k='waterway' v='riverbank' />
   </way>
-  <way id='-39051' action='modify'>
-    <nd ref='-39015' />
-    <nd ref='-39017' />
-    <nd ref='-39019' />
-    <nd ref='-39021' />
-    <nd ref='-39023' />
+  <way id='-41201' action='modify'>
+    <nd ref='-40957' />
+    <nd ref='-40959' />
+    <nd ref='-40961' />
+    <nd ref='-40963' />
+    <nd ref='-40965' />
   </way>
-  <way id='-39053' action='modify'>
-    <nd ref='-39015' />
-    <nd ref='-39033' />
-    <nd ref='-39031' />
-    <nd ref='-39025' />
-    <nd ref='-39027' />
-    <nd ref='-39029' />
-    <nd ref='-39023' />
+  <way id='-41203' action='modify'>
+    <nd ref='-40957' />
+    <nd ref='-40975' />
+    <nd ref='-40973' />
+    <nd ref='-40967' />
+    <nd ref='-40969' />
+    <nd ref='-40971' />
+    <nd ref='-40965' />
   </way>
-  <way id='-39055' action='modify'>
-    <nd ref='-39035' />
-    <nd ref='-39037' />
-    <nd ref='-39039' />
-    <nd ref='-39041' />
+  <way id='-41205' action='modify'>
+    <nd ref='-40977' />
+    <nd ref='-40979' />
+    <nd ref='-40981' />
+    <nd ref='-40983' />
     <tag k='waterway' v='derelict_canal' />
   </way>
-  <way id='-47978' action='modify'>
-    <nd ref='-47976' />
-    <nd ref='-47977' />
-    <nd ref='-47979' />
-    <nd ref='-47981' />
-    <nd ref='-47983' />
-    <nd ref='-47985' />
-    <nd ref='-47987' />
-    <nd ref='-47989' />
-    <nd ref='-47976' />
+  <way id='-41207' action='modify'>
+    <nd ref='-40985' />
+    <nd ref='-40987' />
+    <nd ref='-40989' />
+    <nd ref='-40991' />
+    <nd ref='-40993' />
+    <nd ref='-40995' />
+    <nd ref='-40997' />
+    <nd ref='-40999' />
+    <nd ref='-40985' />
   </way>
-  <way id='-47995' action='modify'>
-    <nd ref='-47993' />
-    <nd ref='-47994' />
-    <nd ref='-47996' />
-    <nd ref='-47998' />
-    <nd ref='-48000' />
-    <nd ref='-48002' />
-    <nd ref='-48004' />
-    <nd ref='-48006' />
-    <nd ref='-47993' />
+  <way id='-41209' action='modify'>
+    <nd ref='-41001' />
+    <nd ref='-41003' />
+    <nd ref='-41005' />
+    <nd ref='-41007' />
+    <nd ref='-41009' />
+    <nd ref='-41011' />
+    <nd ref='-41013' />
+    <nd ref='-41015' />
+    <nd ref='-41001' />
   </way>
-  <way id='-48022' action='modify'>
-    <nd ref='-48020' />
-    <nd ref='-48021' />
-    <nd ref='-48023' />
-    <nd ref='-48020' />
+  <way id='-41211' action='modify'>
+    <nd ref='-41017' />
+    <nd ref='-41019' />
+    <nd ref='-41021' />
+    <nd ref='-41017' />
   </way>
-  <way id='-48070' action='modify'>
-    <nd ref='-48068' />
-    <nd ref='-48069' />
-    <nd ref='-48071' />
-    <nd ref='-48073' />
-    <nd ref='-48075' />
-    <nd ref='-48077' />
-    <nd ref='-48079' />
-    <nd ref='-48081' />
-    <nd ref='-48068' />
+  <way id='-41213' action='modify'>
+    <nd ref='-41023' />
+    <nd ref='-41025' />
+    <nd ref='-41027' />
+    <nd ref='-41029' />
+    <nd ref='-41031' />
+    <nd ref='-41033' />
+    <nd ref='-41035' />
+    <nd ref='-41037' />
+    <nd ref='-41023' />
     <tag k='water' v='oxbow' />
   </way>
-  <way id='-48109' action='modify'>
-    <nd ref='-48107' />
-    <nd ref='-48108' />
-    <nd ref='-48110' />
-    <nd ref='-48112' />
-    <nd ref='-48114' />
-    <nd ref='-48107' />
+  <way id='-41215' action='modify'>
+    <nd ref='-41039' />
+    <nd ref='-41041' />
+    <nd ref='-41043' />
+    <nd ref='-41045' />
+    <nd ref='-41047' />
+    <nd ref='-41039' />
     <tag k='wetland' v='mangrove' />
   </way>
-  <way id='-48226' action='modify'>
-    <nd ref='-48224' />
-    <nd ref='-48225' />
-    <nd ref='-48227' />
-    <nd ref='-48229' />
-    <nd ref='-48231' />
+  <way id='-41217' action='modify'>
+    <nd ref='-41049' />
+    <nd ref='-41051' />
+    <nd ref='-41053' />
+    <nd ref='-41055' />
+    <nd ref='-41057' />
     <tag k='natural' v='coastline' />
   </way>
-  <way id='-48267' action='modify'>
-    <nd ref='-48265' />
-    <nd ref='-48266' />
-    <nd ref='-48268' />
-    <nd ref='-48265' />
+  <way id='-41219' action='modify'>
+    <nd ref='-41061' />
+    <nd ref='-41063' />
+    <nd ref='-41065' />
+    <nd ref='-41061' />
     <tag k='natural' v='bay' />
   </way>
-  <way id='-48281' action='modify'>
-    <nd ref='-48279' />
-    <nd ref='-48280' />
-    <nd ref='-48282' />
-    <nd ref='-48279' />
+  <way id='-41221' action='modify'>
+    <nd ref='-41067' />
+    <nd ref='-41069' />
+    <nd ref='-41071' />
+    <nd ref='-41067' />
     <tag k='natural' v='bay' />
   </way>
-  <way id='-48302' action='modify'>
-    <nd ref='-48300' />
-    <nd ref='-48301' />
-    <nd ref='-48303' />
+  <way id='-41223' action='modify'>
+    <nd ref='-41073' />
+    <nd ref='-41075' />
+    <nd ref='-41077' />
     <tag k='harbour' v='yes' />
   </way>
-  <way id='-48315' action='modify'>
-    <nd ref='-48313' />
-    <nd ref='-48314' />
-    <nd ref='-48316' />
-    <nd ref='-48318' />
-    <nd ref='-48320' />
-    <nd ref='-48322' />
-    <nd ref='-48324' />
-    <nd ref='-48326' />
-    <nd ref='-48328' />
-    <nd ref='-48313' />
+  <way id='-41225' action='modify'>
+    <nd ref='-41079' />
+    <nd ref='-41081' />
+    <nd ref='-41083' />
+    <nd ref='-41085' />
+    <nd ref='-41087' />
+    <nd ref='-41089' />
+    <nd ref='-41091' />
+    <nd ref='-41093' />
+    <nd ref='-41095' />
+    <nd ref='-41079' />
   </way>
-  <way id='-48406' action='modify'>
-    <nd ref='-48404' />
-    <nd ref='-48405' />
-    <nd ref='-48407' />
-    <nd ref='-48409' />
-    <nd ref='-48411' />
-    <nd ref='-48413' />
-    <nd ref='-48415' />
-    <nd ref='-48404' />
+  <way id='-41227' action='modify'>
+    <nd ref='-41097' />
+    <nd ref='-41099' />
+    <nd ref='-41101' />
+    <nd ref='-41103' />
+    <nd ref='-41105' />
+    <nd ref='-41107' />
+    <nd ref='-41109' />
+    <nd ref='-41097' />
     <tag k='place' v='island' />
   </way>
-  <way id='-48434' action='modify'>
-    <nd ref='-48435' />
-    <nd ref='-48436' />
-    <nd ref='-48437' />
-    <nd ref='-48438' />
-    <nd ref='-48439' />
-    <nd ref='-48440' />
-    <nd ref='-48441' />
-    <nd ref='-48435' />
+  <way id='-41229' action='modify'>
+    <nd ref='-41111' />
+    <nd ref='-41113' />
+    <nd ref='-41115' />
+    <nd ref='-41117' />
+    <nd ref='-41119' />
+    <nd ref='-41121' />
+    <nd ref='-41123' />
+    <nd ref='-41111' />
     <tag k='natural' v='not_coastline' />
     <tag k='place' v='island' />
   </way>
-  <way id='-48478' action='modify'>
-    <nd ref='-48404' />
-    <nd ref='-48477' />
-    <nd ref='-48479' />
-    <nd ref='-48481' />
-    <nd ref='-48435' />
+  <way id='-41231' action='modify'>
+    <nd ref='-41097' />
+    <nd ref='-41125' />
+    <nd ref='-41127' />
+    <nd ref='-41129' />
+    <nd ref='-41111' />
     <tag k='man_made' v='pier' />
   </way>
-  <way id='-48493' action='modify'>
-    <nd ref='-48491' />
-    <nd ref='-48492' />
-    <nd ref='-48494' />
-    <nd ref='-48496' />
+  <way id='-41233' action='modify'>
+    <nd ref='-41131' />
+    <nd ref='-41133' />
+    <nd ref='-41135' />
+    <nd ref='-41137' />
   </way>
-  <way id='-48506' action='modify'>
-    <nd ref='-48496' />
-    <nd ref='-48504' />
-    <nd ref='-48505' />
-    <nd ref='-48491' />
+  <way id='-41235' action='modify'>
+    <nd ref='-41137' />
+    <nd ref='-41139' />
+    <nd ref='-41141' />
+    <nd ref='-41131' />
   </way>
-  <way id='-67772' action='modify'>
-    <nd ref='-67770' />
-    <nd ref='-67771' />
-    <nd ref='-67773' />
-    <nd ref='-67775' />
-    <nd ref='-67777' />
-    <nd ref='-67770' />
+  <way id='-41237' action='modify'>
+    <nd ref='-41143' />
+    <nd ref='-41145' />
+    <nd ref='-41147' />
+    <nd ref='-41149' />
+    <nd ref='-41151' />
+    <nd ref='-41143' />
   </way>
-  <way id='-67783' action='modify'>
-    <nd ref='-67781' />
-    <nd ref='-67782' />
-    <nd ref='-67784' />
-    <nd ref='-67786' />
-    <nd ref='-67788' />
-    <nd ref='-67790' />
-    <nd ref='-67781' />
+  <way id='-41239' action='modify'>
+    <nd ref='-41153' />
+    <nd ref='-41155' />
+    <nd ref='-41157' />
+    <nd ref='-41159' />
+    <nd ref='-41161' />
+    <nd ref='-41163' />
+    <nd ref='-41153' />
   </way>
-  <way id='-78351' action='modify'>
-    <nd ref='-78349' />
-    <nd ref='-78350' />
-    <nd ref='-78352' />
-    <nd ref='-78354' />
-    <nd ref='-78356' />
-    <nd ref='-78358' />
-    <nd ref='-78349' />
+  <way id='-41241' action='modify'>
+    <nd ref='-41165' />
+    <nd ref='-41167' />
+    <nd ref='-41169' />
+    <nd ref='-41171' />
+    <nd ref='-41173' />
+    <nd ref='-41175' />
+    <nd ref='-41165' />
     <tag k='water' v='lagoon' />
   </way>
-  <way id='-78369' action='modify'>
-    <nd ref='-78367' />
-    <nd ref='-78368' />
-    <nd ref='-78370' />
-    <nd ref='-78372' />
-    <nd ref='-78367' />
+  <way id='-41243' action='modify'>
+    <nd ref='-41177' />
+    <nd ref='-41179' />
+    <nd ref='-41181' />
+    <nd ref='-41183' />
+    <nd ref='-41177' />
     <tag k='leisure' v='swimming_pool' />
   </way>
-  <way id='-78388' action='modify'>
-    <nd ref='-78389' />
-    <nd ref='-78390' />
-    <nd ref='-78391' />
-    <nd ref='-78392' />
-    <nd ref='-78389' />
+  <way id='-41245' action='modify'>
+    <nd ref='-41185' />
+    <nd ref='-41187' />
+    <nd ref='-41189' />
+    <nd ref='-41191' />
+    <nd ref='-41185' />
     <tag k='covered' v='yes' />
     <tag k='leisure' v='swimming_pool' />
   </way>
-  <relation id='-39057' action='modify'>
-    <member type='way' ref='-39051' role='outer' />
-    <member type='way' ref='-39053' role='outer' />
+  <way id='-41299' action='modify'>
+    <nd ref='-41297' />
+    <nd ref='-41298' />
+    <nd ref='-41300' />
+    <nd ref='-41302' />
+    <nd ref='-41304' />
+    <nd ref='-41306' />
+    <nd ref='-41297' />
+  </way>
+  <way id='-41312' action='modify'>
+    <nd ref='-41310' />
+    <nd ref='-41311' />
+    <nd ref='-41313' />
+    <nd ref='-41315' />
+    <nd ref='-41317' />
+    <nd ref='-41319' />
+    <nd ref='-41310' />
+  </way>
+  <relation id='-41247' action='modify'>
+    <member type='way' ref='-41201' role='outer' />
+    <member type='way' ref='-41203' role='outer' />
     <tag k='natural' v='water' />
     <tag k='seamark:type' v='dam' />
     <tag k='type' v='multipolygon' />
     <tag k='water' v='moat' />
   </relation>
-  <relation id='-48015' action='modify'>
-    <member type='way' ref='-48022' role='inner' />
-    <member type='way' ref='-47995' role='outer' />
-    <member type='way' ref='-47978' role='outer' />
+  <relation id='-41249' action='modify'>
+    <member type='way' ref='-41211' role='inner' />
+    <member type='way' ref='-41209' role='outer' />
+    <member type='way' ref='-41207' role='outer' />
     <tag k='name' v='Some Spring' />
     <tag k='natural' v='spring' />
     <tag k='type' v='multipolygon' />
   </relation>
-  <relation id='-48338' action='modify'>
-    <member type='way' ref='-48281' role='inner' />
-    <member type='way' ref='-48267' role='inner' />
-    <member type='way' ref='-48315' role='outer' />
+  <relation id='-41251' action='modify'>
+    <member type='way' ref='-41221' role='inner' />
+    <member type='way' ref='-41219' role='inner' />
+    <member type='way' ref='-41225' role='outer' />
     <tag k='natural' v='beach' />
     <tag k='type' v='multipolygon' />
   </relation>
-  <relation id='-48515' action='modify'>
-    <member type='way' ref='-48506' role='outer' />
-    <member type='way' ref='-48493' role='outer' />
+  <relation id='-41253' action='modify'>
+    <member type='way' ref='-41235' role='outer' />
+    <member type='way' ref='-41233' role='outer' />
     <tag k='man_made' v='pier' />
     <tag k='type' v='multipolygon' />
   </relation>
-  <relation id='-67797' action='modify'>
-    <member type='way' ref='-67783' role='some_role' />
-    <member type='way' ref='-67772' role='some_role' />
+  <relation id='-41255' action='modify'>
+    <member type='way' ref='-41239' role='some_role' />
+    <member type='way' ref='-41237' role='some_role' />
     <tag k='natural' v='beach' />
+  </relation>
+  <relation id='-41326' action='modify'>
+    <member type='way' ref='-41299' role='inner' />
+    <member type='way' ref='-41312' role='outer' />
+    <tag k='name' v='broken spring' />
+    <tag k='natural' v='spring' />
+    <tag k='type' v='multipolygon' />
   </relation>
 </osm>


### PR DESCRIPTION
### Description:

When multipolygons were malformed, the AtlasStatistics computation would fail on `IllegalArgumentException` in their area computation.

### Potential Impact:

This will allow skipping malformed multipolygons.

### Unit Test Approach:

Added a malformed multipolygon in the water test.
<img width="167" alt="image" src="https://user-images.githubusercontent.com/1944860/46970268-7bb0d800-d06d-11e8-93e5-06c247fc2160.png">

### Test Results:

Error is logged and area is not counted.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
