### PR TITLE
Expanding Atlas area definition, removing irrelevant test

### DIFF
--- a/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
+++ b/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
@@ -1,6 +1,6 @@
 {
     "filters": [
-        "highway->!|highway->platform",
+        "highway->!|highway->platform,bus_stop",
         "railway->!|railway->platform,traverser,station",
         "route->!ferry",
         "man_made->!pier"

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -65,33 +65,6 @@ public class WaySectionProcessorTest
     }
 
     @Test
-    public void testBuildingAtlasWithNestedRelationRemoval()
-    {
-        // Parent Relation https://www.openstreetmap.org/relation/2446626 contains Relation
-        // https://www.openstreetmap.org/relation/2448165, which in turn contains Way
-        // https://www.openstreetmap.org/way/183853720. The Way does not make it into the Atlas, so
-        // the sub-relation becomes empty, leading it to be dropped. This test verifies that the
-        // drop happens, but that the parent Relation is still correctly built, without the dropped
-        // sub-relation as a member.
-        final Atlas slicedRawAtlas = this.setup.getNestedRelationRemovalAtlas();
-        final CountryBoundaryMap boundaryMap = CountryBoundaryMap
-                .fromPlainText(new InputStreamResource(() -> WaySectionProcessorTest.class
-                        .getResourceAsStream("nestedRelationRemovalBoundaryMap.txt")));
-        final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
-                AtlasLoadingOption.createOptionWithAllEnabled(boundaryMap)).run();
-
-        // Validate presence of a top-most relation with no sub-relation
-        Assert.assertEquals("Assert presence of a single relation", 1,
-                finalAtlas.numberOfRelations());
-        final RelationMemberList memberList = finalAtlas.relation(2446626000000L).members();
-        Assert.assertEquals("Final relation should have one member", 1, memberList.size());
-        Assert.assertEquals("The member should be an Edge", ItemType.EDGE,
-                memberList.get(0).getEntity().getType());
-        Assert.assertNull("Explicitly check for absence of sub-relation",
-                finalAtlas.relation(2448165000000L));
-    }
-
-    @Test
     public void testCutAtShardBoundary()
     {
         final Atlas slicedRawAtlas = this.setup.getRawAtlasSpanningOutsideBoundary();


### PR DESCRIPTION
### Description:

Expanding `Atlas Area` definition to handle bus stop polygons. Previously, these ways would not be in the Atlas, since they didn't fit any of the `Area`, `Edge` or `Line` definitions. Here is a sample [way](https://www.openstreetmap.org/way/183853720). I'm removing a test that used this way to assert nested relations were removed - this is no longer needed since nothing should be removed.

### Potential Impact:

More Atlas Areas available for consumption for anyone who relies on the default area configuration file.

### Unit Test Approach:

N/A - all unit tests pass. The unit test that was removed showed the Area being added to the Atlas correctly.

### Test Results:

All integration tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
