### PR TITLE
[Change] Fixed bug with missing parent relations

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
@@ -137,6 +137,16 @@ public class BloatedArea extends Area implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedArea withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedArea withIdentifier(final long identifier)
     {
         this.identifier = identifier;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -88,7 +89,13 @@ public class BloatedArea extends Area implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedArea)
+        {
+            final BloatedArea that = (BloatedArea) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && Objects.equals(this.asPolygon(), that.asPolygon());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAtlas.java
@@ -42,25 +42,6 @@ public class BloatedAtlas implements Atlas
 {
     private static final long serialVersionUID = 5265300513234306056L;
 
-    static <M extends BloatedEntity> boolean equals(final M mine, final Object other)
-    {
-        if (mine == other)
-        {
-            return true;
-        }
-        if (other != null && mine.getClass() == other.getClass())
-        {
-            @SuppressWarnings("unchecked")
-            final M that = (M) other;
-            // Here override the Atlas equality check in AtlasEntity.equals() as the BloatedAtlas is
-            // always
-            // empty and unique.
-            return mine.getIdentifier() == that.getIdentifier();
-        }
-        return false;
-
-    }
-
     @Override
     public Area area(final long identifier)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
@@ -162,6 +162,16 @@ public class BloatedEdge extends Edge implements BloatedEntity
                 + this.relationIdentifiers + "]";
     }
 
+    public BloatedEdge withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedEdge withEndNodeIdentifier(final Long endNodeIdentifier)
     {
         this.endNodeIdentifier = endNodeIdentifier;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -101,7 +102,16 @@ public class BloatedEdge extends Edge implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedEdge)
+        {
+            final BloatedEdge that = (BloatedEdge) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && Objects.equals(this.asPolyLine(), that.asPolyLine())
+                    && BloatedEntity.equalThroughGet(this.start(), that.start(),
+                            Node::getIdentifier)
+                    && BloatedEntity.equalThroughGet(this.end(), that.end(), Node::getIdentifier);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEntity.java
@@ -2,6 +2,8 @@ package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
@@ -31,6 +33,29 @@ public interface BloatedEntity
         }
         result.put(key, value);
         return result;
+    }
+
+    static boolean basicEqual(final AtlasEntity left, final AtlasEntity right)
+    {
+        return left.getIdentifier() == right.getIdentifier()
+                && Objects.equals(left.getTags(), right.getTags())
+                && Objects.equals(left.relations(), right.relations());
+    }
+
+    static <M, T> boolean equalThroughGet(final M left, final M right, final Function<M, T> getter)
+    {
+        if (left == null && right == null)
+        {
+            return true;
+        }
+        else if (left == null || right == null)
+        {
+            return false;
+        }
+        else
+        {
+            return Objects.equals(getter.apply(left), getter.apply(right));
+        }
     }
 
     static AtlasEntity from(final AtlasEntity reference)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
@@ -137,6 +137,16 @@ public class BloatedLine extends Line implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedLine withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedLine withIdentifier(final long identifier)
     {
         this.identifier = identifier;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -88,7 +89,13 @@ public class BloatedLine extends Line implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedLine)
+        {
+            final BloatedLine that = (BloatedLine) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && Objects.equals(this.asPolyLine(), that.asPolyLine());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
@@ -186,6 +186,16 @@ public class BloatedNode extends Node implements BloatedEntity
                 + this.relationIdentifiers + "]";
     }
 
+    public BloatedNode withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedNode withIdentifier(final long identifier)
     {
         this.identifier = identifier;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -109,7 +110,15 @@ public class BloatedNode extends Node implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedNode)
