### PR TITLE
Add validation for edge-node reciprocity

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedArea.java
@@ -137,6 +137,11 @@ public class BloatedArea extends Area implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedArea withAddedTag(final String key, final String value)
+    {
+        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+    }
+
     public BloatedArea withAggregateBoundsExtendedUsing(final Rectangle bounds)
     {
         if (this.aggregateBounds == null)
@@ -170,9 +175,11 @@ public class BloatedArea extends Area implements BloatedEntity
         return this;
     }
 
-    public BloatedArea withAddedTag(final String key, final String value)
+    public BloatedArea withRelations(final Set<Relation> relations)
     {
-        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+        this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
     }
 
     public BloatedArea withRemovedTag(final String key)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedEdge.java
@@ -162,6 +162,11 @@ public class BloatedEdge extends Edge implements BloatedEntity
                 + this.relationIdentifiers + "]";
     }
 
+    public BloatedEdge withAddedTag(final String key, final String value)
+    {
+        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+    }
+
     public BloatedEdge withAggregateBoundsExtendedUsing(final Rectangle bounds)
     {
         if (this.aggregateBounds == null)
@@ -201,15 +206,11 @@ public class BloatedEdge extends Edge implements BloatedEntity
         return this;
     }
 
-    public BloatedEdge withStartNodeIdentifier(final Long startNodeIdentifier)
+    public BloatedEdge withRelations(final Set<Relation> relations)
     {
-        this.startNodeIdentifier = startNodeIdentifier;
+        this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
         return this;
-    }
-
-    public BloatedEdge withAddedTag(final String key, final String value)
-    {
-        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
     }
 
     public BloatedEdge withRemovedTag(final String key)
@@ -221,6 +222,12 @@ public class BloatedEdge extends Edge implements BloatedEntity
             final String newValue)
     {
         return withRemovedTag(oldKey).withAddedTag(newKey, newValue);
+    }
+
+    public BloatedEdge withStartNodeIdentifier(final Long startNodeIdentifier)
+    {
+        this.startNodeIdentifier = startNodeIdentifier;
+        return this;
     }
 
     public BloatedEdge withTags(final Map<String, String> tags)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedLine.java
@@ -137,6 +137,11 @@ public class BloatedLine extends Line implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedLine withAddedTag(final String key, final String value)
+    {
+        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+    }
+
     public BloatedLine withAggregateBoundsExtendedUsing(final Rectangle bounds)
     {
         if (this.aggregateBounds == null)
@@ -170,9 +175,11 @@ public class BloatedLine extends Line implements BloatedEntity
         return this;
     }
 
-    public BloatedLine withAddedTag(final String key, final String value)
+    public BloatedLine withRelations(final Set<Relation> relations)
     {
-        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+        this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
     }
 
     public BloatedLine withRemovedTag(final String key)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedNode.java
@@ -186,6 +186,11 @@ public class BloatedNode extends Node implements BloatedEntity
                 + this.relationIdentifiers + "]";
     }
 
+    public BloatedNode withAddedTag(final String key, final String value)
+    {
+        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+    }
+
     public BloatedNode withAggregateBoundsExtendedUsing(final Rectangle bounds)
     {
         if (this.aggregateBounds == null)
@@ -227,6 +232,13 @@ public class BloatedNode extends Node implements BloatedEntity
         return this;
     }
 
+    public BloatedNode withInEdges(final Set<Edge> inEdges)
+    {
+        this.inEdgeIdentifiers = inEdges.stream().map(Edge::getIdentifier)
+                .collect(Collectors.toCollection(TreeSet::new));
+        return this;
+    }
+
     public BloatedNode withLocation(final Location location)
     {
         this.location = location;
@@ -263,15 +275,24 @@ public class BloatedNode extends Node implements BloatedEntity
         return this;
     }
 
+    public BloatedNode withOutEdges(final Set<Edge> outEdges)
+    {
+        this.outEdgeIdentifiers = outEdges.stream().map(Edge::getIdentifier)
+                .collect(Collectors.toCollection(TreeSet::new));
+        return this;
+    }
+
     public BloatedNode withRelationIdentifiers(final Set<Long> relationIdentifiers)
     {
         this.relationIdentifiers = relationIdentifiers;
         return this;
     }
 
-    public BloatedNode withAddedTag(final String key, final String value)
+    public BloatedNode withRelations(final Set<Relation> relations)
     {
-        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+        this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
     }
 
     public BloatedNode withRemovedTag(final String key)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedPoint.java
