### PR TITLE
Fix double locking sonar error

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -55,7 +55,7 @@
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true" />
 		</module>
-		
+
 		<!-- Checks for metrics -->
 
 		<!-- Checks for Size Violations. -->
@@ -137,7 +137,9 @@
 			<property name="forceStrictCondition" value="false"/>
 		</module> -->
 		<module name="OuterTypeFilename"/>
-		<module name="TrailingComment"/>
+        <module name="TrailingComment">
+            <property name="legalComment" value="NOSONAR"/>
+        </module>
 		<module name="TodoComment" />
 		<module name="UpperEll" />
 	</module>

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -186,6 +186,19 @@ public interface Atlas extends Located, Iterable<AtlasEntity>, Serializable
     Iterable<AtlasEntity> entities();
 
     /**
+     * Return all the {@link AtlasEntity}s of a specific type
+     *
+     * @param type
+     *            The type to restrain to
+     * @param memberClass
+     *            The class of the member
+     * @param <M>
+     *            The AtlasEntity type
+     * @return All the {@link AtlasEntity}s of a specific type
+     */
+    <M extends AtlasEntity> Iterable<M> entities(ItemType type, Class<M> memberClass);
+
+    /**
      * Return all the {@link AtlasEntity}s matching a {@link Predicate}.
      *
      * @param matcher

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -115,6 +115,30 @@ public abstract class BareAtlas implements Atlas
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <M extends AtlasEntity> Iterable<M> entities(final ItemType type,
+            final Class<M> memberClass)
+    {
+        switch (type)
+        {
+            case NODE:
+                return (Iterable<M>) nodes();
+            case EDGE:
+                return (Iterable<M>) edges();
+            case AREA:
+                return (Iterable<M>) areas();
+            case LINE:
+                return (Iterable<M>) lines();
+            case POINT:
+                return (Iterable<M>) points();
+            case RELATION:
+                return (Iterable<M>) relations();
+            default:
+                throw new CoreException("ItemType {} unknown.", type);
+        }
+    }
+
+    @Override
     public Iterable<AtlasEntity> entities(final Predicate<AtlasEntity> matcher)
     {
         return Iterables.filter(this, matcher);
@@ -950,14 +974,14 @@ public abstract class BareAtlas implements Atlas
         }
     }
 
-    private <Member extends AtlasEntity> Supplier<Iterable<Member>> getCachingSupplier(
-            final Iterable<Member> source, final ItemType type)
+    private <M extends AtlasEntity> Supplier<Iterable<M>> getCachingSupplier(
+            final Iterable<M> source, final ItemType type)
     {
         final Set<Long> memberIdentifiersIntersecting = new HashSet<>();
         // A supplier that will effectively cache all the members intersecting that polygon. This is
         // thread safe because the cache is internal to the supplier's scope.
         @SuppressWarnings("unchecked")
-        final Supplier<Iterable<Member>> result = () ->
+        final Supplier<Iterable<M>> result = () ->
         {
             if (memberIdentifiersIntersecting.isEmpty())
             {
@@ -971,8 +995,8 @@ public abstract class BareAtlas implements Atlas
             }
             else
             {
-                return (Iterable<Member>) Iterables.stream(memberIdentifiersIntersecting)
-                        .map(identifier -> this.entity(identifier, type)).collect();
+                return (Iterable<M>) Iterables.stream(memberIdentifiersIntersecting)
+                        .map(entityIdentifier -> this.entity(entityIdentifier, type)).collect();
             }
         };
         return result;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -119,6 +119,11 @@ public abstract class BareAtlas implements Atlas
     public <M extends AtlasEntity> Iterable<M> entities(final ItemType type,
             final Class<M> memberClass)
     {
+        if (type.getMemberClass() != memberClass)
+        {
+            throw new CoreException("ItemType {} and class {} do not match!", type,
+                    memberClass.getSimpleName());
+        }
         switch (type)
         {
             case NODE:
@@ -1066,7 +1071,10 @@ public abstract class BareAtlas implements Atlas
         // Add the reverse
         if (edge.hasReverseEdge())
         {
-            final Edge reverseEdge = edge.reversed().get();
+            // Skip sonar lint here as S3655 "Optional value should only be accessed after calling
+            // isPresent()" will never be the case as the Edge has been verified to have a reverse
+            // edge before.
+            final Edge reverseEdge = edge.reversed().get(); // NOSONAR
             final long reverseEdgeIdentifier = reverseEdge.getIdentifier();
             if (builder.peek().edge(reverseEdgeIdentifier) == null)
             {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ItemType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ItemType.java
@@ -85,22 +85,22 @@ public enum ItemType
     }
 
     @SuppressWarnings("unchecked")
-    public <Member extends AtlasEntity> Class<Member> getMemberClass()
+    public <M extends AtlasEntity> Class<M> getMemberClass()
     {
         switch (this)
         {
             case NODE:
-                return (Class<Member>) Node.class;
+                return (Class<M>) Node.class;
             case EDGE:
-                return (Class<Member>) Edge.class;
+                return (Class<M>) Edge.class;
             case AREA:
-                return (Class<Member>) Area.class;
+                return (Class<M>) Area.class;
             case LINE:
-                return (Class<Member>) Line.class;
+                return (Class<M>) Line.class;
             case POINT:
-                return (Class<Member>) Point.class;
+                return (Class<M>) Point.class;
             case RELATION:
-                return (Class<Member>) Relation.class;
+                return (Class<M>) Relation.class;
 
             default:
                 throw new CoreException("Invalid type {}", this);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ItemType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ItemType.java
@@ -84,6 +84,29 @@ public enum ItemType
         }
     }
 
+    @SuppressWarnings("unchecked")
+    public <Member extends AtlasEntity> Class<Member> getMemberClass()
+    {
+        switch (this)
+        {
+            case NODE:
+                return (Class<Member>) Node.class;
+            case EDGE:
+                return (Class<Member>) Edge.class;
+            case AREA:
+                return (Class<Member>) Area.class;
+            case LINE:
+                return (Class<Member>) Line.class;
+            case POINT:
+                return (Class<Member>) Point.class;
+            case RELATION:
+                return (Class<Member>) Relation.class;
+
+            default:
+                throw new CoreException("Invalid type {}", this);
+        }
+    }
+
     public int getValue()
     {
         return this.value;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
@@ -711,12 +711,6 @@ public class MultiAtlas extends AbstractAtlas
         return this.edgeMemoryBlockSize;
     }
 
-    @Override
-    protected Logger getLogger()
-    {
-        return logger;
-    }
-
     protected long getMaximumSize()
     {
         return this.maximumSize;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -1116,12 +1116,6 @@ public final class PackedAtlas extends AbstractAtlas
         return this.loadSerializationFormat;
     }
 
-    @Override
-    protected Logger getLogger()
-    {
-        return logger;
-    }
-
     protected Optional<PackedAtlasSerializer> getSerializer()
     {
         return Optional.ofNullable(this.serializer);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/BareAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/BareAtlasTest.java
@@ -2,10 +2,20 @@ package org.openstreetmap.atlas.geography.atlas;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Line;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 
 /**
@@ -15,6 +25,52 @@ public class BareAtlasTest
 {
     @Rule
     public final BareAtlasTestRule rule = new BareAtlasTestRule();
+
+    @Rule
+    public ExpectedException testGetEntitiesWithWrongTypeSpecifiedException = ExpectedException
+            .none();
+
+    @Test
+    public void testGetEntitiesWithTypeSpecified()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+
+        final Set<Node> nodes = Iterables.stream(atlas.nodes()).collectToSet();
+        final Set<Edge> edges = Iterables.stream(atlas.edges()).collectToSet();
+        final Set<Area> areas = Iterables.stream(atlas.areas()).collectToSet();
+        final Set<Line> lines = Iterables.stream(atlas.lines()).collectToSet();
+        final Set<Point> points = Iterables.stream(atlas.points()).collectToSet();
+        final Set<Relation> relations = Iterables.stream(atlas.relations()).collectToSet();
+
+        final Set<Node> nodes2 = Iterables.stream(atlas.entities(ItemType.NODE, Node.class))
+                .collectToSet();
+        final Set<Edge> edges2 = Iterables.stream(atlas.entities(ItemType.EDGE, Edge.class))
+                .collectToSet();
+        final Set<Area> areas2 = Iterables.stream(atlas.entities(ItemType.AREA, Area.class))
+                .collectToSet();
+        final Set<Line> lines2 = Iterables.stream(atlas.entities(ItemType.LINE, Line.class))
+                .collectToSet();
+        final Set<Point> points2 = Iterables.stream(atlas.entities(ItemType.POINT, Point.class))
+                .collectToSet();
+        final Set<Relation> relations2 = Iterables
+                .stream(atlas.entities(ItemType.RELATION, Relation.class)).collectToSet();
+
+        Assert.assertEquals(nodes, nodes2);
+        Assert.assertEquals(edges, edges2);
+        Assert.assertEquals(areas, areas2);
+        Assert.assertEquals(lines, lines2);
+        Assert.assertEquals(points, points2);
+        Assert.assertEquals(relations, relations2);
+    }
+
+    @Test
+    public void testGetEntitiesWithWrongTypeSpecified()
+    {
+        this.testGetEntitiesWithWrongTypeSpecifiedException.expect(CoreException.class);
+        this.testGetEntitiesWithWrongTypeSpecifiedException.expectMessage("do not match!");
+        final Atlas atlas = this.rule.getAtlas();
+        atlas.entities(ItemType.NODE, Relation.class);
+    }
 
     @Test
     public void testRelationsOrder()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/ItemTypeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/ItemTypeTest.java
@@ -1,0 +1,57 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.BareAtlasTestRule;
+
+/**
+ * @author matthieun
+ */
+public class ItemTypeTest
+{
+    @Rule
+    public final BareAtlasTestRule rule = new BareAtlasTestRule();
+
+    @Test
+    public void testEntityForIdentifier()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        Assert.assertEquals(atlas.node(1), ItemType.NODE.entityForIdentifier(atlas, 1));
+        Assert.assertEquals(atlas.edge(1), ItemType.EDGE.entityForIdentifier(atlas, 1));
+        Assert.assertEquals(atlas.area(1), ItemType.AREA.entityForIdentifier(atlas, 1));
+        Assert.assertEquals(atlas.line(1), ItemType.LINE.entityForIdentifier(atlas, 1));
+        Assert.assertEquals(atlas.point(1), ItemType.POINT.entityForIdentifier(atlas, 1));
+        Assert.assertEquals(atlas.relation(1), ItemType.RELATION.entityForIdentifier(atlas, 1));
+    }
+
+    @Test
+    public void testGetMemberClass()
+    {
+        Assert.assertEquals(Node.class, ItemType.NODE.getMemberClass());
+        Assert.assertEquals(Edge.class, ItemType.EDGE.getMemberClass());
+        Assert.assertEquals(Area.class, ItemType.AREA.getMemberClass());
+        Assert.assertEquals(Line.class, ItemType.LINE.getMemberClass());
+        Assert.assertEquals(Point.class, ItemType.POINT.getMemberClass());
+        Assert.assertEquals(Relation.class, ItemType.RELATION.getMemberClass());
+    }
+
+    @Test
+    public void testToShotsString()
+    {
+        Assert.assertEquals("N", ItemType.NODE.toShortString());
+        Assert.assertEquals("E", ItemType.EDGE.toShortString());
+        Assert.assertEquals("A", ItemType.AREA.toShortString());
+        Assert.assertEquals("L", ItemType.LINE.toShortString());
+        Assert.assertEquals("P", ItemType.POINT.toShortString());
+        Assert.assertEquals("R", ItemType.RELATION.toShortString());
+
+        Assert.assertEquals(ItemType.NODE, ItemType.shortValueOf("N"));
+        Assert.assertEquals(ItemType.EDGE, ItemType.shortValueOf("E"));
+        Assert.assertEquals(ItemType.AREA, ItemType.shortValueOf("A"));
+        Assert.assertEquals(ItemType.LINE, ItemType.shortValueOf("L"));
+        Assert.assertEquals(ItemType.POINT, ItemType.shortValueOf("P"));
+        Assert.assertEquals(ItemType.RELATION, ItemType.shortValueOf("R"));
+    }
+}


### PR DESCRIPTION
### Description:

[Sonar flags double locking with non-volatile members as a non thread-safe operation]( https://sonarcloud.io/project/issues?id=org.openstreetmap.atlas%3Aatlas&issues=AWSBg5Ghl6vpliCeK61L&open=AWSBg5Ghl6vpliCeK61L).
This PR attempts to solve this by using volatile spatial indices in `AbstractAtlas` and also refactors some methods to reduce code complexity.

Also avoided a code smell by using `M` instead of `Member` as a generic variable in many methods.

### Potential Impact:

Should have no impact.

### Unit Test Approach:

All unit tests covering de-serialization, and PackedAtlas and MultiAtlas creation pass.
DNM until large scale tests prove no other issue.

### Test Results:

DNM until large scale tests prove no other issue.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)