### PR TITLE
Fixed inconsistent geometry

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/CoordinateToNewPointMapping.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/CoordinateToNewPointMapping.java
@@ -17,10 +17,12 @@ import com.vividsolutions.jts.geom.PrecisionModel;
  * For example, we'll have a slice that has a Coordinate of (-8.3261734, 6.8663838) and another one
  * that is really close, but differs at the 7th digit of significance: (-8.3261735, 6.8663838) -
  * note the 4 and 5 for the latitude value. This will cause us to create two separate Points at what
- * should be a single Location. To prevent this from happening, we're storing all Coordinates with 6
- * digits of precision. This class takes care of doing any conversions and lookup for the caller.
+ * should be a single Location. To prevent this from happening, we're maintaining maps for
+ * TemporaryPoints that have been made made while slicing, allowing for consistent geometry per OSM
+ * shape and limiting duplicate TemporaryPoints.
  *
  * @author mgostintsev
+ * @author samuelgass
  */
 public class CoordinateToNewPointMapping
 {
@@ -28,37 +30,137 @@ public class CoordinateToNewPointMapping
     private static final Integer SIX_DIGIT_PRECISION_SCALE = 1_000_000;
 
     private final Map<Coordinate, Long> coordinateToPointIdentifierMap;
+    private final Map<Long, Map<Coordinate, Long>> scaledPerIdentifierMap;
     private final PrecisionModel precisionModel;
 
     public CoordinateToNewPointMapping()
     {
         this.coordinateToPointIdentifierMap = new ConcurrentHashMap<>();
+        this.scaledPerIdentifierMap = new ConcurrentHashMap<>();
         this.precisionModel = new PrecisionModel(SIX_DIGIT_PRECISION_SCALE);
     }
 
-    public boolean containsCoordinate(final Coordinate coordinate)
+    /**
+     * Takes a coordinate and an OSM identifier, and returns whether the coordinate has been mapped
+     * before. The mapping check is somewhat unintuitive-- first, it checks to see if the coordinate
+     * has a six digit approximation already used by this OSM shape. This enforces consistency
+     * across OSM shape builds, ensuring they always use the same six-digit precision coordinate if
+     * necessary. If this is false, then the higher 7-digit precision map is checked. This ensures
+     * that if a TemporaryPoint with the same 7-digit precision has already been made by another OSM
+     * shape, it will be used instead of a duplicate being made.
+     *
+     * @param coordinate
+     *            The coordinate to check the cache for
+     * @param osmIdentifier
+     *            The OSM identifier whose shape is being sliced
+     * @return True if the 6-digit scaled coordinate exists in the cache for this OSM shape, or else
+     *         if the 7-digit original coordinate exists in the high precision general cache. False
+     *         if neither of those caches contain relevant entries.
+     */
+
+    public boolean containsCoordinate(final Coordinate coordinate, final Long osmIdentifier)
+    {
+        //
+        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
+        {
+            final Coordinate scaled = getScaledCoordinate(coordinate);
+            if (this.scaledPerIdentifierMap.get(osmIdentifier).containsKey(scaled))
+            {
+                return true;
+            }
+        }
+        if (this.coordinateToPointIdentifierMap.containsKey(coordinate))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Takes a coordinate of 7-digit precision and an OSM identifer for the shape being sliced.
+     * First examines the cache mapping to this OSM idenitifier-- if the scaled 6-digit version of
+     * this coordinate exists there, then returns the TemporaryPoint id associated with that.
+     * Otherwise, searches the higher 7-digit precision general cache for the point. If this logic
+     * is reached, then the 6-digit scaled OSM map didn't have an entry for this point, so we update
+     * that mapping, then return the TemporaryPoint id associated for the point.
+     *
+     * @param coordinate
+     *            The coordinate to get the mapped TemporaryPoint identifier for
+     * @param osmIdentifier
+     *            The OSM identifier for the shape being sliced
+     * @return The TemporaryPoint identifier for the coordinate
+     */
+    public Long getPointForCoordinate(final Coordinate coordinate, final Long osmIdentifier)
     {
         final Coordinate scaled = getScaledCoordinate(coordinate);
-        return this.coordinateToPointIdentifierMap.containsKey(scaled);
+        // if this geometry has already used a six-digit approximation, use it
+        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
+        {
+            if (this.scaledPerIdentifierMap.get(osmIdentifier).containsKey(scaled))
+            {
+                return this.scaledPerIdentifierMap.get(osmIdentifier).get(scaled);
+            }
+        }
+
+        // else, there must be a seven digit precision equals value location already created -- use
+        // that point instead of making a new one
+        if (this.coordinateToPointIdentifierMap.containsKey(coordinate))
+        {
+            final Long cachedPoint = this.coordinateToPointIdentifierMap.get(coordinate);
+            storeMapping(coordinate, osmIdentifier, cachedPoint);
+            return cachedPoint;
+        }
+        return null;
     }
 
-    public Long getPointForCoordinate(final Coordinate coordinate)
-    {
-        final Coordinate precise = getScaledCoordinate(coordinate);
-        return this.coordinateToPointIdentifierMap.get(precise);
-    }
-
-    public void storeMapping(final Coordinate coordinate, final Long value)
-    {
-        final Coordinate scaled = getScaledCoordinate(coordinate);
-        this.coordinateToPointIdentifierMap.put(scaled, value);
-    }
-
-    private Coordinate getScaledCoordinate(final Coordinate target)
+    /**
+     * Takes a coordinate and returns a copy that is scaled to 6-digits of precision.
+     *
+     * @param target
+     *            The coordinate to scale
+     * @return The coordinate scaled to 6-digits
+     */
+    public Coordinate getScaledCoordinate(final Coordinate target)
     {
         // Clone to avoid updating actual coordinate
         final Coordinate cloned = (Coordinate) target.clone();
         this.precisionModel.makePrecise(cloned);
         return cloned;
+    }
+
+    /**
+     * Takes a coordinate, an OSM identifier, and a TemporaryPoint id and puts them in the cache.
+     * Since there are two mappings, first inserts the Point into the scaled per-OSM-shape cache,
+     * then inserts into the general 7-digit precision cache.
+     *
+     * @param coordinate
+     *            Coordinate used to create the point
+     * @param osmIdentifier
+     *            The OSM identifier for the shape being sliced
+     * @param point
+     *            The identifier for the TemporaryPoint made with the coordinate
+     */
+    public void storeMapping(final Coordinate coordinate, final Long osmIdentifier,
+            final Long point)
+    {
+        final Coordinate scaled = getScaledCoordinate(coordinate);
+        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
+        {
+            this.scaledPerIdentifierMap.get(osmIdentifier).put(scaled, point);
+            if (!this.coordinateToPointIdentifierMap.containsKey(coordinate))
+            {
+                this.coordinateToPointIdentifierMap.put(coordinate, point);
+            }
+        }
+        else
+        {
+            final Map<Coordinate, Long> newCachedMap = new ConcurrentHashMap<>();
+            newCachedMap.put(scaled, point);
+            this.scaledPerIdentifierMap.put(osmIdentifier, newCachedMap);
+            if (!this.coordinateToPointIdentifierMap.containsKey(coordinate))
+            {
+                this.coordinateToPointIdentifierMap.put(coordinate, point);
+            }
+        }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/CoordinateToNewPointMapping.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/CoordinateToNewPointMapping.java
@@ -17,9 +17,8 @@ import com.vividsolutions.jts.geom.PrecisionModel;
  * For example, we'll have a slice that has a Coordinate of (-8.3261734, 6.8663838) and another one
  * that is really close, but differs at the 7th digit of significance: (-8.3261735, 6.8663838) -
  * note the 4 and 5 for the latitude value. This will cause us to create two separate Points at what
- * should be a single Location. To prevent this from happening, we're maintaining maps for
- * TemporaryPoints that have been made made while slicing, allowing for consistent geometry per OSM
- * shape and limiting duplicate TemporaryPoints.
+ * should be a single Location. To prevent this from happening, we're storing all points at 6-digit
+ * precision
  *
  * @author mgostintsev
  * @author samuelgass
@@ -30,87 +29,37 @@ public class CoordinateToNewPointMapping
     private static final Integer SIX_DIGIT_PRECISION_SCALE = 1_000_000;
 
     private final Map<Coordinate, Long> coordinateToPointIdentifierMap;
-    private final Map<Long, Map<Coordinate, Long>> scaledPerIdentifierMap;
     private final PrecisionModel precisionModel;
 
     public CoordinateToNewPointMapping()
     {
         this.coordinateToPointIdentifierMap = new ConcurrentHashMap<>();
-        this.scaledPerIdentifierMap = new ConcurrentHashMap<>();
         this.precisionModel = new PrecisionModel(SIX_DIGIT_PRECISION_SCALE);
     }
 
     /**
-     * Takes a coordinate and an OSM identifier, and returns whether the coordinate has been mapped
-     * before. The mapping check is somewhat unintuitive-- first, it checks to see if the coordinate
-     * has a six digit approximation already used by this OSM shape. This enforces consistency
-     * across OSM shape builds, ensuring they always use the same six-digit precision coordinate if
-     * necessary. If this is false, then the higher 7-digit precision map is checked. This ensures
-     * that if a TemporaryPoint with the same 7-digit precision has already been made by another OSM
-     * shape, it will be used instead of a duplicate being made.
+     * Checks if this coordinate exists in the map or not
      *
      * @param coordinate
      *            The coordinate to check the cache for
-     * @param osmIdentifier
-     *            The OSM identifier whose shape is being sliced
-     * @return True if the 6-digit scaled coordinate exists in the cache for this OSM shape, or else
-     *         if the 7-digit original coordinate exists in the high precision general cache. False
-     *         if neither of those caches contain relevant entries.
+     * @return True if the coordinate exists, false if not
      */
 
-    public boolean containsCoordinate(final Coordinate coordinate, final Long osmIdentifier)
+    public boolean containsCoordinate(final Coordinate coordinate)
     {
-        //
-        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
-        {
-            final Coordinate scaled = getScaledCoordinate(coordinate);
-            if (this.scaledPerIdentifierMap.get(osmIdentifier).containsKey(scaled))
-            {
-                return true;
-            }
-        }
-        if (this.coordinateToPointIdentifierMap.containsKey(coordinate))
-        {
-            return true;
-        }
-        return false;
+        return this.coordinateToPointIdentifierMap.containsKey(coordinate);
     }
 
     /**
-     * Takes a coordinate of 7-digit precision and an OSM identifer for the shape being sliced.
-     * First examines the cache mapping to this OSM idenitifier-- if the scaled 6-digit version of
-     * this coordinate exists there, then returns the TemporaryPoint id associated with that.
-     * Otherwise, searches the higher 7-digit precision general cache for the point. If this logic
-     * is reached, then the 6-digit scaled OSM map didn't have an entry for this point, so we update
-     * that mapping, then return the TemporaryPoint id associated for the point.
+     * Gets the TemporaryPoint identifier for this coordinate
      *
      * @param coordinate
      *            The coordinate to get the mapped TemporaryPoint identifier for
-     * @param osmIdentifier
-     *            The OSM identifier for the shape being sliced
      * @return The TemporaryPoint identifier for the coordinate
      */
-    public Long getPointForCoordinate(final Coordinate coordinate, final Long osmIdentifier)
+    public Long getPointForCoordinate(final Coordinate coordinate)
     {
-        final Coordinate scaled = getScaledCoordinate(coordinate);
-        // if this geometry has already used a six-digit approximation, use it
-        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
-        {
-            if (this.scaledPerIdentifierMap.get(osmIdentifier).containsKey(scaled))
-            {
-                return this.scaledPerIdentifierMap.get(osmIdentifier).get(scaled);
-            }
-        }
-
-        // else, there must be a seven digit precision equals value location already created -- use
-        // that point instead of making a new one
-        if (this.coordinateToPointIdentifierMap.containsKey(coordinate))
-        {
-            final Long cachedPoint = this.coordinateToPointIdentifierMap.get(coordinate);
-            storeMapping(coordinate, osmIdentifier, cachedPoint);
-            return cachedPoint;
-        }
-        return null;
+        return this.coordinateToPointIdentifierMap.get(coordinate);
     }
 
     /**
@@ -129,38 +78,15 @@ public class CoordinateToNewPointMapping
     }
 
     /**
-     * Takes a coordinate, an OSM identifier, and a TemporaryPoint id and puts them in the cache.
-     * Since there are two mappings, first inserts the Point into the scaled per-OSM-shape cache,
-     * then inserts into the general 7-digit precision cache.
+     * Takes a coordinate, and a TemporaryPoint id and puts them in the cache.
      *
      * @param coordinate
      *            Coordinate used to create the point
-     * @param osmIdentifier
-     *            The OSM identifier for the shape being sliced
      * @param point
      *            The identifier for the TemporaryPoint made with the coordinate
      */
-    public void storeMapping(final Coordinate coordinate, final Long osmIdentifier,
-            final Long point)
+    public void storeMapping(final Coordinate coordinate, final Long point)
     {
-        final Coordinate scaled = getScaledCoordinate(coordinate);
-        if (this.scaledPerIdentifierMap.containsKey(osmIdentifier))
-        {
-            this.scaledPerIdentifierMap.get(osmIdentifier).put(scaled, point);
-            if (!this.coordinateToPointIdentifierMap.containsKey(coordinate))
-            {
-                this.coordinateToPointIdentifierMap.put(coordinate, point);
-            }
-        }
-        else
-        {
-            final Map<Coordinate, Long> newCachedMap = new ConcurrentHashMap<>();
-            newCachedMap.put(scaled, point);
-            this.scaledPerIdentifierMap.put(osmIdentifier, newCachedMap);
-            if (!this.coordinateToPointIdentifierMap.containsKey(coordinate))
-            {
-                this.coordinateToPointIdentifierMap.put(coordinate, point);
-            }
-        }
+        this.coordinateToPointIdentifierMap.put(coordinate, point);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasCountrySlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasCountrySlicer.java
@@ -82,14 +82,14 @@ public class RawAtlasCountrySlicer
         // duplicate points at the same location and to allow fast lookup to construct new lines
         // requiring the temporary point as a Line shape point
         final CoordinateToNewPointMapping newPointCoordinates = new CoordinateToNewPointMapping();
-
         final RawAtlasSlicer pointAndLineSlicer = new RawAtlasPointAndLineSlicer(this.countries,
                 this.countryBoundaryMap, rawAtlas, slicedPointAndLineChanges, newPointCoordinates);
         final Atlas slicedPointsAndLinesAtlas = pointAndLineSlicer.slice();
 
+        final CoordinateToNewPointMapping newPointCoordinatesRelations = new CoordinateToNewPointMapping();
         final RawAtlasSlicer relationSlicer = new RawAtlasRelationSlicer(slicedPointsAndLinesAtlas,
                 this.countries, this.countryBoundaryMap, slicedPointAndLineChanges,
-                slicedRelationChanges, newPointCoordinates);
+                slicedRelationChanges, newPointCoordinatesRelations);
 
         logger.info("Finished all Slicing for Shard {} in {}", shardName, time.elapsedSince());
         return relationSlicer.slice();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -98,8 +98,11 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
      * raw Atlas, and adds the points the list of points for the line.
      *
      * @param location
+     *            The location for the point(s)
      * @param rawAtlasPoints
+     *            The points from the raw Atlas
      * @param line
+     *            The List representing the points for the line to add the points to
      */
     private void addRawAtlasPointsToLine(final Location location,
             final Iterable<Point> rawAtlasPoints, final List<Long> line)
@@ -289,12 +292,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
 
                             // Check the cache for this coordinate -- if it already exists, we'll
                             // use it. Otherwise, scale to 6-digits and continue
-                            if (getCoordinateToPointMapping().containsCoordinate(coordinate,
-                                    line.getOsmIdentifier()))
+                            if (getCoordinateToPointMapping().containsCoordinate(coordinate))
                             {
-                                newLineShapePoints
-                                        .add(getCoordinateToPointMapping().getPointForCoordinate(
-                                                coordinate, line.getOsmIdentifier()));
+                                newLineShapePoints.add(getCoordinateToPointMapping()
+                                        .getPointForCoordinate(coordinate));
                             }
                             else
                             {
@@ -319,7 +320,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                                                     coordinate),
                                             pointIdentifierFactory, pointTags);
                                     getCoordinateToPointMapping().storeMapping(coordinate,
-                                            line.getOsmIdentifier(), newPoint.getIdentifier());
+                                            newPoint.getIdentifier());
                                     newLineShapePoints.add(newPoint.getIdentifier());
                                     this.slicedPointAndLineChanges.createPoint(newPoint);
                                 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -93,6 +93,28 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
     }
 
     /**
+     * Takes a location, a list of points from the raw Atlas at that location, and a list of point
+     * IDs. Ensures the tags for the point are updated, ensures the points are not removed from the
+     * raw Atlas, and adds the points the list of points for the line.
+     *
+     * @param location
+     * @param rawAtlasPoints
+     * @param line
+     */
+    private void addRawAtlasPointsToLine(final Location location,
+            final Iterable<Point> rawAtlasPoints, final List<Long> line)
+    {
+        final Map<String, String> pointTags = createPointTags(location, true);
+        for (final Point rawAtlasPoint : rawAtlasPoints)
+        {
+            this.pointsMarkedForRemoval.remove(rawAtlasPoint.getIdentifier());
+            this.slicedPointAndLineChanges.updatePointTags(rawAtlasPoint.getIdentifier(),
+                    pointTags);
+            line.add(rawAtlasPoint.getIdentifier());
+        }
+    }
+
+    /**
      * Converts the given {@link Line} into a JTS {@link Geometry} and slices it.
      *
      * @param line
@@ -238,10 +260,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
             {
                 for (final Geometry slice : slices)
                 {
-                    // Check if the slice is within the working bound
+                    // Check if the slice is within the working bound and mark all points for this
+                    // slice for removal if so
                     if (isOutsideWorkingBound(slice))
                     {
-                        // Mark all existing points from this slice for removal and continue
                         removeShapePointsFromFilteredSliced(slice);
                         continue;
                     }
@@ -249,70 +271,69 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                     // Keep track of identifiers that form the geometry of the new line
                     final List<Long> newLineShapePoints = new ArrayList<>(slice.getNumPoints());
 
-                    final Coordinate[] jtsSliceCoordinates = slice.getCoordinates();
+                    // Because country shapes do not share border, we are reducing the precision of
+                    // the geometry
+                    final Coordinate[] jtsSliceCoordinates = PRECISION_REDUCER
+                            .edit(slice.getCoordinates(), slice);
                     for (final Coordinate coordinate : jtsSliceCoordinates)
                     {
-                        // Because country shapes do not share border, we are rounding coordinate
-                        // first to consider very close nodes as one
-                        roundCoordinate(coordinate);
+                        final Location coordinateLocation = JTS_LOCATION_CONVERTER
+                                .backwardConvert(coordinate);
+                        final Iterable<Point> rawAtlasPointsAtSliceVertex = this.rawAtlas
+                                .pointsAt(coordinateLocation);
 
-                        if (getCoordinateToPointMapping().containsCoordinate(coordinate))
+                        // If there aren't any points at this precision in the raw Atlas, need to
+                        // examine cache and possibly scale the coordinate to 6 digits of precision
+                        if (Iterables.isEmpty(rawAtlasPointsAtSliceVertex))
                         {
-                            // A new point was already created for this coordinate. Look it up and
-                            // use it for the line we're creating
-                            newLineShapePoints.add(getCoordinateToPointMapping()
-                                    .getPointForCoordinate(coordinate));
-                        }
-                        else
-                        {
-                            // The point is in the original Raw Atlas or we need to create a new one
-                            final Location coordinateLocation = JTS_LOCATION_CONVERTER
-                                    .backwardConvert(coordinate);
-                            final Iterable<Point> rawAtlasPointsAtSliceVertex = this.rawAtlas
-                                    .pointsAt(coordinateLocation);
 
-                            if (Iterables.isEmpty(rawAtlasPointsAtSliceVertex))
+                            // Check the cache for this coordinate -- if it already exists, we'll
+                            // use it. Otherwise, scale to 6-digits and continue
+                            if (getCoordinateToPointMapping().containsCoordinate(coordinate,
+                                    line.getOsmIdentifier()))
                             {
-                                // Grab the country code tags for this point
-                                final Map<String, String> pointTags = createPointTags(
-                                        coordinateLocation, false);
-
-                                // Need to create a new point
-                                final TemporaryPoint newPoint = createNewPoint(coordinate,
-                                        pointIdentifierFactory, pointTags);
-
-                                // Store coordinate to avoid creating duplicate points
-                                getCoordinateToPointMapping().storeMapping(coordinate,
-                                        newPoint.getIdentifier());
-
-                                // Store this point to reconstruct the line geometry
-                                newLineShapePoints.add(newPoint.getIdentifier());
-
-                                // Save the point to add to the rebuilt atlas
-                                this.slicedPointAndLineChanges.createPoint(newPoint);
+                                newLineShapePoints
+                                        .add(getCoordinateToPointMapping().getPointForCoordinate(
+                                                coordinate, line.getOsmIdentifier()));
                             }
                             else
                             {
-                                // Grab the country code tags for this point
-                                final Map<String, String> pointTags = createPointTags(
-                                        coordinateLocation, true);
+                                final Location scaledLocation = JTS_LOCATION_CONVERTER
+                                        .backwardConvert(getCoordinateToPointMapping()
+                                                .getScaledCoordinate(coordinate));
+                                final Iterable<Point> rawAtlasPointsAtScaledCoordinate = this.rawAtlas
+                                        .pointsAt(scaledLocation);
 
-                                // There is at least one point at this location in the raw Atlas.
-                                // Update all existing points to have the country code.
-                                for (final Point rawAtlasPoint : rawAtlasPointsAtSliceVertex)
+                                // If the raw Atlas doesn't contain the 6-digit coordinate either,
+                                // then we'll make a point at that location and update the cache and
+                                // changeset with it. Otherwise, use the existing Atlas point by
+                                // making sure it's kept and adding it to the line
+                                if (Iterables.isEmpty(rawAtlasPointsAtScaledCoordinate))
                                 {
-                                    // Make sure to keep this point
-                                    this.pointsMarkedForRemoval
-                                            .remove(rawAtlasPoint.getIdentifier());
-
-                                    // Update the country codes
-                                    this.slicedPointAndLineChanges.updatePointTags(
-                                            rawAtlasPoint.getIdentifier(), pointTags);
-
-                                    // Add all point identifiers to make up the new Line
-                                    newLineShapePoints.add(rawAtlasPoint.getIdentifier());
+                                    final Map<String, String> pointTags = createPointTags(
+                                            scaledLocation, false);
+                                    pointTags.put(SyntheticBoundaryNodeTag.KEY,
+                                            SyntheticBoundaryNodeTag.YES.toString());
+                                    final TemporaryPoint newPoint = createNewPoint(
+                                            getCoordinateToPointMapping().getScaledCoordinate(
+                                                    coordinate),
+                                            pointIdentifierFactory, pointTags);
+                                    getCoordinateToPointMapping().storeMapping(coordinate,
+                                            line.getOsmIdentifier(), newPoint.getIdentifier());
+                                    newLineShapePoints.add(newPoint.getIdentifier());
+                                    this.slicedPointAndLineChanges.createPoint(newPoint);
+                                }
+                                else
+                                {
+                                    addRawAtlasPointsToLine(scaledLocation,
+                                            rawAtlasPointsAtScaledCoordinate, newLineShapePoints);
                                 }
                             }
+                        }
+                        else
+                        {
+                            addRawAtlasPointsToLine(coordinateLocation, rawAtlasPointsAtSliceVertex,
+                                    newLineShapePoints);
                         }
                     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -245,12 +245,11 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
 
             if (Iterables.isEmpty(rawAtlasPointsAtCoordinate))
             {
-                if (getCoordinateToPointMapping().containsCoordinate(pointCoordinate,
-                        relationIdentifier))
+                if (getCoordinateToPointMapping().containsCoordinate(pointCoordinate))
                 {
                     // A new point was already created for this coordinate - use it
-                    newLineShapePoints.add(getCoordinateToPointMapping()
-                            .getPointForCoordinate(pointCoordinate, relationIdentifier));
+                    newLineShapePoints.add(
+                            getCoordinateToPointMapping().getPointForCoordinate(pointCoordinate));
                 }
                 else
                 {
@@ -271,7 +270,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
 
                         // Store coordinate to avoid creating duplicate points
                         getCoordinateToPointMapping().storeMapping(pointCoordinate,
-                                relationIdentifier, newPoint.getIdentifier());
+                                newPoint.getIdentifier());
 
                         // Store this point to reconstruct the line geometry
                         newLineShapePoints.add(newPoint.getIdentifier());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -235,56 +235,67 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
     {
         // Keep track of identifiers that form the geometry of the new line
         final List<Long> newLineShapePoints = new ArrayList<>(lineString.getNumPoints());
-
-        for (int exteriorIndex = 0; exteriorIndex < lineString.getNumPoints(); exteriorIndex++)
+        final Coordinate[] lineCoordinates = PRECISION_REDUCER.edit(lineString.getCoordinates(),
+                lineString);
+        for (final Coordinate pointCoordinate : lineCoordinates)
         {
-            final Coordinate pointCoordinate = lineString.getCoordinateN(exteriorIndex);
-            roundCoordinate(pointCoordinate);
+            final Location pointLocation = JTS_LOCATION_CONVERTER.backwardConvert(pointCoordinate);
+            final Iterable<Point> rawAtlasPointsAtCoordinate = this.partiallySlicedRawAtlas
+                    .pointsAt(pointLocation);
 
-            if (getCoordinateToPointMapping().containsCoordinate(pointCoordinate))
+            if (Iterables.isEmpty(rawAtlasPointsAtCoordinate))
             {
-                // A new point was already created for this coordinate - use it
-                newLineShapePoints
-                        .add(getCoordinateToPointMapping().getPointForCoordinate(pointCoordinate));
-            }
-            else
-            {
-                // The point is in the original Raw Atlas or need to create a new one
-                final Location pointLocation = JTS_LOCATION_CONVERTER
-                        .backwardConvert(pointCoordinate);
-                final Iterable<Point> rawAtlasPointsAtCoordinate = this.partiallySlicedRawAtlas
-                        .pointsAt(pointLocation);
-                if (Iterables.isEmpty(rawAtlasPointsAtCoordinate))
+                if (getCoordinateToPointMapping().containsCoordinate(pointCoordinate,
+                        relationIdentifier))
                 {
-                    // Point doesn't exist in the raw Atlas, create a new one
-                    final Map<String, String> newPointTags = createPointTags(pointLocation, false);
-                    newPointTags.put(SyntheticBoundaryNodeTag.KEY,
-                            SyntheticBoundaryNodeTag.YES.toString());
-                    final long newPointIdentifier = createNewPointIdentifier(
-                            pointIdentifierGenerator, pointCoordinate);
-                    final TemporaryPoint newPoint = new TemporaryPoint(newPointIdentifier,
-                            JTS_LOCATION_CONVERTER.backwardConvert(pointCoordinate), newPointTags);
-
-                    // Store coordinate to avoid creating duplicate points
-                    getCoordinateToPointMapping().storeMapping(pointCoordinate,
-                            newPoint.getIdentifier());
-
-                    // Store this point to reconstruct the line geometry
-                    newLineShapePoints.add(newPoint.getIdentifier());
-
-                    // Save the point to add to the rebuilt atlas
-                    this.slicedRelationChanges.createPoint(newPoint);
+                    // A new point was already created for this coordinate - use it
+                    newLineShapePoints.add(getCoordinateToPointMapping()
+                            .getPointForCoordinate(pointCoordinate, relationIdentifier));
                 }
                 else
                 {
-                    // There is at least one point at this Location in the raw Atlas. Update all
-                    // existing points to have the country code. Note: raw Atlas combines all nodes
-                    // at a single location, so expect only a single point to be added here.
-                    for (final Point rawAtlasPoint : rawAtlasPointsAtCoordinate)
+                    final Location scaledLocation = JTS_LOCATION_CONVERTER.backwardConvert(
+                            getCoordinateToPointMapping().getScaledCoordinate(pointCoordinate));
+                    final Iterable<Point> rawAtlasPointsAtScaledCoordinate = this.partiallySlicedRawAtlas
+                            .pointsAt(scaledLocation);
+                    if (Iterables.isEmpty(rawAtlasPointsAtScaledCoordinate))
                     {
-                        // Add all point identifiers to make up the new Line
-                        newLineShapePoints.add(rawAtlasPoint.getIdentifier());
+                        final Map<String, String> newPointTags = createPointTags(scaledLocation,
+                                false);
+                        newPointTags.put(SyntheticBoundaryNodeTag.KEY,
+                                SyntheticBoundaryNodeTag.YES.toString());
+                        final long newPointIdentifier = createNewPointIdentifier(
+                                pointIdentifierGenerator, pointCoordinate);
+                        final TemporaryPoint newPoint = new TemporaryPoint(newPointIdentifier,
+                                scaledLocation, newPointTags);
+
+                        // Store coordinate to avoid creating duplicate points
+                        getCoordinateToPointMapping().storeMapping(pointCoordinate,
+                                relationIdentifier, newPoint.getIdentifier());
+
+                        // Store this point to reconstruct the line geometry
+                        newLineShapePoints.add(newPoint.getIdentifier());
+
+                        // Save the point to add to the rebuilt atlas
+                        this.slicedRelationChanges.createPoint(newPoint);
                     }
+                    else
+                    {
+                        for (final Point rawAtlasPoint : rawAtlasPointsAtScaledCoordinate)
+                        {
+                            // Add all point identifiers to make up the new Line
+                            newLineShapePoints.add(rawAtlasPoint.getIdentifier());
+                        }
+                    }
+                }
+            }
+
+            else
+            {
+                for (final Point rawAtlasPoint : rawAtlasPointsAtCoordinate)
+                {
+                    // Add all point identifiers to make up the new Line
+                    newLineShapePoints.add(rawAtlasPoint.getIdentifier());
                 }
             }
         }
@@ -648,8 +659,6 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                 closedOuterLines, closedInnerLines);
 
         final long[] identifierSeeds = createIdentifierSeeds(relation);
-        final CountrySlicingIdentifierFactory lineIdentifierGenerator = new CountrySlicingIdentifierFactory(
-                identifierSeeds[0]);
         final CountrySlicingIdentifierFactory pointIdentifierGenerator = new CountrySlicingIdentifierFactory(
                 identifierSeeds);
 
@@ -659,6 +668,8 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
             final int outerIndex = entry.getKey();
             final List<Integer> innerIndices = entry.getValue();
 
+            final CountrySlicingIdentifierFactory lineIdentifierGenerator = new CountrySlicingIdentifierFactory(
+                    +identifierSeeds[outerIndex]);
             Geometry mergedMembers = null;
 
             // Convert outer to ring

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -668,6 +668,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
             final int outerIndex = entry.getKey();
             final List<Integer> innerIndices = entry.getValue();
 
+            // Use the index of the outer to determine the new line identifier
             final CountrySlicingIdentifierFactory lineIdentifierGenerator = new CountrySlicingIdentifierFactory(
                     +identifierSeeds[outerIndex]);
             Geometry mergedMembers = null;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -31,6 +31,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.PrecisionModel;
+import com.vividsolutions.jts.precision.PrecisionReducerCoordinateOperation;
 
 /**
  * The abstract class that contains all common raw Atlas slicing functionality.
@@ -41,15 +43,19 @@ public abstract class RawAtlasSlicer
 {
     private static final Logger logger = LoggerFactory.getLogger(RawAtlasSlicer.class);
 
-    // Constants
-    private static final double SEVEN_DIGIT_PRECISION_SCALE = 10_000_000;
-
     // JTS converters
     protected static final JtsPolygonConverter JTS_POLYGON_CONVERTER = new JtsPolygonConverter();
     protected static final JtsPolyLineConverter JTS_POLYLINE_CONVERTER = new JtsPolyLineConverter();
     protected static final JtsLocationConverter JTS_LOCATION_CONVERTER = new JtsLocationConverter();
     protected static final JtsLinearRingConverter JTS_LINEAR_RING_CONVERTER = new JtsLinearRingConverter();
     protected static final MultiplePolyLineToPolygonsConverter MULTIPLE_POLY_LINE_TO_POLYGON_CONVERTER = new MultiplePolyLineToPolygonsConverter();
+
+    // JTS precision handling
+    private static final Integer SEVEN_DIGIT_PRECISION_SCALE = 10_000_000;
+    private static final PrecisionModel PRECISION_MODEL = new PrecisionModel(
+            SEVEN_DIGIT_PRECISION_SCALE);
+    protected static final PrecisionReducerCoordinateOperation PRECISION_REDUCER = new PrecisionReducerCoordinateOperation(
+            PRECISION_MODEL, false);
 
     // The countries we're interested in slicing against
     private final Set<String> countries;
@@ -151,22 +157,6 @@ public abstract class RawAtlasSlicer
         throw new CoreException(
                 "All raw Atlas lines must have a country code by the time Relation slicing is done. One of the two Lines {} or {} does not!",
                 one.getIdentifier(), two.getIdentifier());
-    }
-
-    /**
-     * JTS has trouble dealing with high-precision double values. For this reason, we round all
-     * coordinates to 7 degrees of precision. See {@link Coordinate} java doc for more detailed
-     * explanation of scaling.
-     *
-     * @param coordinate
-     *            The {@link Coordinate} to round
-     */
-    protected static void roundCoordinate(final Coordinate coordinate)
-    {
-        coordinate.x = Math.round(coordinate.x * SEVEN_DIGIT_PRECISION_SCALE)
-                / SEVEN_DIGIT_PRECISION_SCALE;
-        coordinate.y = Math.round(coordinate.y * SEVEN_DIGIT_PRECISION_SCALE)
-                / SEVEN_DIGIT_PRECISION_SCALE;
     }
 
     public RawAtlasSlicer(final Set<String> countries, final CountryBoundaryMap countryBoundaryMap,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
@@ -132,7 +132,7 @@ public class RelationSlicingTest
         final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
         new ComplexBuildingFinder().find(slicedAtlas).forEach(System.out::println);
 
-        Assert.assertEquals(23, slicedAtlas.numberOfPoints());
+        Assert.assertEquals(25, slicedAtlas.numberOfPoints());
         Assert.assertEquals(2, slicedAtlas.numberOfLines());
         Assert.assertEquals(2, slicedAtlas.numberOfRelations());
     }