@@ -138,6 +138,11 @@ public class BloatedPoint extends Point implements BloatedEntity
                 + ", tags=" + this.tags + ", relationIdentifiers=" + this.relationIdentifiers + "]";
     }
 
+    public BloatedPoint withAddedTag(final String key, final String value)
+    {
+        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+    }
+
     public BloatedPoint withAggregateBoundsExtendedUsing(final Rectangle bounds)
     {
         if (this.aggregateBounds == null)
@@ -171,9 +176,11 @@ public class BloatedPoint extends Point implements BloatedEntity
         return this;
     }
 
-    public BloatedPoint withAddedTag(final String key, final String value)
+    public BloatedPoint withRelations(final Set<Relation> relations)
     {
-        return withTags(BloatedEntity.addNewTag(getTags(), key, value));
+        this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
     }
 
     public BloatedPoint withRemovedTag(final String key)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -137,8 +137,9 @@ public class Change implements Located, Serializable
         {
             final int existingIndex = this.identifierToIndex.get(key);
             final FeatureChange existing = this.featureChanges.get(existingIndex);
-            logger.trace("Change already has a {}. Adding {} triggered a merge attempt!", existing,
-                    featureChange);
+            logger.trace(
+                    "Change already has a similar feature change. Triggered a merge attempt! Existing: {}; New: {}",
+                    existing, featureChange);
             chosen = existing.merge(featureChange);
             this.featureChanges.set(existingIndex, chosen);
         }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -251,13 +251,21 @@ public class FeatureChange implements Located, Serializable
             else if (memberMergerOption.isPresent())
             {
                 // They are unequal, but we can attempt a merge
-                result = memberMergerOption.get().apply(leftMember, rightMember);
+                try
+                {
+                    result = memberMergerOption.get().apply(leftMember, rightMember);
+                }
+                catch (final CoreException e)
+                {
+                    throw new CoreException("Attempted merge failed for {}: {} and {}", memberName,
+                            leftMember, rightMember, e);
+                }
             }
             else
             {
                 // They are unequal and we do not have a tool to merge them.
-                throw new CoreException("Conflicting {}: {} and {}", memberName, leftMember,
-                        rightMember);
+                throw new CoreException("Conflicting members, no merge option for {}: {} and {}",
+                        memberName, leftMember, rightMember);
             }
         }
         else

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasEdgeValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasEdgeValidator.java
@@ -5,6 +5,7 @@ import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,17 +39,31 @@ public class AtlasEdgeValidator
     {
         for (final Edge edge : this.atlas.edges())
         {
-            if (edge.start() == null)
+            final Node start = edge.start();
+            if (start == null)
             {
                 throw new CoreException(
                         "Edge {} is logically disconnected at its start. Referenced Node does not exist.",
                         edge.getIdentifier());
             }
-            if (edge.end() == null)
+            if (start.outEdges().stream()
+                    .noneMatch(edgeAtNode -> edgeAtNode.getIdentifier() == edge.getIdentifier()))
+            {
+                throw new CoreException("Edge {} references start Node {}. It is not reciprocal.",
+                        edge.getIdentifier(), start.getIdentifier());
+            }
+            final Node end = edge.end();
+            if (end == null)
             {
                 throw new CoreException(
                         "Edge {} is logically disconnected at its end. Referenced Node does not exist.",
                         edge.getIdentifier());
+            }
+            if (end.inEdges().stream()
+                    .noneMatch(edgeAtNode -> edgeAtNode.getIdentifier() == edge.getIdentifier()))
+            {
+                throw new CoreException("Edge {} references end Node {}. It is not reciprocal.",
+                        edge.getIdentifier(), end.getIdentifier());
             }
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
@@ -27,24 +27,24 @@ public class AtlasValidator
 
     public void validate()
     {
-        logger.debug("Starting validation of Atlas {}", this.atlas.getName());
+        logger.info("Starting validation of Atlas {}", this.atlas.getName());
         final Time start = Time.now();
-        logger.debug("Starting relation validation of Atlas {}", this.atlas.getName());
+        logger.trace("Starting relation validation of Atlas {}", this.atlas.getName());
         final Time startRelations = Time.now();
         validateRelationsPresent();
         validateRelationsLinked();
-        logger.debug("Finished relation validation of Atlas {} in {}", this.atlas.getName(),
+        logger.trace("Finished relation validation of Atlas {} in {}", this.atlas.getName(),
                 startRelations.elapsedSince());
-        logger.debug("Starting tags validation of Atlas {}", this.atlas.getName());
+        logger.trace("Starting tags validation of Atlas {}", this.atlas.getName());
         final Time startTags = Time.now();
         validateTagsPresent();
-        logger.debug("Finished tags validation of Atlas {} in {}", this.atlas.getName(),
+        logger.trace("Finished tags validation of Atlas {} in {}", this.atlas.getName(),
                 startTags.elapsedSince());
         new AtlasLocationItemValidator(this.atlas).validate();
         new AtlasLineItemValidator(this.atlas).validate();
         new AtlasEdgeValidator(this.atlas).validate();
         new AtlasNodeValidator(this.atlas).validate();
-        logger.debug("Finished validation of Atlas {} in {}", this.atlas.getName(),
+        logger.info("Finished validation of Atlas {} in {}", this.atlas.getName(),
                 start.elapsedSince());
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
@@ -32,31 +32,36 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
             final PolyLine currentShape = edge.asPolyLine();
             if (currentShape.size() > 2 && !edge.hasReverseEdge())
             {
+                // Prepare members to fill out: shapes, ids, etc.
                 final Location cut = currentShape.get(currentShape.size() / 2);
                 final PolyLine shape1 = currentShape.between(currentShape.first(), 0, cut, 0);
                 final PolyLine shape2 = currentShape.between(cut, 0, currentShape.last(), 0);
-
                 final long middleNodeIdentifier = identifierGenerator.incrementAndGet();
                 final long oldEdgeIdentifier = edge.getIdentifier();
                 final long newEdgeIdentifier1 = identifierGenerator.incrementAndGet();
                 final long newEdgeIdentifier2 = identifierGenerator.incrementAndGet();
+
+                // This is a new Edge, use "from" instead of "shallowFrom"
                 final BloatedEdge firstEdge = BloatedEdge.from(edge)
                         .withIdentifier(newEdgeIdentifier1).withPolyLine(shape1)
                         .withEndNodeIdentifier(middleNodeIdentifier);
+                // This is a new Edge, use "from" instead of "shallowFrom"
                 final BloatedEdge secondEdge = BloatedEdge.from(edge)
                         .withIdentifier(newEdgeIdentifier2).withPolyLine(shape2)
                         .withStartNodeIdentifier(middleNodeIdentifier);
-                // Update relations of edge to also list second edge that has a new ID here.
+
+                // Update relations of edge to instead list first and second edge that have new IDs
                 edge.relations().stream().map(relation ->
                 {
                     // newMembers exclude the old edge explicitly
                     final RelationMemberList newMembers = new RelationMemberList(relation.members()
-                            .stream().filter(member -> member.getEntity().equals(edge))
+                            .stream().filter(member -> !member.getEntity().equals(edge))
                             .collect(Collectors.toList()));
                     return BloatedRelation.shallowFrom(relation)
                             .withMembersAndSource(newMembers, relation)
                             // With the new relation members
-                            .withExtraMember(firstEdge, edge).withExtraMember(secondEdge, edge);
+                            .withExtraMember(firstEdge, edge)
+                            .withExtraMember(secondEdge, edge);
                 }).map(FeatureChange::add).forEach(result::add);
 
                 // Add the two new edges.
@@ -70,8 +75,13 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                         Sets.treeSet(newEdgeIdentifier2), Sets.hashSet())));
 
                 // End node has a replaced start edge identifier
-                result.add(FeatureChange.add(BloatedNode.from(edge.end())
+                result.add(FeatureChange.add(BloatedNode.shallowFrom(edge.end())
+                        .withInEdges(edge.end().inEdges())
                         .withInEdgeIdentifierReplaced(oldEdgeIdentifier, newEdgeIdentifier2)));
+                // Start node has a replaced end edge identifier
+                result.add(FeatureChange.add(BloatedNode.shallowFrom(edge.start())
+                        .withOutEdges(edge.start().outEdges())
+                        .withOutEdgeIdentifierReplaced(oldEdgeIdentifier, newEdgeIdentifier1)));
             }
         }
         return result;


### PR DESCRIPTION
### Description:

- Fixed an issue with `BloatedRelation.withExtraMember` which was looking at the wrong member set for a tag source
- Added a bunch of convenience methods in Bloated entities
- Updated logging levels for validation
- Added Atlas validation for edge-node connectivity: all edges that reference a node must be present in the node's corresponding connected edge set.
- Fixed discrepancies in the `AtlasChangeGeneratorSplitRoundabout` test, surfaced by the new validation.

### Potential Impact:

Less ways to mis-construct a Change object.

### Unit Test Approach:

Updated existing unit test.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)