### PR TITLE
Tokenize string in RunScript

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/runtime/RunScript.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/runtime/RunScript.java
@@ -22,12 +22,12 @@ public final class RunScript
 
     public static void run(final String command)
     {
-        run(new String[] { command });
+        run(command.split("\\s+"));
     }
 
     public static void run(final String command, final List<RunScriptMonitor> monitors)
     {
-        run(new String[] { command }, monitors);
+        run(command.split("\\s+"), monitors);
     }
 
     public static void run(final String[] commandArray)


### PR DESCRIPTION
### Description:

Tokenize the command string on whitespace. Previously this would pass the full command string to a single element of an array, which would cause RunScript to look for a program named the program name plus its arguments. This will correctly split the arguments from the program name.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)