### PR TITLE
TaggableFilter old constructor for backwards compatibility

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/filters/TaggableFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/filters/TaggableFilter.java
@@ -80,6 +80,17 @@ public class TaggableFilter implements Predicate<Taggable>, Serializable
         return new LineFilterConverter().convert(definition);
     }
 
+    /**
+     * @param definition
+     *            The {@link String} definition of the filter
+     * @deprecated Use {@code TaggableFilter.forDefinition(definition)} instead.
+     */
+    @Deprecated()
+    public TaggableFilter(final String definition)
+    {
+        this(TaggableFilter.forDefinition(definition));
+    }
+
     protected TaggableFilter(final List<TaggableFilter> children, final TreeBoolean treeBoolean)
     {
         this.children = children;
@@ -94,6 +105,14 @@ public class TaggableFilter implements Predicate<Taggable>, Serializable
         this.treeBoolean = TreeBoolean.OR;
         this.simple = simple;
         this.definition = definition;
+    }
+
+    private TaggableFilter(final TaggableFilter other)
+    {
+        this.children = other.children;
+        this.treeBoolean = other.treeBoolean;
+        this.simple = other.simple;
+        this.definition = other.definition;
     }
 
     @Override


### PR DESCRIPTION
### Description:

atlas-checks is making extensive use of new `TaggableFilter(definition)`. Adding this back until it is all migrated to `TaggableFilter.forDefinition`.

### Potential Impact:

One new deprecated constructor

### Unit Test Approach:

Same unit tests

### Test Results:

Same unit tests

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
