### PR TITLE
Remove double-checked locking in DynamicGridIndexBuilder

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/DynamicGridIndexBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/DynamicGridIndexBuilder.java
@@ -196,7 +196,7 @@ public class DynamicGridIndexBuilder extends AbstractGridIndexBuilder
     private static final double GRANULARITY = 0.02;
 
     // RTree to hold grid boxes
-    private STRtree index;
+    private volatile STRtree index;
 
     // RTree to hold raw boundaries
     private STRtree rawIndex;
@@ -256,11 +256,13 @@ public class DynamicGridIndexBuilder extends AbstractGridIndexBuilder
     @Override
     public STRtree getIndex()
     {
-        if (this.index == null)
+        STRtree localIndex = this.index;
+        if (localIndex == null)
         {
             synchronized (this)
             {
-                if (this.index == null)
+                localIndex = this.index;
+                if (localIndex == null)
                 {
                     this.index = new STRtree();
                     final BlockingQueue<GridWorkItem> queue = new LinkedBlockingQueue<>();


### PR DESCRIPTION
### Description:

Remove the [last instance of double-checked locking](https://sonarcloud.io/project/issues?id=org.openstreetmap.atlas%3Aatlas&issues=AWSBg5DGl6vpliCeK6yr&open=AWSBg5DGl6vpliCeK6yr). This is a follow-up of #254 

### Potential Impact:

None

### Unit Test Approach:

Rely on existing unit-tests

### Test Results:

Use existing unit test results.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
