### PR TITLE
Fixing way-sectioning hotspot

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionChangeSet.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionChangeSet.java
@@ -100,13 +100,17 @@ public class WaySectionChangeSet
         return this.edgeToNodeMapping.get(line.getIdentifier());
     }
 
-    public synchronized Set<Long> getPointsThatBecomeNodes()
+    public Set<Long> getPointsThatBecomeNodes()
     {
-        if (this.pointsToBecomesNodes.isEmpty())
+        synchronized (this)
         {
-            // This is an expensive calculation - do it once and cache the results.
-            this.pointsToBecomesNodes.addAll(this.getCreatedNodes().stream()
-                    .map(TemporaryNode::getIdentifier).collect(Collectors.toSet()));
+            if (this.pointsToBecomesNodes.isEmpty())
+            {
+                // This is an expensive calculation - do it once and cache the results.
+                this.pointsToBecomesNodes.addAll(this.edgeToNodeMapping.values().stream()
+                        .flatMap(mapping -> mapping.getNodes().stream())
+                        .map(TemporaryNode::getIdentifier).collect(Collectors.toSet()));
+            }
         }
 
         return this.pointsToBecomesNodes;
@@ -130,11 +134,5 @@ public class WaySectionChangeSet
     public void recordPoint(final Point point)
     {
         this.pointsToStayPoints.add(point.getIdentifier());
-    }
-
-    private Set<TemporaryNode> getCreatedNodes()
-    {
-        return this.edgeToNodeMapping.values().stream()
-                .flatMap(mapping -> mapping.getNodes().stream()).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
### Description:

There was a hotspot in the `WaySectionChangeSet` class. Specifically, we were calling `getCreatedNodes()` many times. There were two things wrong with this: 1. It was an expensive operation - looping through all edge to node mappings and collecting the Nodes into a single set for each call. 2. The function was called multiple times in several places. It was called twice at the final build level (once to get the number of `Node`s to create the `AtlasSize` estimate and once to build the final Nodes) and again for each thread processing the raw Atlas points for shape point detection stage. This was un-necessary! The first step in way-sectioning is to identify all `Node` locations in the `Atlas`. Once this is calculated, the number of `Node`s will not change and we can safely aggregate and construct this `Collection`, cache it and rely on it for all future processing.

The solution was exactly this - to calculate the number of `Node`s once and cache the resulting set. The expensive operation would be done a single time and you would be guaranteed to get consistent results, since the number of `Node`s would not change. All future calls would rely on the cache value.

### Potential Impact:

This should not have any downstream impact. The atlas generation time is faster, otherwise, the produced atlases are the same as before.

### Unit Test Approach:

All existing unit and integration tests are passing. `RawAtlasIntegrationTest` has sped up a little bit as well.

### Test Results:
**Functionality**:
I compared the generated Atlas files before and after the fix for size and feature counts, they are identical. All the unit and integration tests confirm this as well, as there are multiple feature count specific tests.

**Performance**:
There was a particularly slow shard (thanks to @matthieun for supplying the shard and code to reproduce!) that was taking almost an hour locally to section. Here are local data points (my MBP), before and after the fix:

**Before**:
```
2018-10-17 12:03:37 INFO  [main] WaySectionProcessor:866 - Finished Shape Point Detection for Shard 8-200-117 in 41.626 minutes
2018-10-17 12:08:14 INFO  [main] WaySectionProcessor:866 - Finished Sectioned Atlas Creation for Shard 8-200-117 in 3.240 minutes
2018-10-17 12:08:17 INFO  [main] WaySectionProcessor:866 - Finished Way-Sectioning for Shard 8-200-117 in 49.674 minutes
```

**After**:
```
2018-10-17 10:07:02 INFO  [main] WaySectionProcessor:866 - Finished Shape Point Detection for Shard 8-200-117 in 1.970 minutes
2018-10-17 10:08:12 INFO  [main] WaySectionProcessor:866 - Finished Sectioned Atlas Creation for Shard 8-200-117 in 55.720 seconds
2018-10-17 10:08:13 INFO  [main] WaySectionProcessor:866 - Finished Way-Sectioning for Shard 8-200-117 in 6.748 minutes
```

Here are data points when run on a Spark cluster, before and after the fix:

**Before**: `Finished sectioning raw Atlas for THA_8-200-117_ in 73.444 minutes`
**After**: `Finished sectioning raw Atlas for THA_8-200-117_ in 24.331 minutes`

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