+        {
+            final BloatedNode that = (BloatedNode) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && Objects.equals(this.getLocation(), that.getLocation())
+                    && Objects.equals(this.inEdges(), that.inEdges())
+                    && Objects.equals(this.outEdges(), that.outEdges());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
@@ -138,6 +138,16 @@ public class BloatedPoint extends Point implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedPoint withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedPoint withIdentifier(final long identifier)
     {
         this.identifier = identifier;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -83,7 +84,13 @@ public class BloatedPoint extends Point implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedPoint)
+        {
+            final BloatedPoint that = (BloatedPoint) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && Objects.equals(this.getLocation(), that.getLocation());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
@@ -191,6 +191,16 @@ public class BloatedRelation extends Relation implements BloatedEntity
                 + "]";
     }
 
+    public BloatedRelation withAggregateBoundsExtendedUsing(final Rectangle bounds)
+    {
+        if (this.aggregateBounds == null)
+        {
+            this.aggregateBounds = bounds;
+        }
+        this.aggregateBounds = Rectangle.forLocated(this.aggregateBounds, bounds);
+        return this;
+    }
+
     public BloatedRelation withAllKnownOsmMembers(final RelationBean allKnownOsmMembers)
     {
         this.allKnownOsmMembers = allKnownOsmMembers;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
@@ -170,7 +170,7 @@ public class BloatedRelation extends Relation implements BloatedEntity
     }
 
     @Override
-    public long osmRelationIdentifier()
+    public Long osmRelationIdentifier()
     {
         return this.osmRelationIdentifier;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.bloated;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -121,7 +122,19 @@ public class BloatedRelation extends Relation implements BloatedEntity
     @Override
     public boolean equals(final Object other)
     {
-        return BloatedAtlas.equals(this, other);
+        if (other instanceof BloatedRelation)
+        {
+            final BloatedRelation that = (BloatedRelation) other;
+            return BloatedEntity.basicEqual(this, that)
+                    && BloatedEntity.equalThroughGet(this.members(), that.members(),
+                            RelationMemberList::asBean)
+                    && Objects.equals(this.allRelationsWithSameOsmIdentifier(),
+                            that.allRelationsWithSameOsmIdentifier())
+                    && BloatedEntity.equalThroughGet(this.allKnownOsmMembers(),
+                            that.allKnownOsmMembers(), RelationMemberList::asBean)
+                    && Objects.equals(this.osmRelationIdentifier(), that.osmRelationIdentifier());
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -163,6 +163,28 @@ public class RelationBean implements Serializable, Iterable<RelationBeanItem>
         return result.iterator();
     }
 
+    public RelationBean merge(final RelationBean other)
+    {
+        final RelationBean result = new RelationBean();
+        for (final RelationBeanItem leftItem : this)
+        {
+            result.addItem(leftItem);
+        }
+        for (final RelationBeanItem rightItem : other)
+        {
+            final Optional<RelationBeanItem> existingLeftItem = this
+                    .getItemFor(rightItem.getIdentifier(), rightItem.getType());
+            if (existingLeftItem.isPresent()
+                    && existingLeftItem.get().getRole().equals(rightItem.getRole()))
+            {
+                // Role already exists, continue.
+                continue;
+            }
+            result.addItem(rightItem);
+        }
+        return result;
+    }
+
     /**
      * @return The number of members in this {@link RelationBean}
      */

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -12,6 +12,8 @@ import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBean
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 
+import com.google.common.collect.HashMultiset;
+
 /**
  * @author matthieun
  */
@@ -95,15 +97,25 @@ public class RelationBean implements Serializable, Iterable<RelationBeanItem>
         addItem(item.getIdentifier(), item.getRole(), item.getType());
     }
 
+    /**
+     * Check if the two beans are the same, without looking at the List order.
+     *
+     * @param other
+     *            The other object
+     * @return True if the other object is a {@link RelationBean} and is equal regardless of order.
+     */
     @Override
     public boolean equals(final Object other)
     {
         if (other instanceof RelationBean)
         {
             final RelationBean that = (RelationBean) other;
-            return Iterables.equals(this.getMemberIdentifiers(), that.getMemberIdentifiers())
-                    && Iterables.equals(this.getMemberRoles(), that.getMemberRoles())
-                    && Iterables.equals(this.getMemberTypes(), that.getMemberTypes());
+            return Iterables.equals(HashMultiset.create(this.getMemberIdentifiers()),
+                    HashMultiset.create(that.getMemberIdentifiers()))
+                    && Iterables.equals(HashMultiset.create(this.getMemberRoles()),
+                            HashMultiset.create(that.getMemberRoles()))
+                    && Iterables.equals(HashMultiset.create(this.getMemberTypes()),
+                            HashMultiset.create(that.getMemberTypes()));
         }
         return false;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.conversion.Converter;
@@ -32,8 +33,10 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
         // Validate
         final ChangeBuilder builder = new ChangeBuilder();
         result.forEach(builder::add);
-        new ChangeAtlas(atlas, builder.get());
-        return result;
+        final Change change = builder.get();
+        new ChangeAtlas(atlas, change);
+        // Return the already merged changes
+        return change.changes().collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -132,7 +132,7 @@ public class Change implements Located, Serializable
         {
             final int existingIndex = this.identifierToIndex.get(key);
             final FeatureChange existing = this.featureChanges.get(existingIndex);
-            logger.warn("Change already has a {}. Adding {} triggered a merge attempt!", existing,
+            logger.trace("Change already has a {}. Adding {} triggered a merge attempt!", existing,
                     featureChange);
             chosen = existing.merge(featureChange);
             this.featureChanges.set(existingIndex, chosen);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
@@ -3,10 +3,10 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 
 /**
@@ -54,9 +54,7 @@ public class ChangeArea extends Area // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Area::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     private <T extends Object> T attribute(final Function<Area, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
@@ -3,9 +3,9 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
@@ -67,9 +67,7 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Edge::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -1,9 +1,13 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 
 /**
  * Utility class for Change entities: ChangeNode, ChangeEdge, etc.
@@ -12,6 +16,33 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
  */
 public final class ChangeEntity
 {
+    /**
+     * Filter parent relations that are mentioned in a ChangeEntity to only those that are not null.
+     *
+     * @param listed
+     *            The relation set to filter
+     * @param parent
+     *            The parent {@link ChangeAtlas}
+     * @return the set of {@link ChangeRelation} that are not null.
+     */
+    static Set<Relation> filterRelations(final Set<Relation> listed, final ChangeAtlas parent)
+    {
+        return listed.stream().map(relation -> parent.relation(relation.getIdentifier()))
+                .filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    /**
+     * Get either the attribute asked from the change entity (override), or from the backup entity
+     * if unavailable.
+     * 
+     * @param source
+     *            The source entity
+     * @param override
+     *            The change entity (override)
+     * @param memberExtractor
+     *            Extract the member attribute from that entity
+     * @return The corresponding attribute
+     */
     static <T extends Object, M extends AtlasEntity> T getAttributeOrBackup(final M source,
             final M override, final Function<M, T> memberExtractor)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -32,9 +34,40 @@ public final class ChangeEntity
     }
 
     /**
+     * Get all the available attributes asked from the change entity (override), and/or from the
+     * backup entity.
+     *
+     * @param source
+     *            The source entity
+     * @param override
+     *            The change entity (override)
+     * @param memberExtractor
+     *            Extract the member attribute from that entity
+     * @return The corresponding attribute list. Will not be empty.
+     */
+    static <T extends Object, M extends AtlasEntity> List<T> getAttributeAndOptionallyBackup(
+            final M source, final M override, final Function<M, T> memberExtractor)
+    {
+        final List<T> result = new ArrayList<>();
+        if (override != null)
+        {
+            result.add(memberExtractor.apply(override));
+        }
+        if (source != null)
+        {
+            result.add(memberExtractor.apply(source));
+        }
+        if (result.isEmpty())
+        {
+            throw new CoreException("Could not retrieve attribute from source nor backup!");
+        }
+        return result;
+    }
+
+    /**
      * Get either the attribute asked from the change entity (override), or from the backup entity
      * if unavailable.
-     * 
+     *
      * @param source
      *            The source entity
      * @param override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -51,11 +51,20 @@ public final class ChangeEntity
         final List<T> result = new ArrayList<>();
         if (override != null)
         {
-            result.add(memberExtractor.apply(override));
+            final T member = memberExtractor.apply(override);
+            if (member != null)
+            {
+                result.add(member);
+            }
+
         }
         if (source != null)
         {
-            result.add(memberExtractor.apply(source));
+            final T member = memberExtractor.apply(source);
+            if (member != null)
+            {
+                result.add(member);
+            }
         }
         if (result.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
@@ -3,9 +3,9 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 
@@ -54,9 +54,7 @@ public class ChangeLine extends Line // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Line::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     private <T extends Object> T attribute(final Function<Line, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
@@ -87,9 +88,7 @@ public class ChangeNode extends Node // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Node::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .filter(relation -> relation != null).collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     private <T extends Object> T attribute(final Function<Node, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
@@ -3,9 +3,9 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 
@@ -53,9 +53,7 @@ public class ChangePoint extends Point // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Point::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     private <T extends Object> T attribute(final Function<Point, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -68,7 +68,9 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public RelationMemberList members()
     {
-        final RelationBean mergedMembersBean = allAvailableAttributes(Relation::members).stream()
+        final List<RelationMemberList> availableMemberLists = allAvailableAttributes(
+                Relation::members);
+        final RelationBean mergedMembersBean = availableMemberLists.stream()
                 .map(RelationMemberList::asBean).reduce(new RelationBean(), RelationBean::merge);
         final RelationBean filteredAndMergedMembersBean = new RelationBean();
         mergedMembersBean.forEach(relationBeanItem ->
@@ -83,7 +85,7 @@ public class ChangeRelation extends Relation // NOSONAR
     }
 
     @Override
-    public long osmRelationIdentifier()
+    public Long osmRelationIdentifier()
     {
         return attribute(Relation::osmRelationIdentifier);
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -80,9 +80,7 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return attribute(Relation::relations).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toSet());
+        return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
     }
 
     private <T extends Object> T attribute(final Function<Relation, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -68,7 +68,18 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public RelationMemberList members()
     {
-        return membersFor(attribute(Relation::members).asBean());
+        final RelationBean mergedMembersBean = allAvailableAttributes(Relation::members).stream()
+                .map(RelationMemberList::asBean).reduce(new RelationBean(), RelationBean::merge);
+        final RelationBean filteredAndMergedMembersBean = new RelationBean();
+        mergedMembersBean.forEach(relationBeanItem ->
+        {
+            if (getChangeAtlas().entity(relationBeanItem.getIdentifier(),
+                    relationBeanItem.getType()) != null)
+            {
+                filteredAndMergedMembersBean.addItem(relationBeanItem);
+            }
+        });
+        return membersFor(filteredAndMergedMembersBean);
     }
 
     @Override
@@ -81,6 +92,13 @@ public class ChangeRelation extends Relation // NOSONAR
     public Set<Relation> relations()
     {
         return ChangeEntity.filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+    }
+
+    private <T extends Object> List<T> allAvailableAttributes(
+            final Function<Relation, T> memberExtractor)
+    {
+        return ChangeEntity.getAttributeAndOptionallyBackup(this.source, this.override,
+                memberExtractor);
     }
 
     private <T extends Object> T attribute(final Function<Relation, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -26,7 +26,6 @@ import org.openstreetmap.atlas.geography.atlas.bloated.BloatedNode;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedPoint;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedRelation;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
-import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBeanItem;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
@@ -58,25 +57,7 @@ public class FeatureChange implements Located, Serializable
     private static final long serialVersionUID = 9172045162819925515L;
     private static final BinaryOperator<Map<String, String>> tagMerger = Maps::withMaps;
     private static final BinaryOperator<Set<Long>> directReferenceMerger = Sets::withSets;
-    private static final BinaryOperator<RelationBean> relationBeanMerger = (leftBean, rightBean) ->
-    {
-        final RelationBean result = new RelationBean();
-        for (final RelationBeanItem leftItem : leftBean)
-        {
-            result.addItem(leftItem);
-        }
-        for (final RelationBeanItem rightItem : rightBean)
-        {
-            if (leftBean.getItemFor(rightItem.getIdentifier(), rightItem.getType()).isPresent())
-            {
-                // Collision, fail
-                throw new CoreException("Unable to merge relation beans. Collision for {} {}",
-                        rightItem.getType(), rightItem.getIdentifier());
-            }
-            result.addItem(rightItem);
-        }
-        return result;
-    };
+    private static final BinaryOperator<RelationBean> relationBeanMerger = RelationBean::merge;
 
     private final ChangeType changeType;
     private final AtlasEntity reference;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicRelation.java
@@ -61,7 +61,7 @@ public class DynamicRelation extends Relation
     }
 
     @Override
-    public long osmRelationIdentifier()
+    public Long osmRelationIdentifier()
     {
         return subRelation().osmRelationIdentifier();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -268,7 +268,7 @@ public abstract class Relation extends AtlasEntity implements Iterable<RelationM
      *
      * @return The OSM identifier
      */
-    public abstract long osmRelationIdentifier();
+    public abstract Long osmRelationIdentifier();
 
     @Override
     public String toDiffViewFriendlyString()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiRelation.java
@@ -164,7 +164,7 @@ public class MultiRelation extends Relation
     }
 
     @Override
-    public long osmRelationIdentifier()
+    public Long osmRelationIdentifier()
     {
         return getSingleSubRelation().osmRelationIdentifier();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedRelation.java
@@ -53,7 +53,7 @@ public class PackedRelation extends Relation
     }
 
     @Override
-    public long osmRelationIdentifier()
+    public Long osmRelationIdentifier()
     {
         return packedAtlas().relationOsmIdentifier(this.index);
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
@@ -27,16 +27,24 @@ public class AtlasValidator
 
     public void validate()
     {
-        logger.debug("Starting validation of ChangeAtlas {}", this.atlas.getName());
+        logger.debug("Starting validation of Atlas {}", this.atlas.getName());
         final Time start = Time.now();
+        logger.debug("Starting relation validation of Atlas {}", this.atlas.getName());
+        final Time startRelations = Time.now();
         validateRelationsPresent();
         validateRelationsLinked();
+        logger.debug("Finished relation validation of Atlas {} in {}", this.atlas.getName(),
+                startRelations.elapsedSince());
+        logger.debug("Starting tags validation of Atlas {}", this.atlas.getName());
+        final Time startTags = Time.now();
         validateTagsPresent();
+        logger.debug("Finished tags validation of Atlas {} in {}", this.atlas.getName(),
+                startTags.elapsedSince());
         new AtlasLocationItemValidator(this.atlas).validate();
         new AtlasLineItemValidator(this.atlas).validate();
         new AtlasEdgeValidator(this.atlas).validate();
         new AtlasNodeValidator(this.atlas).validate();
-        logger.debug("Finished validation of ChangeAtlas {} in {}", this.atlas.getName(),
+        logger.debug("Finished validation of Atlas {} in {}", this.atlas.getName(),
                 start.elapsedSince());
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
@@ -29,14 +29,32 @@ public class AtlasValidator
     {
         logger.debug("Starting validation of ChangeAtlas {}", this.atlas.getName());
         final Time start = Time.now();
-        this.validateRelationsPresent();
-        this.validateTagsPresent();
+        validateRelationsPresent();
+        validateRelationsLinked();
+        validateTagsPresent();
         new AtlasLocationItemValidator(this.atlas).validate();
         new AtlasLineItemValidator(this.atlas).validate();
         new AtlasEdgeValidator(this.atlas).validate();
         new AtlasNodeValidator(this.atlas).validate();
         logger.debug("Finished validation of ChangeAtlas {} in {}", this.atlas.getName(),
                 start.elapsedSince());
+    }
+
+    protected void validateRelationsLinked()
+    {
+        for (final AtlasEntity entity : this.atlas.entities())
+        {
+            for (final Relation relation : entity.relations())
+            {
+                if (!relation.members().asBean()
+                        .getItemFor(entity.getIdentifier(), entity.getType()).isPresent())
+                {
+                    throw new CoreException(
+                            "Entity {} {} lists parent relation {} which does not have it as a member.",
+                            entity.getType(), entity.getIdentifier(), relation.getIdentifier());
+                }
+            }
+        }
     }
 
     protected void validateRelationsPresent()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAreaTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAreaTest.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * @author matthieun
@@ -20,6 +21,34 @@ public class BloatedAreaTest
 {
     @Rule
     public BloatedTestRule rule = new BloatedTestRule();
+
+    @Test
+    public void testBloatedEquals()
+    {
+        final BloatedArea area11 = new BloatedArea(123L, null, null, null);
+        final BloatedArea area12 = new BloatedArea(123L, null, null, null);
+        final BloatedArea area21 = new BloatedArea(123L, Polygon.SILICON_VALLEY, null, null);
+        final BloatedArea area22 = new BloatedArea(123L, Polygon.SILICON_VALLEY, null, null);
+        final BloatedArea area23 = new BloatedArea(123L, Polygon.SILICON_VALLEY_2, null, null);
+        final BloatedArea area31 = new BloatedArea(123L, null, Maps.hashMap("key", "value"), null);
+        final BloatedArea area32 = new BloatedArea(123L, null, Maps.hashMap("key", "value"), null);
+        final BloatedArea area33 = new BloatedArea(123L, null, Maps.hashMap(), null);
+        final BloatedArea area41 = new BloatedArea(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedArea area42 = new BloatedArea(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedArea area43 = new BloatedArea(123L, null, null, Sets.hashSet(1L));
+
+        Assert.assertEquals(area11, area12);
+        Assert.assertEquals(area21, area22);
+        Assert.assertEquals(area31, area32);
+        Assert.assertEquals(area41, area42);
+
+        Assert.assertNotEquals(area11, area21);
+        Assert.assertNotEquals(area11, area31);
+        Assert.assertNotEquals(area11, area41);
+        Assert.assertNotEquals(area21, area23);
+        Assert.assertNotEquals(area31, area33);
+        Assert.assertNotEquals(area41, area43);
+    }
 
     @Test
     public void testFull()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdgeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdgeTest.java
@@ -7,10 +7,12 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * @author matthieun
@@ -19,6 +21,53 @@ public class BloatedEdgeTest
 {
     @Rule
     public BloatedTestRule rule = new BloatedTestRule();
+
+    @Test
+    public void testBloatedEquals()
+    {
+        final BloatedEdge edge11 = new BloatedEdge(123L, null, null, null, null, null);
+        final BloatedEdge edge12 = new BloatedEdge(123L, null, null, null, null, null);
+        final BloatedEdge edge21 = new BloatedEdge(123L, PolyLine.TEST_POLYLINE, null, null, null,
+                null);
+        final BloatedEdge edge22 = new BloatedEdge(123L, PolyLine.TEST_POLYLINE, null, null, null,
+                null);
+        final BloatedEdge edge23 = new BloatedEdge(123L, Polygon.SILICON_VALLEY_2, null, null, null,
+                null);
+        final BloatedEdge edge31 = new BloatedEdge(123L, null, Maps.hashMap("key", "value"), null,
+                null, null);
+        final BloatedEdge edge32 = new BloatedEdge(123L, null, Maps.hashMap("key", "value"), null,
+                null, null);
+        final BloatedEdge edge33 = new BloatedEdge(123L, null, Maps.hashMap(), null, null, null);
+        final BloatedEdge edge41 = new BloatedEdge(123L, null, null, null, null,
+                Sets.hashSet(1L, 2L));
+        final BloatedEdge edge42 = new BloatedEdge(123L, null, null, null, null,
+                Sets.hashSet(1L, 2L));
+        final BloatedEdge edge43 = new BloatedEdge(123L, null, null, null, null, Sets.hashSet(1L));
+        final BloatedEdge edge51 = new BloatedEdge(123L, null, null, 1L, null, null);
+        final BloatedEdge edge52 = new BloatedEdge(123L, null, null, 1L, null, null);
+        final BloatedEdge edge53 = new BloatedEdge(123L, null, null, 2L, null, null);
+        final BloatedEdge edge61 = new BloatedEdge(123L, null, null, null, 1L, null);
+        final BloatedEdge edge62 = new BloatedEdge(123L, null, null, null, 1L, null);
+        final BloatedEdge edge63 = new BloatedEdge(123L, null, null, null, 2L, null);
+
+        Assert.assertEquals(edge11, edge12);
+        Assert.assertEquals(edge21, edge22);
+        Assert.assertEquals(edge31, edge32);
+        Assert.assertEquals(edge41, edge42);
+        Assert.assertEquals(edge51, edge52);
+        Assert.assertEquals(edge61, edge62);
+
+        Assert.assertNotEquals(edge11, edge21);
+        Assert.assertNotEquals(edge11, edge31);
+        Assert.assertNotEquals(edge11, edge41);
+        Assert.assertNotEquals(edge11, edge51);
+        Assert.assertNotEquals(edge11, edge61);
+        Assert.assertNotEquals(edge21, edge23);
+        Assert.assertNotEquals(edge31, edge33);
+        Assert.assertNotEquals(edge41, edge43);
+        Assert.assertNotEquals(edge51, edge53);
+        Assert.assertNotEquals(edge61, edge63);
+    }
 
     @Test
     public void testFull()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLineTest.java
@@ -7,10 +7,12 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * @author matthieun
@@ -19,6 +21,34 @@ public class BloatedLineTest
 {
     @Rule
     public BloatedTestRule rule = new BloatedTestRule();
+
+    @Test
+    public void testBloatedEquals()
+    {
+        final BloatedLine line11 = new BloatedLine(123L, null, null, null);
+        final BloatedLine line12 = new BloatedLine(123L, null, null, null);
+        final BloatedLine line21 = new BloatedLine(123L, PolyLine.TEST_POLYLINE, null, null);
+        final BloatedLine line22 = new BloatedLine(123L, PolyLine.TEST_POLYLINE, null, null);
+        final BloatedLine line23 = new BloatedLine(123L, Polygon.SILICON_VALLEY_2, null, null);
+        final BloatedLine line31 = new BloatedLine(123L, null, Maps.hashMap("key", "value"), null);
+        final BloatedLine line32 = new BloatedLine(123L, null, Maps.hashMap("key", "value"), null);
+        final BloatedLine line33 = new BloatedLine(123L, null, Maps.hashMap(), null);
+        final BloatedLine line41 = new BloatedLine(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedLine line42 = new BloatedLine(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedLine line43 = new BloatedLine(123L, null, null, Sets.hashSet(1L));
+
+        Assert.assertEquals(line11, line12);
+        Assert.assertEquals(line21, line22);
+        Assert.assertEquals(line31, line32);
+        Assert.assertEquals(line41, line42);
+
+        Assert.assertNotEquals(line11, line21);
+        Assert.assertNotEquals(line11, line31);
+        Assert.assertNotEquals(line11, line41);
+        Assert.assertNotEquals(line21, line23);
+        Assert.assertNotEquals(line31, line33);
+        Assert.assertNotEquals(line41, line43);
+    }
 
     @Test
     public void testFull()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNodeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNodeTest.java
@@ -26,6 +26,57 @@ public class BloatedNodeTest
     public BloatedTestRule rule = new BloatedTestRule();
 
     @Test
+    public void testBloatedEquals()
+    {
+        final BloatedNode node11 = new BloatedNode(123L, null, null, null, null, null);
+        final BloatedNode node12 = new BloatedNode(123L, null, null, null, null, null);
+        final BloatedNode node21 = new BloatedNode(123L, Location.COLOSSEUM, null, null, null,
+                null);
+        final BloatedNode node22 = new BloatedNode(123L, Location.COLOSSEUM, null, null, null,
+                null);
+        final BloatedNode node23 = new BloatedNode(123L, Location.EIFFEL_TOWER, null, null, null,
+                null);
+        final BloatedNode node31 = new BloatedNode(123L, null, Maps.hashMap("key", "value"), null,
+                null, null);
+        final BloatedNode node32 = new BloatedNode(123L, null, Maps.hashMap("key", "value"), null,
+                null, null);
+        final BloatedNode node33 = new BloatedNode(123L, null, Maps.hashMap(), null, null, null);
+        final BloatedNode node41 = new BloatedNode(123L, null, null, null, null,
+                Sets.hashSet(1L, 2L));
+        final BloatedNode node42 = new BloatedNode(123L, null, null, null, null,
+                Sets.hashSet(1L, 2L));
+        final BloatedNode node43 = new BloatedNode(123L, null, null, null, null, Sets.hashSet(1L));
+        final BloatedNode node51 = new BloatedNode(123L, null, null, Sets.treeSet(1L, 2L), null,
+                null);
+        final BloatedNode node52 = new BloatedNode(123L, null, null, Sets.treeSet(1L, 2L), null,
+                null);
+        final BloatedNode node53 = new BloatedNode(123L, null, null, Sets.treeSet(1L), null, null);
+        final BloatedNode node61 = new BloatedNode(123L, null, null, null, Sets.treeSet(1L, 2L),
+                null);
+        final BloatedNode node62 = new BloatedNode(123L, null, null, null, Sets.treeSet(1L, 2L),
+                null);
+        final BloatedNode node63 = new BloatedNode(123L, null, null, null, Sets.treeSet(1L), null);
+
+        Assert.assertEquals(node11, node12);
+        Assert.assertEquals(node21, node22);
+        Assert.assertEquals(node31, node32);
+        Assert.assertEquals(node41, node42);
+        Assert.assertEquals(node51, node52);
+        Assert.assertEquals(node61, node62);
+
+        Assert.assertNotEquals(node11, node21);
+        Assert.assertNotEquals(node11, node31);
+        Assert.assertNotEquals(node11, node41);
+        Assert.assertNotEquals(node11, node51);
+        Assert.assertNotEquals(node11, node61);
+        Assert.assertNotEquals(node21, node23);
+        Assert.assertNotEquals(node31, node33);
+        Assert.assertNotEquals(node41, node43);
+        Assert.assertNotEquals(node51, node53);
+        Assert.assertNotEquals(node61, node63);
+    }
+
+    @Test
     public void testFull()
     {
         final Atlas atlas = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPointTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPointTest.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * @author matthieun
@@ -20,6 +21,36 @@ public class BloatedPointTest
 {
     @Rule
     public BloatedTestRule rule = new BloatedTestRule();
+
+    @Test
+    public void testBloatedEquals()
+    {
+        final BloatedPoint point11 = new BloatedPoint(123L, null, null, null);
+        final BloatedPoint point12 = new BloatedPoint(123L, null, null, null);
+        final BloatedPoint point21 = new BloatedPoint(123L, Location.COLOSSEUM, null, null);
+        final BloatedPoint point22 = new BloatedPoint(123L, Location.COLOSSEUM, null, null);
+        final BloatedPoint point23 = new BloatedPoint(123L, Location.EIFFEL_TOWER, null, null);
+        final BloatedPoint point31 = new BloatedPoint(123L, null, Maps.hashMap("key", "value"),
+                null);
+        final BloatedPoint point32 = new BloatedPoint(123L, null, Maps.hashMap("key", "value"),
+                null);
+        final BloatedPoint point33 = new BloatedPoint(123L, null, Maps.hashMap(), null);
+        final BloatedPoint point41 = new BloatedPoint(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedPoint point42 = new BloatedPoint(123L, null, null, Sets.hashSet(1L, 2L));
+        final BloatedPoint point43 = new BloatedPoint(123L, null, null, Sets.hashSet(1L));
+
+        Assert.assertEquals(point11, point12);
+        Assert.assertEquals(point21, point22);
+        Assert.assertEquals(point31, point32);
+        Assert.assertEquals(point41, point42);
+
+        Assert.assertNotEquals(point11, point21);
+        Assert.assertNotEquals(point11, point31);
+        Assert.assertNotEquals(point11, point41);
+        Assert.assertNotEquals(point21, point23);
+        Assert.assertNotEquals(point31, point33);
+        Assert.assertNotEquals(point41, point43);
+    }
 
     @Test
     public void testFull()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelationTest.java
@@ -1,13 +1,20 @@
 package org.openstreetmap.atlas.geography.atlas.bloated;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * @author matthieun
@@ -16,6 +23,89 @@ public class BloatedRelationTest
 {
     @Rule
     public BloatedTestRule rule = new BloatedTestRule();
+
+    @Test
+    public void testBloatedEquals()
+    {
+        final RelationBean members1 = new RelationBean();
+        members1.addItem(456L, "myRole", ItemType.AREA);
+        final RelationBean members2 = new RelationBean();
+        members2.addItem(789L, "myRole", ItemType.AREA);
+
+        final List<Long> allRelationsWithSameOsmIdentifier1 = new ArrayList<>();
+        allRelationsWithSameOsmIdentifier1.add(456L);
+        final List<Long> allRelationsWithSameOsmIdentifier2 = new ArrayList<>();
+        allRelationsWithSameOsmIdentifier2.add(789L);
+
+        final BloatedRelation relation11 = new BloatedRelation(123L, null, null, null, null, null,
+                null, null);
+        final BloatedRelation relation12 = new BloatedRelation(123L, null, null, null, null, null,
+                null, null);
+        final BloatedRelation relation21 = new BloatedRelation(123L, null,
+                Polygon.SILICON_VALLEY.bounds(), null, null, null, null, null);
+        final BloatedRelation relation22 = new BloatedRelation(123L, null,
+                Polygon.SILICON_VALLEY.bounds(), null, null, null, null, null);
+        final BloatedRelation relation23 = new BloatedRelation(123L, null,
+                Polygon.SILICON_VALLEY_2.bounds(), null, null, null, null, null);
+        final BloatedRelation relation31 = new BloatedRelation(123L, Maps.hashMap("key", "value"),
+                null, null, null, null, null, null);
+        final BloatedRelation relation32 = new BloatedRelation(123L, Maps.hashMap("key", "value"),
+                null, null, null, null, null, null);
+        final BloatedRelation relation33 = new BloatedRelation(123L, Maps.hashMap(), null, null,
+                null, null, null, null);
+        final BloatedRelation relation41 = new BloatedRelation(123L, null, null, null, null, null,
+                null, Sets.hashSet(1L, 2L));
+        final BloatedRelation relation42 = new BloatedRelation(123L, null, null, null, null, null,
+                null, Sets.hashSet(1L, 2L));
+        final BloatedRelation relation43 = new BloatedRelation(123L, null, null, null, null, null,
+                null, Sets.hashSet(1L));
+        final BloatedRelation relation51 = new BloatedRelation(123L, null, null, members1, null,
+                null, null, null);
+        final BloatedRelation relation52 = new BloatedRelation(123L, null, null, members1, null,
+                null, null, null);
+        final BloatedRelation relation53 = new BloatedRelation(123L, null, null, members2, null,
+                null, null, null);
+        final BloatedRelation relation61 = new BloatedRelation(123L, null, null, null,
+                allRelationsWithSameOsmIdentifier1, null, null, null);
+        final BloatedRelation relation62 = new BloatedRelation(123L, null, null, null,
+                allRelationsWithSameOsmIdentifier1, null, null, null);
+        final BloatedRelation relation63 = new BloatedRelation(123L, null, null, null,
+                allRelationsWithSameOsmIdentifier2, null, null, null);
+        final BloatedRelation relation71 = new BloatedRelation(123L, null, null, null, null,
+                members1, null, null);
+        final BloatedRelation relation72 = new BloatedRelation(123L, null, null, null, null,
+                members1, null, null);
+        final BloatedRelation relation73 = new BloatedRelation(123L, null, null, null, null,
+                members2, null, null);
+        final BloatedRelation relation81 = new BloatedRelation(123L, null, null, null, null, null,
+                456L, null);
+        final BloatedRelation relation82 = new BloatedRelation(123L, null, null, null, null, null,
+                456L, null);
+        final BloatedRelation relation83 = new BloatedRelation(123L, null, null, null, null, null,
+                789L, null);
+
+        Assert.assertEquals(relation11, relation12);
+        Assert.assertEquals(relation21, relation22);
+        Assert.assertEquals(relation31, relation32);
+        Assert.assertEquals(relation41, relation42);
+        Assert.assertEquals(relation51, relation52);
+        Assert.assertEquals(relation61, relation62);
+        Assert.assertEquals(relation71, relation72);
+        Assert.assertEquals(relation81, relation82);
+
+        // Here bounds are considered a derivation of the rest, and thus do not trigger an un-equal.
+        Assert.assertEquals(relation11, relation21);
+        Assert.assertNotEquals(relation11, relation31);
+        Assert.assertNotEquals(relation11, relation41);
+        // Here bounds are considered a derivation of the rest, and thus do not trigger an un-equal.
+        Assert.assertEquals(relation21, relation23);
+        Assert.assertNotEquals(relation31, relation33);
+        Assert.assertNotEquals(relation41, relation43);
+        Assert.assertNotEquals(relation51, relation53);
+        Assert.assertNotEquals(relation61, relation63);
+        Assert.assertNotEquals(relation71, relation73);
+        Assert.assertNotEquals(relation81, relation83);
+    }
 
     @Test
     public void testFull()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorAddTurnRestrictions.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorAddTurnRestrictions.java
@@ -1,0 +1,116 @@
+package org.openstreetmap.atlas.geography.atlas.change;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.bloated.BloatedEdge;
+import org.openstreetmap.atlas.geography.atlas.bloated.BloatedNode;
+import org.openstreetmap.atlas.geography.atlas.bloated.BloatedRelation;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
+
+import com.google.common.collect.Lists;
+
+/**
+ * @author matthieun
+ */
+public class AtlasChangeGeneratorAddTurnRestrictions implements AtlasChangeGenerator
+{
+    @Override
+    public Set<FeatureChange> generateWithoutValidation(final Atlas atlas)
+    {
+        final AtomicLong identifierGenerator = new AtomicLong();
+        final Set<FeatureChange> result = new HashSet<>();
+        final Long parentRelationIdentifier = identifierGenerator.incrementAndGet();
+        final RelationBean parentMembers = new RelationBean();
+        Rectangle parentBounds = null;
+        for (final Node node : atlas.nodes(node -> node.valence() > 3))
+        {
+            final SortedSet<Edge> inEdges = node.inEdges();
+            final SortedSet<Edge> outEdges = node.outEdges();
+            for (final Edge inEdge : inEdges)
+            {
+                for (final Edge outEdge : outEdges)
+                {
+                    final RelationBean members = new RelationBean();
+                    members.addItem(inEdge.getIdentifier(), "from", ItemType.EDGE);
+                    inEdge.reversed().ifPresent(reversed -> members
+                            .addItem(reversed.getIdentifier(), "from", ItemType.EDGE));
+                    members.addItem(node.getIdentifier(), "via", ItemType.NODE);
+                    members.addItem(outEdge.getIdentifier(), "to", ItemType.EDGE);
+                    outEdge.reversed().ifPresent(reversed -> members
+                            .addItem(reversed.getIdentifier(), "to", ItemType.EDGE));
+                    final Long relationIdentifier = identifierGenerator.incrementAndGet();
+                    final Rectangle bounds = Rectangle.forLocated(inEdge, outEdge);
+                    if (parentBounds == null)
+                    {
+                        parentBounds = bounds;
+                    }
+                    else
+                    {
+                        parentBounds = Rectangle.forLocated(parentBounds, bounds);
+                    }
+                    parentMembers.addItem(relationIdentifier, "addition", ItemType.RELATION);
+                    result.add(FeatureChange.add(new BloatedRelation(relationIdentifier,
+                            Maps.hashMap("type", "restriction", "restriction", "no_left_turn"),
+                            bounds, members, Lists.newArrayList(relationIdentifier), members,
+                            relationIdentifier, Sets.hashSet(parentRelationIdentifier))));
+                    result.add(FeatureChange
+                            .add(BloatedEdge.shallowFrom(inEdge).withRelationIdentifiers(
+                                    mergeRelationMembers(inEdge.relations(), relationIdentifier))));
+                    if (inEdge.hasReverseEdge())
+                    {
+                        result.add(
+                                FeatureChange.add(BloatedEdge.shallowFrom(inEdge.reversed().get())
+                                        .withRelationIdentifiers(mergeRelationMembers(
+                                                inEdge.relations(), relationIdentifier))));
+                    }
+                    result.add(
+                            FeatureChange.add(BloatedNode.shallowFrom(node).withRelationIdentifiers(
+                                    mergeRelationMembers(node.relations(), relationIdentifier))));
+                    result.add(FeatureChange.add(BloatedEdge.shallowFrom(outEdge)
+                            .withRelationIdentifiers(mergeRelationMembers(outEdge.relations(),
+                                    relationIdentifier))));
+                    if (outEdge.hasReverseEdge())
+                    {
+                        result.add(
+                                FeatureChange.add(BloatedEdge.shallowFrom(outEdge.reversed().get())
+                                        .withRelationIdentifiers(mergeRelationMembers(
+                                                outEdge.relations(), relationIdentifier))));
+                    }
+                    // Break here to avoid too many Relation FeatureChanges and make validation
+                    // super slow for unit tests.
+                    break;
+                }
+                // Break here to avoid too many Relation FeatureChanges and make validation super
+                // slow for unit tests.
+                break;
+            }
+        }
+        if (!result.isEmpty())
+        {
+            result.add(FeatureChange.add(new BloatedRelation(parentRelationIdentifier,
+                    Maps.hashMap("name", "parent_of_new_restrictions"), parentBounds, parentMembers,
+                    Lists.newArrayList(parentRelationIdentifier), parentMembers,
+                    parentRelationIdentifier, Sets.hashSet())));
+        }
+        return result;
+    }
+
+    private Set<Long> mergeRelationMembers(final Set<Relation> relations, final Long newIdentifier)
+    {
+        return Sets.withSets(
+                relations.stream().map(Relation::getIdentifier).collect(Collectors.toSet()),
+                Sets.hashSet(newIdentifier));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
@@ -65,11 +65,6 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                         .withInEdgeIdentifierReplaced(oldEdgeIdentifier, newEdgeIdentifier)));
             }
         }
-        final ChangeBuilder builder = new ChangeBuilder();
-        result.forEach(builder::add);
-        final Change change = builder.get();
-        final ChangeAtlas changeAtlas = new ChangeAtlas(atlas, change);
-        System.out.println(changeAtlas.relation(2981334000000L));
         return result;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedEdge;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedNode;
+import org.openstreetmap.atlas.geography.atlas.bloated.BloatedRelation;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.tags.JunctionTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
@@ -41,6 +42,11 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                 final BloatedEdge secondEdge = BloatedEdge.from(edge)
                         .withIdentifier(newEdgeIdentifier).withPolyLine(shape2)
                         .withStartNodeIdentifier(middleNodeIdentifier);
+                // Update relations of edge to also list second edge that has a new ID here.
+                edge.relations().stream()
+                        .map(relation -> BloatedRelation.shallowFrom(relation)
+                                .withMembers(relation.members()).withExtraMember(secondEdge, edge))
+                        .map(FeatureChange::add).forEach(result::add);
 
                 // Add the two new edges. First one has same ID as old edge and replaces it.
                 result.add(FeatureChange.add(firstEdge));
@@ -56,6 +62,10 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                         .withInEdgeIdentifierReplaced(oldEdgeIdentifier, newEdgeIdentifier)));
             }
         }
+        final ChangeBuilder builder = new ChangeBuilder();
+        result.forEach(builder::add);
+        final ChangeAtlas changeAtlas = new ChangeAtlas(atlas, builder.get());
+        System.out.println(changeAtlas.relation(2981334000000L));
         return result;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
@@ -46,7 +46,10 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                 edge.relations().stream()
                         .map(relation -> BloatedRelation.shallowFrom(relation)
                                 .withMembers(relation.members()).withExtraMember(secondEdge, edge))
-                        .map(FeatureChange::add).forEach(result::add);
+                        .map(FeatureChange::add).forEach(featureChange ->
+                        {
+                            result.add(featureChange);
+                        });
 
                 // Add the two new edges. First one has same ID as old edge and replaces it.
                 result.add(FeatureChange.add(firstEdge));
@@ -64,7 +67,8 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
         }
         final ChangeBuilder builder = new ChangeBuilder();
         result.forEach(builder::add);
-        final ChangeAtlas changeAtlas = new ChangeAtlas(atlas, builder.get());
+        final Change change = builder.get();
+        final ChangeAtlas changeAtlas = new ChangeAtlas(atlas, change);
         System.out.println(changeAtlas.relation(2981334000000L));
         return result;
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -81,17 +81,23 @@ public class ChangeAtlasTest
         final Relation disconnectedFeatures = atlas.relation(41834000000L);
         final Map<String, String> tags = disconnectedFeatures.getTags();
         tags.put("newKey", "newValue");
-        changeBuilder.add(new FeatureChange(ChangeType.ADD,
-                BloatedRelation.shallowFrom(disconnectedFeatures).withTags(tags)));
+        changeBuilder.add(FeatureChange
+                .add(BloatedRelation.shallowFrom(disconnectedFeatures).withTags(tags)));
         final Change change = changeBuilder.get();
 
         final Atlas changeAtlas = new ChangeAtlas(atlas, change);
-        Assert.assertEquals(tags, changeAtlas.relation(41834000000L).getTags());
+        final Relation changeRelation = changeAtlas.relation(41834000000L);
+        Assert.assertEquals(tags, changeRelation.getTags());
+        Assert.assertEquals(disconnectedFeatures.members().asBean(),
+                changeRelation.members().asBean());
 
         final Relation parentRelation = changeAtlas.relation(41860000000L);
-        final Relation fromRelation = (Relation) Iterables.stream(parentRelation.members())
+        final Relation changeRelationFromParentRelation = (Relation) Iterables
+                .stream(parentRelation.members())
                 .firstMatching(member -> "child1".equals(member.getRole())).get().getEntity();
-        Assert.assertEquals(tags, fromRelation.getTags());
+        Assert.assertEquals(tags, changeRelationFromParentRelation.getTags());
+        Assert.assertEquals(disconnectedFeatures.members().asBean(),
+                changeRelationFromParentRelation.members().asBean());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
@@ -198,9 +198,8 @@ public class FeatureChangeTest
     @Test
     public void testMergeRelationMembersRoleCollision()
     {
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-
+        // OSM allows (but discourages) the same feature to appear multiple times with the same or
+        // different roles.
         final RelationBean members1 = new RelationBean();
         members1.addItem(new RelationBeanItem(456L, "myRole1", ItemType.AREA));
         final RelationBean members2 = new RelationBean();
@@ -212,7 +211,8 @@ public class FeatureChangeTest
                 123L, null, Rectangle.TEST_RECTANGLE, members1, null, null, null, null));
         final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, new BloatedRelation(
                 123L, null, Rectangle.TEST_RECTANGLE, members2, null, null, null, null));
-        featureChange1.merge(featureChange2);
+        Assert.assertEquals(result, ((Relation) featureChange1.merge(featureChange2).getReference())
+                .members().asBean());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -12,6 +13,7 @@ import org.openstreetmap.atlas.geography.atlas.bloated.BloatedEdge;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedNode;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.tags.JunctionTag;
@@ -31,7 +33,7 @@ public class MultipleChangeAtlasTest
     private Atlas atlas;
     private Atlas subAtlas;
     private ChangeAtlas changeAtlas;
-    private final String saveLocally = null;
+    private final String saveLocally = "/Users/matthieun/Desktop/test";
 
     @Test
     public void allEdgesAreStraight()
@@ -103,6 +105,11 @@ public class MultipleChangeAtlasTest
         resetAndChange("splitRoundaboutEdges", new AtlasChangeGeneratorSplitRoundabout());
         Assert.assertEquals(6, Iterables.size(this.atlas.edges(JunctionTag::isRoundabout)));
         Assert.assertEquals(12, Iterables.size(this.changeAtlas.edges(JunctionTag::isRoundabout)));
+        Assert.assertEquals(
+                this.atlas.edge(221434104000005L).relations().stream().map(Relation::getIdentifier)
+                        .collect(Collectors.toSet()),
+                this.changeAtlas.edge(10L).relations().stream().map(Relation::getIdentifier)
+                        .collect(Collectors.toSet()));
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
@@ -11,7 +11,9 @@ import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedEdge;
 import org.openstreetmap.atlas.geography.atlas.bloated.BloatedNode;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
@@ -34,6 +36,21 @@ public class MultipleChangeAtlasTest
     private Atlas subAtlas;
     private ChangeAtlas changeAtlas;
     private final String saveLocally = null;
+
+    @Test
+    public void addTurnRestrictions()
+    {
+        resetAndChange("addTurnRestrictions", new AtlasChangeGeneratorAddTurnRestrictions());
+        final Node via = this.changeAtlas.node(3985226613000000L);
+        final Relation restriction = via.relations().iterator().next();
+        Assert.assertNotNull(restriction);
+        final RelationBean members = new RelationBean();
+        members.addItem(221434099000002L, "from", ItemType.EDGE);
+        members.addItem(via.getIdentifier(), "via", ItemType.NODE);
+        members.addItem(634444999000000L, "to", ItemType.EDGE);
+        members.addItem(-634444999000000L, "to", ItemType.EDGE);
+        Assert.assertEquals(members, restriction.members().asBean());
+    }
 
     @Test
     public void allEdgesAreStraight()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
@@ -33,7 +33,7 @@ public class MultipleChangeAtlasTest
     private Atlas atlas;
     private Atlas subAtlas;
     private ChangeAtlas changeAtlas;
-    private final String saveLocally = "/Users/matthieun/Desktop/test";
+    private final String saveLocally = null;
 
     @Test
     public void allEdgesAreStraight()


### PR DESCRIPTION
### Description:

- Validation checks that "claimed" parent relations, when they exist, also claim the feature as a member. (Reciprocity)
- Relation members are now filtered in case one of the declared members does not exist
- Relation bean merging is generalized, and is used:
  - When merging two `FeatureChange` items of the same relation
  - When `ChangeAtlas` has a source and an override relation member list to merge
- BloatedEntities now all declare their specific equals method, that checks all the members, null or not.

### Potential Impact:

N/A

### Unit Test Approach:

Unit tests have been amended

### Test Results:

All unit tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
