### PR TITLE
adding highway=toll_gantry tag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/HighwayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/HighwayTag.java
@@ -64,7 +64,8 @@ public enum HighwayTag
     MILESTONE,
     TURNING_LOOP,
     CORRIDOR,
-    NO;
+    NO,
+    TOLL_GANTRY;
 
     @TagKey
     public static final String KEY = "highway";


### PR DESCRIPTION
### Description:
There are few places in OSM with highway=toll_gantry tags on nodes for toll payment. Adding this tag to the ```HighwayTag``` class.

Example: https://www.openstreetmap.org/node/157288624

Tag Info: https://taginfo.openstreetmap.org/tags/highway=toll_gantry#overview

### Potential Impact:
Atlas generator can way section at these nodes for toll support.

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
