### PR TITLE
Added a size cutoff to the BigNodeFinder.isDualCarriageWayJunctionRoute

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/bignode/BigNodeFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/bignode/BigNodeFinder.java
@@ -240,6 +240,12 @@ public class BigNodeFinder implements Finder<BigNode>
      * prevent bad edge cases while constructing the big node
      */
     private static final int MAXIMUM_DUAL_CARRIAGEWAY_ROUTE_SIZE = 10;
+    /**
+     * This is a maximum number of possible exploratory routes when searching for dual carriage way
+     * junction routes. This is to prevent exponential slowdowns during rare edge cases, eg. when
+     * OSM ways overlap.
+     */
+    private static final int MAXIMUM_CANDIDATE_JUNCTION_ROUTE_SET_SIZE = 10_000;
 
     private final EdgeDirectionComparator edgeDirectionComparator = new EdgeDirectionComparator();
 
@@ -433,6 +439,13 @@ public class BigNodeFinder implements Finder<BigNode>
      */
     private Optional<Route> isDualCarriageWayJunctionRoute(final Set<Route> candidateJunctionRoutes)
     {
+        if (candidateJunctionRoutes.size() > MAXIMUM_CANDIDATE_JUNCTION_ROUTE_SET_SIZE)
+        {
+            logger.warn(
+                    "Aborting isDualCarriageWayJunctionRoute, candidate set size {} exceeded {}",
+                    candidateJunctionRoutes.size(), MAXIMUM_CANDIDATE_JUNCTION_ROUTE_SET_SIZE);
+            return Optional.empty();
+        }
         if (candidateJunctionRoutes.isEmpty())
         {
             return Optional.empty();


### PR DESCRIPTION
### Description:

In the case where OSM data contained overlapping ways, this method would be forced to explore an exponential explosion of possible routes. This PR simply adds a cutoff to prevent this explosion. Ideally, we could fix the overlapping way issue earlier in the pipeline and then bump the threshold up for safety.

### Potential Impact:

It is possible, but unlikely, that potential valid BigNodes will be missed. However, based on some initial testing this seems not to be the case.

### Unit Test Approach:

See next section.

### Test Results:

I ran multiple tests with different cut-offs. 50,000 initially seemed promising, since 50,000 > 8! - which would cover more possible BigNode configurations. However, based on my tests, actual results showed no difference between 10,000 (> 7!) and 50,000, while 50,000 took over 3 times as long to compute.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
