### PR TITLE
[Change] Lots of filtering implemented

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -92,9 +92,24 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
     @Override
     public Edge edge(final long identifier)
     {
-        return entityFor(identifier, ItemType.EDGE, () -> this.source.edge(identifier),
+        final Edge edge = entityFor(identifier, ItemType.EDGE, () -> this.source.edge(identifier),
                 (sourceEntity, overrideEntity) -> new ChangeEdge(this, (Edge) sourceEntity,
                         (Edge) overrideEntity));
+
+        /*
+         * If the edge was not found in this atlas, return null. Additionally, we then check to see
+         * if this edge is missing a start or end node (which may have been removed by a
+         * FeatureChange). In this case, we also want to "remove" the edge by returning null.
+         */
+        if (edge == null)
+        {
+            return null;
+        }
+        if (edge.start() == null || edge.end() == null)
+        {
+            return null;
+        }
+        return edge;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -239,9 +239,25 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
     @Override
     public Relation relation(final long identifier)
     {
-        return entityFor(identifier, ItemType.RELATION, () -> this.source.relation(identifier),
+        final Relation relation = entityFor(identifier, ItemType.RELATION,
+                () -> this.source.relation(identifier),
                 (sourceEntity, overrideEntity) -> new ChangeRelation(this, (Relation) sourceEntity,
                         (Relation) overrideEntity));
+
+        /*
+         * If the relation was not found in this atlas, return null. Additionally, we check to see
+         * if the relation has no members. If so, it is considered shallow and is dropped from the
+         * atlas.
+         */
+        if (relation == null)
+        {
+            return null;
+        }
+        if (relation.members().isEmpty())
+        {
+            return null;
+        }
+        return relation;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -246,8 +246,9 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
 
         /*
          * If the relation was not found in this atlas, return null. Additionally, we check to see
-         * if the relation has no members. If so, it is considered shallow and is dropped from the
-         * atlas.
+         * if the relation has no members. If so, it is considered empty and is dropped from the
+         * atlas. This logic, combined with the logic in ChangeRelation.membersFor, will
+         * automatically handle removing non-empty but shallow relations as well.
          */
         if (relation == null)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -7,7 +7,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 
 /**
  * Utility class for Change entities: ChangeNode, ChangeEdge, etc.
- * 
+ *
  * @author matthieun
  */
 public final class ChangeEntity

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -50,29 +50,31 @@ public class ChangeNode extends Node // NOSONAR
     public SortedSet<Long> inEdgeIdentifiers()
     {
         return attribute(Node::inEdges).stream().map(Edge::getIdentifier)
+                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
                 .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
     public SortedSet<Edge> inEdges()
     {
-        return attribute(Node::inEdges).stream()
-                .map(edge -> getChangeAtlas().edge(edge.getIdentifier()))
-                .filter(edge -> edge != null).collect(Collectors.toCollection(TreeSet::new));
+        return inEdgeIdentifiers().stream()
+                .map(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier))
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     public SortedSet<Long> outEdgeIdentifiers()
     {
         return attribute(Node::outEdges).stream().map(Edge::getIdentifier)
+                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
                 .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
     public SortedSet<Edge> outEdges()
     {
-        return attribute(Node::outEdges).stream()
-                .map(edge -> getChangeAtlas().edge(edge.getIdentifier()))
-                .filter(edge -> edge != null).collect(Collectors.toCollection(TreeSet::new));
+        return outEdgeIdentifiers().stream()
+                .map(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier))
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBeanItem;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -100,14 +99,11 @@ public class ChangeRelation extends Relation // NOSONAR
         {
             final AtlasEntity memberChangeEntity = getChangeAtlas().entity(item.getIdentifier(),
                     item.getType());
-            if (memberChangeEntity == null)
+            if (memberChangeEntity != null)
             {
-                throw new CoreException(
-                        "Member {} {} (Role = \"{}\") is referenced in Relation {} but is unavailable or removed in ChangeAtlas {}.",
-                        item.getType(), item.getIdentifier(), item.getRole(), this.getIdentifier(),
-                        getChangeAtlas().getName());
+                memberList.add(
+                        new RelationMember(item.getRole(), memberChangeEntity, getIdentifier()));
             }
-            memberList.add(new RelationMember(item.getRole(), memberChangeEntity, getIdentifier()));
         }
         return new RelationMemberList(memberList);
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -48,8 +48,9 @@ public class ChangeAtlasTest
     public void testBounds()
     {
         final Atlas atlas = this.rule.getAtlas();
-        Assert.assertEquals("POLYGON ((-122.2450237 37.5920679, -122.2450237 37.5938783, "
-                + "-122.2412753 37.5938783, -122.2412753 37.5920679, -122.2450237 37.5920679))",
+        Assert.assertEquals(
+                "POLYGON ((-122.2450237 37.5920679, -122.2450237 37.5938783, "
+                        + "-122.2412753 37.5938783, -122.2412753 37.5920679, -122.2450237 37.5920679))",
                 atlas.bounds().toWkt());
 
         final ChangeBuilder changeBuilder = new ChangeBuilder();
@@ -66,8 +67,9 @@ public class ChangeAtlasTest
         final Change change = changeBuilder.get();
 
         final Atlas changeAtlas = new ChangeAtlas(atlas, change);
-        Assert.assertEquals("POLYGON ((-122.2450237 37.5920679, -122.2450237 37.5938873, "
-                + "-122.2412753 37.5938873, -122.2412753 37.5920679, -122.2450237 37.5920679))",
+        Assert.assertEquals(
+                "POLYGON ((-122.2450237 37.5920679, -122.2450237 37.5938873, "
+                        + "-122.2412753 37.5938873, -122.2412753 37.5920679, -122.2450237 37.5920679))",
                 changeAtlas.bounds().toWkt());
     }
 

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.josm.osm
@@ -105,4 +105,9 @@
     <tag k='name' v='parent' />
     <tag k='type' v='parent' />
   </relation>
+  <relation id='-41861' action='modify'>
+    <member type='relation' ref='-41860' role='child1' />
+    <tag k='name' v='super-parent' />
+    <tag k='type' v='super-parent' />
+  </relation>
 </osm>


### PR DESCRIPTION
### Description:

Changes included in this PR:

1) `ChangeAtlas.edge(id)` and `ChangeAtlas.edges()` now filter out edges who are missing one or both of their start/end nodes.

2) Nodes now filter out connected edges that are present in the source atlas, weren't removed by a `FeatureChange`, **but** that have been removed by the algorithm described in 1)

3) Relations now filter out removed members from their member list, even if a member was indirectly removed thru a `FeatureChange` that touched a dependent feature (eg. if a `FeatureChange` removed a node, which triggered an edge removal where the edge was a relation member).

4) `ChangeAtlas.relation(id)` and `ChangeAtlas.relations()` now filter out empty and shallow relations. It handles shallowness at any level of nesting (see unit tests for confirmation).

### Unit Test Approach:

Added some new unit tests. See "Files Changed".

Also added a new relation to the test atlas. This relation contains one member, namely another relation. That member relation also contains only relations as members. This is useful for testing that relation shallowness removal works at multiple levels of nesting.

### Test Results:

Unit tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)