### PR TITLE
Print if a Flag switch is present

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/runtime/Command.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/runtime/Command.java
@@ -211,6 +211,7 @@ public abstract class Command
                         final Switch<?> foundSwitch = switches.get(switchName);
                         if (foundSwitch instanceof Flag)
                         {
+                            logger.info("Found flag {}", switchName, Boolean.TRUE.toString());
                             inputValues.put(foundSwitch, Boolean.TRUE.toString());
                         }
                         else


### PR DESCRIPTION
### Description:

Print if there is a flag that is found. All switches that have the ability to affect the command behavior are printed, and the flag wasn't printed whether it was found or not. 

### Potential Impact:

All commands that use flags will have an extra line logged per flag.  

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)