### PR TITLE
[Change] Fixed issue where excluded members were wiped in RelationMemberList

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedRelation.java
@@ -317,7 +317,7 @@ public class BloatedRelation extends Relation implements BloatedEntity
      * In case this {@link BloatedRelation} is created from an existing relation, and the new member
      * list has had some existing members removed, use
      * {@link #withMembers(Optional, RelationMemberList)}
-     * 
+     *
      * @param members
      *            The full members of the Relation
      * @return This
@@ -373,7 +373,9 @@ public class BloatedRelation extends Relation implements BloatedEntity
             memberList.add(new RelationMember(item.getRole(),
                     getAtlas().entity(item.getIdentifier(), item.getType()), getIdentifier()));
         }
-        return new RelationMemberList(memberList);
+        final RelationMemberList result = new RelationMemberList(memberList);
+        bean.getExplicitlyExcluded().forEach(result::addItemExplicitlyExcluded);
+        return result;
     }
 
     private void updateBounds(final Rectangle bounds)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -137,6 +137,11 @@ public class RelationBean implements Serializable, Iterable<RelationBeanItem>
         return false;
     }
 
+    public Set<RelationBeanItem> getExplicitlyExcluded()
+    {
+        return this.explicitlyExcluded;
+    }
+
     public Optional<RelationBeanItem> getItemFor(final long identifier, final ItemType type)
     {
         for (int index = 0; index < this.memberIdentifiers.size(); index++)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/RelationMemberList.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/RelationMemberList.java
@@ -2,13 +2,16 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.AbstractCollection;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBeanItem;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 
 /**
@@ -17,6 +20,7 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
 public class RelationMemberList extends AbstractCollection<RelationMember> implements Located
 {
     private final List<RelationMember> members;
+    private final Set<RelationBeanItem> explicitlyExcluded;
 
     public RelationMemberList(final Iterable<RelationMember> members)
     {
@@ -29,6 +33,12 @@ public class RelationMemberList extends AbstractCollection<RelationMember> imple
             this.members = new ArrayList<>();
             members.forEach(member -> this.members.add(member));
         }
+        this.explicitlyExcluded = new HashSet<>();
+    }
+
+    public void addItemExplicitlyExcluded(final RelationBeanItem item)
+    {
+        this.explicitlyExcluded.add(item);
     }
 
     public RelationBean asBean()
@@ -39,6 +49,7 @@ public class RelationMemberList extends AbstractCollection<RelationMember> imple
             result.addItem(member.getEntity().getIdentifier(), member.getRole(),
                     member.getEntity().getType());
         }
+        this.explicitlyExcluded.forEach(result::addItemExplicitlyExcluded);
         return result;
     }
 


### PR DESCRIPTION
### Description:

RelationMemberList was not forwarding the excluded members to RelationBean in the `asBean()` method.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
