### PR TITLE
Updated Enum Set For Turn Restrictions

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/TurnRestrictionTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TurnRestrictionTag.java
@@ -29,7 +29,7 @@ public enum TurnRestrictionTag
     public static final String KEY = "restriction";
 
     private static final EnumSet<TurnRestrictionTag> NO_PATH_RESTRICTIONS = EnumSet
-            .of(NO_RIGHT_TURN, NO_LEFT_TURN, NO_U_TURN, NO_STRAIGHT_ON);
+            .of(NO_RIGHT_TURN, NO_LEFT_TURN, NO_U_TURN, NO_STRAIGHT_ON, NO_ENTRY, NO_EXIT);
     private static final EnumSet<TurnRestrictionTag> ONLY_PATH_RESTRICTIONS = EnumSet
             .of(ONLY_RIGHT_TURN, ONLY_LEFT_TURN, ONLY_STRAIGHT_ON);
 


### PR DESCRIPTION
### Description:

Updated enum set for turn restrictions. NO_PATH_RESTRICTIONS set was missing values NO_EXIT and NO_ENTRY. This was causing false flags when running the InvalidTurnRestrictionCheck, due to the TurnRestriction class using NO_PATH_RESTRICTIONS to determine the type of turn restriction.

### Potential Impact:

Will affect what TurnRestictionCheck flags. Turn Restriction Check is in Atlas Checks.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)