### PR TITLE
PackedAtlas is now full protobuf by default. 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -67,8 +67,8 @@ public final class PackedAtlas extends AbstractAtlas
      */
     public enum AtlasSerializationFormat
     {
-        JAVA,
         PROTOBUF,
+        JAVA
     }
 
     private static final long serialVersionUID = -7582554057580336684L;
@@ -127,8 +127,8 @@ public final class PackedAtlas extends AbstractAtlas
     private transient PackedAtlasSerializer serializer;
 
     // Serialization formats for saving/loading this PackedAtlas
-    private AtlasSerializationFormat saveSerializationFormat = AtlasSerializationFormat.JAVA;
-    private AtlasSerializationFormat loadSerializationFormat = AtlasSerializationFormat.JAVA;
+    private AtlasSerializationFormat saveSerializationFormat = AtlasSerializationFormat.PROTOBUF;
+    private AtlasSerializationFormat loadSerializationFormat = AtlasSerializationFormat.PROTOBUF;
 
     // Meta-Data
     private AtlasMetaData metaData = new AtlasMetaData();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -111,7 +111,7 @@ public final class PackedAtlasSerializer
         final AtlasSerializationFormat[] possibleFormats = AtlasSerializationFormat.values();
         for (final AtlasSerializationFormat candidateFormat : possibleFormats)
         {
-            logger.info("Trying load format {}", candidateFormat);
+            logger.debug("Trying load format {}", candidateFormat);
             atlas.setLoadSerializationFormat(candidateFormat);
             try
             {
@@ -119,11 +119,11 @@ public final class PackedAtlasSerializer
             }
             catch (final CoreException exception)
             {
-                logger.info("Load format {} invalid", candidateFormat);
+                logger.debug("Load format {} invalid", candidateFormat);
                 continue;
             }
             // If we make it here, then we found the appropriate format and we can bail out
-            logger.info("Using load format {}", candidateFormat);
+            logger.debug("Using load format {}", candidateFormat);
             return;
         }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
@@ -287,8 +287,8 @@ public class PackedAtlasSerializerTest
         final Atlas protoAtlas = new AtlasResourceLoader().withAtlasFileExtensionFilterSetTo(false)
                 .load(protoResource);
 
-        Assert.assertEquals(1, javaResource.getNumberStreamsClosed());
-        Assert.assertEquals(2, protoResource.getNumberStreamsClosed());
+        Assert.assertEquals(2, javaResource.getNumberStreamsClosed());
+        Assert.assertEquals(1, protoResource.getNumberStreamsClosed());
     }
 
     @Test


### PR DESCRIPTION
Additionally, we now guarantee a successful first load for proto atlases.

### Description:

`PackedAtlas` now defaults to proto for the save and load format. The logger for load format selection is now `debug`. Also, we now declare `PROTOBUF` first in the enum so that it is the first format that `determineLoadFormat` tries.

### Potential Impact:

N/A

### Unit Test Approach:

Check all proto related unit tests. Updated `testResourceClosureOnInvalidLoadFormat` to reflect the change.

### Test Results:

All tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)