### PR TITLE
[Change] Keep track of explicitly removed relation members

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
@@ -293,6 +293,40 @@ public class BloatedRelation extends Relation implements BloatedEntity
         return withMembers(source, members.asBean(), members.bounds());
     }
 
+    /**
+     * Assign this {@link BloatedRelation} with members.
+     * <p>
+     * In case this {@link BloatedRelation} is created from an existing relation, and the new member
+     * list has had some existing members removed, use
+     * {@link #withMembers(Optional, RelationBean, Rectangle)}
+     *
+     * @param members
+     *            The members of the relation
+     * @param bounds
+     *            The bounds of all the members of the relation.
+     * @return This
+     */
+    public BloatedRelation withMembers(final RelationBean members, final Rectangle bounds)
+    {
+        return withMembers(Optional.empty(), members, bounds);
+    }
+
+    /**
+     * Assign this {@link BloatedRelation} with members.
+     * <p>
+     * In case this {@link BloatedRelation} is created from an existing relation, and the new member
+     * list has had some existing members removed, use
+     * {@link #withMembers(Optional, RelationMemberList)}
+     * 
+     * @param members
+     *            The full members of the Relation
+     * @return This
+     */
+    public BloatedRelation withMembers(final RelationMemberList members)
+    {
+        return withMembers(Optional.empty(), members);
+    }
+
     public BloatedRelation withOsmRelationIdentifier(final Long osmRelationIdentifier)
     {
         this.osmRelationIdentifier = osmRelationIdentifier;

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelationTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.bloated;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -134,9 +135,9 @@ public class BloatedRelationTest
         final BloatedRelation result = BloatedRelation.shallowFrom(source);
         Assert.assertEquals(source.getIdentifier(), result.getIdentifier());
         Assert.assertEquals(source.bounds(), result.bounds());
-        result.withMembers(new RelationMemberList(source.members()));
+        result.withMembers(Optional.of(source), new RelationMemberList(source.members()));
         Assert.assertEquals(source.members().asBean(), result.members().asBean());
-        result.withMembers(source.members().asBean(), source.bounds());
+        result.withMembers(Optional.of(source), source.members().asBean(), source.bounds());
         Assert.assertEquals(source.bounds(), result.bounds());
         Assert.assertEquals(source.members().asBean(), result.members().asBean());
         result.withAllKnownOsmMembers(source.allKnownOsmMembers().asBean());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -325,8 +326,9 @@ public class ChangeAtlasTest
         final RelationMemberList newMembers = new RelationMemberList(disconnectedFeatures.members()
                 .stream().filter(member -> !(member.getEntity() instanceof Point))
                 .collect(Collectors.toList()));
-        changeBuilder.add(new FeatureChange(ChangeType.ADD,
-                BloatedRelation.shallowFrom(disconnectedFeatures).withMembers(newMembers)));
+        changeBuilder.add(
+                new FeatureChange(ChangeType.ADD, BloatedRelation.shallowFrom(disconnectedFeatures)
+                        .withMembers(Optional.of(disconnectedFeatures), newMembers)));
         changeBuilder.add(new FeatureChange(ChangeType.REMOVE,
                 BloatedPoint.shallowFrom(atlas.point(41822000000L))));
         final Change change = changeBuilder.get();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
@@ -122,11 +122,22 @@ public class MultipleChangeAtlasTest
         resetAndChange("splitRoundaboutEdges", new AtlasChangeGeneratorSplitRoundabout());
         Assert.assertEquals(6, Iterables.size(this.atlas.edges(JunctionTag::isRoundabout)));
         Assert.assertEquals(12, Iterables.size(this.changeAtlas.edges(JunctionTag::isRoundabout)));
-        Assert.assertEquals(
-                this.atlas.edge(221434104000005L).relations().stream().map(Relation::getIdentifier)
-                        .collect(Collectors.toSet()),
-                this.changeAtlas.edge(10L).relations().stream().map(Relation::getIdentifier)
-                        .collect(Collectors.toSet()));
+        final Set<Long> extectedParentRelations = this.atlas.edge(221434104000005L).relations()
+                .stream().map(Relation::getIdentifier).collect(Collectors.toSet());
+        Assert.assertEquals(extectedParentRelations, this.changeAtlas.edge(14L).relations().stream()
+                .map(Relation::getIdentifier).collect(Collectors.toSet()));
+        Assert.assertEquals(extectedParentRelations, this.changeAtlas.edge(15L).relations().stream()
+                .map(Relation::getIdentifier).collect(Collectors.toSet()));
+        Assert.assertTrue(this.changeAtlas.relation(3001321000000L).members().asBean()
+                .getItemFor(14L, ItemType.EDGE).isPresent());
+        Assert.assertTrue(this.changeAtlas.relation(3001321000000L).members().asBean()
+                .getItemFor(15L, ItemType.EDGE).isPresent());
+        Assert.assertTrue(this.atlas.relation(3001321000000L).members().asBean()
+                .getItemFor(221434104000005L, ItemType.EDGE).isPresent());
+        // Make sure the removed edge was not added back by a mishap in the relation bean merging
+        // somewhere
+        Assert.assertFalse(this.changeAtlas.relation(3001321000000L).members().asBean()
+                .getItemFor(221434104000005L, ItemType.EDGE).isPresent());
     }
 
     /**


### PR DESCRIPTION
### Description:

This fixes a bug where a relation member that was intentionally removed would be added back when merging relation beans.

### Potential Impact:

N/A

### Unit Test Approach:

Altered unit tests.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