### PR DESCRIPTION
### Description:

Under certain conditions, geometry across shards was being constructed in both shards but varied slightly due to precision and rounding logic. This PR updates the slicing operation in a number of ways intended to address this problem. 

First, the logic around point creation during slicing has been updated. If the Atlas contains a point at 7 digits of precision matching the sliced coordinate, that point is used. Otherwise, the point is reduced to 6 digits of prevision, and then either an existing Atlas point at that location is used, or a new TemporaryPoint is constructed. 

Additionally, the cache of coordinates to new points has been reconfigured to maintain a per-OSM-identifier cache at the 6 digit of precision level, with a secondary global 7-digit precision map. 

The result logic tweaks the weight of various components of slicing. Existing Atlas points are now prioritized. If there is an existing Atlas point matching the 7-digit precision coordinate, it is always used; similarly, when scaling down to 6-digit precision for a coordinate, the Atlas points are again checked at that newly scaled location. This limits the number of TemporaryPoints made and prevents excess duplicate Points in the final sliced Atlas.

Additionally, this substantially increases determinism in the final output geometry. Previously, there was a corner case involving two shards processing the same geometry differently caused by a caching collision. Since the cache wasn't organizing by OSM identifier, shapes not shared across shards could contribute their 6-digit precision coordinates to the cache, causing different cache contents during the slicing operations for different shards. 

### Potential Impact:

Should fix geometry related errors in Atlas verifier. Otherwise, will round all SyntheticBoundaryNodes created by slicing to 6-digits of prevision, causing slightly different shapes that previous versions.

### Unit Test Approach:

None. Any suggestions for unit tests are greatly appreciated-- this is a complex issue that's hard to design simple cases around.

### Test Results:

Basic sanity tests passed, Atlas verifier no longer shows geometry issues on my runs. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)