### PR TITLE
Add sudo:false for travis VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ branches:
 language: java
 jdk:
   - oraclejdk8
+sudo: false
+dist: trusty
 before_install:
   - chmod -R ug+x .travis
   - .travis/install.sh


### PR DESCRIPTION
### Description:

This is an attempt to fix #242 

### Potential Impact:

Use sudo=false and dist=trusty in builds. That might solve the issue as per https://github.com/travis-ci/travis-ci/issues/9555#issuecomment-413187047

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)