### PR TITLE
subAtlas(Polygon) missing reverse edge and performance

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -953,7 +953,7 @@ public abstract class BareAtlas implements Atlas
     private <Member extends AtlasEntity> Supplier<Iterable<Member>> getCachingSupplier(
             final Iterable<Member> source, final ItemType type)
     {
-        final List<Set<Long>> memberIdentifiersIntersecting = new ArrayList<>();
+        final Set<Long> memberIdentifiersIntersecting = new HashSet<>();
         // A supplier that will effectively cache all the members intersecting that polygon. This is
         // thread safe because the cache is internal to the supplier's scope.
         @SuppressWarnings("unchecked")
@@ -961,19 +961,17 @@ public abstract class BareAtlas implements Atlas
         {
             if (memberIdentifiersIntersecting.isEmpty())
             {
-                final Set<Long> intersecting = new HashSet<>();
-                memberIdentifiersIntersecting.add(intersecting);
                 // Here using a map instead of forEach to pipe the edge identifiers to the cache
                 // list without having to re-open the iterable.
                 return Iterables.stream(source).map(member ->
                 {
-                    intersecting.add(member.getIdentifier());
+                    memberIdentifiersIntersecting.add(member.getIdentifier());
                     return member;
                 }).collect();
             }
             else
             {
-                return (Iterable<Member>) Iterables.stream(memberIdentifiersIntersecting.get(0))
+                return (Iterable<Member>) Iterables.stream(memberIdentifiersIntersecting)
                         .map(identifier -> this.entity(identifier, type)).collect();
             }
         };

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -579,6 +579,8 @@ public abstract class BareAtlas implements Atlas
         {
             if (builder.peek().edge(edge.getIdentifier()) == null)
             {
+                // Here, making sure that edge identifiers are not 0 to work around an issue in unit
+                // tests: https://github.com/osmlab/atlas/issues/252
                 if (edge.getIdentifier() != 0 && edge.hasReverseEdge())
                 {
                     final Edge reverse = edge.reversed().get();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -573,13 +573,13 @@ public abstract class BareAtlas implements Atlas
         {
             if (builder.peek().edge(edge.getIdentifier()) == null)
             {
-                if (!edge.isMasterEdge())
+                if (edge.hasReverseEdge())
                 {
-                    final Edge master = edge.reversed().get();
-                    if (builder.peek().edge(master.getIdentifier()) == null)
+                    final Edge reverse = edge.reversed().get();
+                    if (builder.peek().edge(reverse.getIdentifier()) == null)
                     {
-                        builder.addEdge(master.getIdentifier(), master.asPolyLine(),
-                                master.getTags());
+                        builder.addEdge(reverse.getIdentifier(), reverse.asPolyLine(),
+                                reverse.getTags());
                     }
                 }
                 builder.addEdge(edge.getIdentifier(), edge.asPolyLine(), edge.getTags());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -526,8 +526,6 @@ public abstract class BareAtlas implements Atlas
                 linesIntersecting(boundary), ItemType.LINE);
         final Supplier<Iterable<Point>> pointsWithin = getCachingSupplier(pointsWithin(boundary),
                 ItemType.POINT);
-        final Supplier<Iterable<Relation>> relationsWithEntitiesIntersecting = getCachingSupplier(
-                relationsWithEntitiesIntersecting(boundary), ItemType.RELATION);
 
         // Generate the size estimates, then the builder.
         // Nodes estimating is a bit tricky. We want to include all the nodes within the polygon,
@@ -541,7 +539,7 @@ public abstract class BareAtlas implements Atlas
         final long lineNumber = Math.round(Iterables.size(linesIntersecting.get()) * ratioBuffer);
         final long pointNumber = Math.round(Iterables.size(pointsWithin.get()) * ratioBuffer);
         final long relationNumber = Math
-                .round(Iterables.size(relationsWithEntitiesIntersecting.get()) * ratioBuffer);
+                .round(Iterables.size(relationsWithEntitiesIntersecting(boundary)) * ratioBuffer);
         final AtlasSize size = new AtlasSize(edgeNumber, nodeNumber, areaNumber, lineNumber,
                 pointNumber, relationNumber);
         final PackedAtlasBuilder builder = new PackedAtlasBuilder().withSizeEstimates(size)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -573,7 +573,7 @@ public abstract class BareAtlas implements Atlas
         {
             if (builder.peek().edge(edge.getIdentifier()) == null)
             {
-                if (edge.hasReverseEdge())
+                if (edge.getIdentifier() != 0 && edge.hasReverseEdge())
                 {
                     final Edge reverse = edge.reversed().get();
                     if (builder.peek().edge(reverse.getIdentifier()) == null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -955,6 +955,8 @@ public abstract class BareAtlas implements Atlas
             {
                 final Set<Long> intersecting = new HashSet<>();
                 memberIdentifiersIntersecting.add(intersecting);
+                // Here using a map instead of forEach to pipe the edge identifiers to the cache
+                // list without having to re-open the iterable.
                 return Iterables.stream(source).map(member ->
                 {
                     intersecting.add(member.getIdentifier());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -524,13 +524,16 @@ public abstract class BareAtlas implements Atlas
         // but we also want to include those attached to edges that span outside the polygon.
         // Instead of doing a count to have an exact number, we choose here to have an arbitrary 20%
         // buffer on top of the nodes inside the polygon. This mostly avoids resizing.
-        final double nodeRatioBuffer = 1.2;
-        final long nodeNumber = Math.round(Iterables.size(nodesWithin(boundary)) * nodeRatioBuffer);
-        final long edgeNumber = Iterables.size(edgesIntersecting.get());
-        final long areaNumber = Iterables.size(areasIntersecting(boundary));
-        final long lineNumber = Iterables.size(linesIntersecting(boundary));
-        final long pointNumber = Iterables.size(pointsWithin(boundary));
-        final long relationNumber = Iterables.size(relationsWithEntitiesIntersecting(boundary));
+        final double ratioBuffer = 1.2;
+        final long nodeNumber = Math.round(Iterables.size(nodesWithin(boundary)) * ratioBuffer);
+        final long edgeNumber = Math.round(Iterables.size(edgesIntersecting.get()) * ratioBuffer);
+        final long areaNumber = Math
+                .round(Iterables.size(areasIntersecting(boundary)) * ratioBuffer);
+        final long lineNumber = Math
+                .round(Iterables.size(linesIntersecting(boundary)) * ratioBuffer);
+        final long pointNumber = Math.round(Iterables.size(pointsWithin(boundary)) * ratioBuffer);
+        final long relationNumber = Math
+                .round(Iterables.size(relationsWithEntitiesIntersecting(boundary)) * ratioBuffer);
         final AtlasSize size = new AtlasSize(edgeNumber, nodeNumber, areaNumber, lineNumber,
                 pointNumber, relationNumber);
         final PackedAtlasBuilder builder = new PackedAtlasBuilder().withSizeEstimates(size)
@@ -645,8 +648,13 @@ public abstract class BareAtlas implements Atlas
                 }
             });
         }
+        final PackedAtlas result = (PackedAtlas) builder.get();
+        if (result != null)
+        {
+            result.trim();
+        }
         logger.info("Cut sub-atlas in {}", begin.elapsedSince());
-        return Optional.ofNullable(builder.get());
+        return Optional.ofNullable(result);
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasRule.java
@@ -22,6 +22,10 @@ public class SubAtlasRule extends CoreTestRule
     private static final String FOUR = "37.780825, -122.471896";
     private static final String FIVE = "37.780835, -122.471896";
 
+    private static final String SIX = "37.045982,-121.7539795";
+    private static final String SIX_PRIME = "37.0459867,-121.7539853";
+    private static final String SEVEN = "37.0459913,-121.7539913";
+
     @TestAtlas(
 
             nodes = {
@@ -141,9 +145,41 @@ public class SubAtlasRule extends CoreTestRule
             })
     private Atlas filteredOutMemberRelationAtlas;
 
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "6", coordinates = @Loc(value = SIX)),
+                    @Node(id = "7", coordinates = @Loc(value = SEVEN)),
+
+            }, edges = {
+
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=trunk" }),
+
+                    @Edge(id = "67", coordinates = { @Loc(value = SIX), @Loc(value = SIX_PRIME),
+                            @Loc(value = SEVEN) }, tags = { "highway=primary" }),
+                    @Edge(id = "-67", coordinates = { @Loc(value = SEVEN), @Loc(value = SIX_PRIME),
+                            @Loc(value = SIX) }, tags = { "highway=primary" }),
+
+                    @Edge(id = "76", coordinates = { @Loc(value = SEVEN), @Loc(value = SIX_PRIME),
+                            @Loc(value = SIX) }, tags = { "highway=primary" }),
+                    @Edge(id = "-76", coordinates = { @Loc(value = SIX), @Loc(value = SIX_PRIME),
+                            @Loc(value = SEVEN) }, tags = { "highway=primary" })
+
+            })
+    private Atlas atlasWithEdgeAlongBoundary;
+
     public Atlas getAtlas()
     {
         return this.atlas;
+    }
+
+    public Atlas getAtlasWithEdgeAlongBoundary()
+    {
+        return this.atlasWithEdgeAlongBoundary;
     }
 
     public Atlas getFilteredOutMemberRelationAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
@@ -7,6 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 
@@ -131,6 +132,28 @@ public class SubAtlasTest
         Assert.assertEquals(1, source.relation(5).members().size());
         Assert.assertNotNull(sub.relation(5));
         Assert.assertEquals(1, sub.relation(5).members().size());
+    }
+
+    @Test
+    public void testSubAtlasWithPolygonAndEdgeAtBoundary()
+    {
+        final Atlas source = this.rule.getAtlasWithEdgeAlongBoundary();
+        final Polygon boundary = Polygon
+                .wkt("POLYGON ((-121.7540269 37.0463639, -121.75403 37.04635, "
+                        + "-121.75408 37.0462, -121.75408 37.04611, -121.75406 37.04606, "
+                        + "-121.75399 37.04599, -121.75344 37.04557, -121.75338 37.0455, "
+                        + "-121.7533422 37.0454102, -121.7544982 37.0454102, "
+                        + "-121.7544982 37.0463639, -121.7540269 37.0463639))");
+        final Atlas result = source.subAtlas(boundary).get();
+        Assert.assertEquals(4, result.numberOfEdges());
+        // Does not clip with JTS
+        Assert.assertNotNull(result.edge(67));
+        // Does clip with JTS
+        Assert.assertNotNull(result.edge(-67));
+        // Does clip with JTS
+        Assert.assertNotNull(result.edge(76));
+        // Does not clip with JTS
+        Assert.assertNotNull(result.edge(-76));
     }
 
     @Test


### PR DESCRIPTION
### Description:

This fixes two issues:
- `subAtlas(Polygon)` would in some cases include a reverse edge without its master edge, in a very corner case where JTS would match the reverse edge to the `Polygon`, but not the master edge.
```
org.openstreetmap.atlas.geography.atlas.exception.AtlasIntegrityException: Cannot build an Atlas with a negative edge without its positive counterpart: -XXXXXXXXX
	at org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder.lambda$verifyNegativeEdgesHaveMasterEdge$1(PackedAtlasBuilder.java:319)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder.verifyNegativeEdgesHaveMasterEdge(PackedAtlasBuilder.java:312)
	at org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder.get(PackedAtlasBuilder.java:211)
	at org.openstreetmap.atlas.geography.atlas.BareAtlas.subAtlas(BareAtlas.java:629)
```
- Improve `subAtlas` performance by caching the edges intersecting the polygon, instead of re-computing them 3 times.

### Potential Impact:

A more accurate `subAtlas` in very corner cases. A faster `subAtlas` in most cases.

### Unit Test Approach:

Added one unit test that exposes the corner case, and verifies that the master edge gets added.

### Test Results:

Tests succeed.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)