### PR TITLE
Removing deprecated code and updating FastClasspathScanner to ClassGraph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies
     compile packages.commons.cli
     compile packages.commons.csv
     compile packages.commons.lang
-    compile packages.fastclasspath
+    compile packages.classgraph
     compile packages.guava
     compile packages.jsonassert
     compile packages.jackson.core

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@ project.ext.versions = [
     cli: '1.3.1',
     csv: '1.2',
     lang: '3.4',
-    fastclasspath: '2.9.4',
+    classgraph: '4.4.12',
     guava: '18.0',
     jsonassert:'1.3.0',
     jackson_core:'2.8.8',
@@ -52,7 +52,7 @@ project.ext.packages = [
             csv : "org.apache.commons:commons-csv:${versions.csv}",
             lang: "org.apache.commons:commons-lang3:${versions.lang}",
     ],
-    fastclasspath: "io.github.lukehutch:fast-classpath-scanner:${versions.fastclasspath}",
+    classgraph: "io.github.classgraph:classgraph:${versions.classgraph}",
     guava: "com.google.guava:guava:${versions.guava}",
     jsonassert: "org.skyscreamer:jsonassert:${versions.jsonassert}",
     jackson:[

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/SubAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/SubAtlasIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 
 /**
  * @author matthieun
@@ -17,7 +18,7 @@ public class SubAtlasIntegrationTest extends AtlasIntegrationTest
         final Atlas cuba = loadCuba();
         final Atlas sub = cuba
                 .subAtlas(Rectangle.forCorners(Location.forString("20.049468, -74.368043"),
-                        Location.forString("20.382402, -74.077814")))
+                        Location.forString("20.382402, -74.077814")), AtlasCutType.SOFT_CUT)
                 .orElseThrow(() -> new CoreException("SubAtlas was not present."));
         Assert.assertEquals(523, sub.metaData().getSize().getNodeNumber());
         Assert.assertEquals(1344, sub.metaData().getSize().getEdgeNumber());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -845,33 +845,6 @@ public interface Atlas extends Located, Iterable<AtlasEntity>, Serializable
     SortedSet<SnappedEdge> snaps(Location point, Distance threshold);
 
     /**
-     * Return a sub-atlas from this Atlas. TODO Remove this call next major release.
-     * <p>
-     * This would be a soft cut, meaning:
-     * <ul>
-     * <li>{@link Node}: It is included only if it is inside the polygon, or if a valid edge (below)
-     * has it at one of its ends.
-     * <li>{@link Edge}: It is included only if it is intersecting or inside the polygon.
-     * <li>{@link Area}: It is included only if it is intersecting or inside the polygon.
-     * <li>{@link Line}: It is included only if it is intersecting or inside the polygon.
-     * <li>{@link Point}: It is included only if it is inside the polygon.
-     * <li>{@link Relation}: It is included only if at least one of its members is valid per the
-     * above. Among its members, only the ones that are valid will be included in the member list.
-     * </ul>
-     *
-     * @param boundary
-     *            The boundary within which the sub atlas will be built
-     * @return An optional sub-atlas. The optional will be empty in case the boundary would return
-     *         an empty atlas, which is not allowed.
-     * @deprecated use {@link #subAtlas(Polygon, AtlasCutType)} with SOFT_CUT cut type instead.
-     */
-    @Deprecated
-    default Optional<Atlas> subAtlas(final Polygon boundary)
-    {
-        return subAtlas(boundary, AtlasCutType.SOFT_CUT);
-    }
-
-    /**
      * Return a sub-atlas from this Atlas.
      *
      * @param boundary
@@ -882,21 +855,6 @@ public interface Atlas extends Located, Iterable<AtlasEntity>, Serializable
      *         {@link Polygon} after the cut was applied. Returning an empty atlas is not allowed.
      */
     Optional<Atlas> subAtlas(Polygon boundary, AtlasCutType cutType);
-
-    /**
-     * Return a sub-atlas from this Atlas. TODO Remove this call next major release.
-     *
-     * @param matcher
-     *            The matcher to consider
-     * @return An optional sub-atlas. The optional will be empty in case there is nothing matching
-     *         the supplied predicate. Returning an empty atlas is not allowed.
-     * @deprecated use {@link #subAtlas(Predicate, AtlasCutType)} with SOFT_CUT cut type instead.
-     */
-    @Deprecated
-    default Optional<Atlas> subAtlas(final Predicate<AtlasEntity> matcher)
-    {
-        return subAtlas(matcher, AtlasCutType.SOFT_CUT);
-    }
 
     /**
      * Return a sub-atlas from this Atlas.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/README.md
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/README.md
@@ -1,6 +1,6 @@
 # Using Atlas
 
-* Grab one or more Atlas files (from [here](https://apple.box.com/s/3k3wcc0lq1fhqgozxr4mdi0llf95byo3) or after [building them yourself](#building-an-atlas-from-an-osmpbf-file)), and open them with [`AtlasResourceLoader`](src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java):
+* Grab one or more Atlas files (from [here](https://apple.box.com/s/3k3wcc0lq1fhqgozxr4mdi0llf95byo3) or after [building them yourself](src/main/java/org/openstreetmap/atlas/geography/atlas/README.md#building-an-atlas-from-an-osmpbf-file)), and open them with [`AtlasResourceLoader`](src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java):
 ```
 final File atlasFile = new File("/path/to/source.atlas");
 final Atlas atlas = new AtlasResourceLoader().load(atlasFile);
@@ -117,8 +117,8 @@ Atlas objects can be soft-filtered based on a `Predicate` or a `Polygon`.
 final Atlas atlas;
 
 final Predicate<AtlasEntity> predicate;
-final Atlas predicateAtlas = atlas.subAtlas(predicate);
+final Atlas predicateAtlas = atlas.subAtlas(predicate, AtlasCutType.SOFT_CUT);
 
 final Polygon polygon;
-final Atlas polygonAtlas = atlas.subAtlas(polygon);
+final Atlas polygonAtlas = atlas.subAtlas(polygon, AtlasCutType.SOFT_CUT);
 ```

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/bloated/BloatedAtlas.java
@@ -609,28 +609,8 @@ public class BloatedAtlas implements Atlas
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * @deprecated
-     */
-    @Deprecated
-    @Override
-    public Optional<Atlas> subAtlas(final Polygon boundary)
-    {
-        throw new UnsupportedOperationException();
-    }
-
     @Override
     public Optional<Atlas> subAtlas(final Polygon boundary, final AtlasCutType cutType)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * @deprecated
-     */
-    @Deprecated
-    @Override
-    public Optional<Atlas> subAtlas(final Predicate<AtlasEntity> matcher)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AbstractAtlasOutputTestSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AbstractAtlasOutputTestSubCommand.java
@@ -128,14 +128,10 @@ abstract class AbstractAtlasOutputTestSubCommand extends AbstractAtlasSubCommand
     {
         this.subAtlases = ConcurrentHashMap.newKeySet();
         this.distanceInMeters = (Optional<Double>) command.getOption(DISTANCE_IN_METERS_PARAMETER);
-        ((Optional<Path>) command.getOption(OUTPUT_TO_TEXT_PARAMETER)).ifPresent(path ->
-        {
-            this.outputTextPath = path;
-        });
-        ((Optional<Path>) command.getOption(OUTPUT_TO_PACKED_ATLAS_PARAMETER)).ifPresent(path ->
-        {
-            this.packedAtlasPath = path;
-        });
+        ((Optional<Path>) command.getOption(OUTPUT_TO_TEXT_PARAMETER))
+                .ifPresent(path -> this.outputTextPath = path);
+        ((Optional<Path>) command.getOption(OUTPUT_TO_PACKED_ATLAS_PARAMETER))
+                .ifPresent(path -> this.packedAtlasPath = path);
 
         if (this.outputTextPath == null && this.packedAtlasPath == null)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AbstractAtlasOutputTestSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AbstractAtlasOutputTestSubCommand.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
 import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
@@ -149,6 +150,6 @@ abstract class AbstractAtlasOutputTestSubCommand extends AbstractAtlasSubCommand
         {
             rectangle = rectangle.expand(Distance.meters(this.distanceInMeters.get()));
         }
-        item.getAtlas().subAtlas(rectangle).ifPresent(this.subAtlases::add);
+        item.getAtlas().subAtlas(rectangle, AtlasCutType.SOFT_CUT).ifPresent(this.subAtlases::add);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasSplitterWithSlippyTileCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/AtlasSplitterWithSlippyTileCommand.java
@@ -10,6 +10,7 @@ import java.util.stream.StreamSupport;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
@@ -46,6 +47,14 @@ public class AtlasSplitterWithSlippyTileCommand extends AbstractAtlasSubCommand
     }
 
     @Override
+    public void usage(final PrintStream writer)
+    {
+        writer.printf(AtlasCommandConstants.INPUT_PARAMETER_DESCRIPTION);
+        writer.printf(AtlasCommandConstants.INPUT_ZOOM_LEVEL);
+        writer.printf(AtlasCommandConstants.OUTPUT_FOLDER_DESCRIPTION);
+    }
+
+    @Override
     protected void handle(final Atlas atlas, final CommandMap command)
     {
         final int zoomLevel = (int) command.get(ZOOM_LEVEL);
@@ -75,15 +84,7 @@ public class AtlasSplitterWithSlippyTileCommand extends AbstractAtlasSubCommand
 
     private PackedAtlas buildAtlasBasedOnTile(final SlippyTile tile, final Atlas atlas)
     {
-        return atlas.subAtlas(tile.bounds())
+        return atlas.subAtlas(tile.bounds(), AtlasCutType.SOFT_CUT)
                 .map(subAtlas -> new PackedAtlasCloner().cloneFrom(subAtlas)).orElse(null);
-    }
-
-    @Override
-    public void usage(final PrintStream writer)
-    {
-        writer.printf(AtlasCommandConstants.INPUT_PARAMETER_DESCRIPTION);
-        writer.printf(AtlasCommandConstants.INPUT_ZOOM_LEVEL);
-        writer.printf(AtlasCommandConstants.OUTPUT_FOLDER_DESCRIPTION);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/command/SubAtlasSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/command/SubAtlasSubCommand.java
@@ -14,6 +14,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.utilities.runtime.Command.Flag;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
@@ -70,8 +71,8 @@ public class SubAtlasSubCommand extends AbstractAtlasSubCommand
         final Rectangle rectangle = (Rectangle) command.get(SUB);
         try
         {
-            final Atlas saveMe = new PackedAtlasCloner().cloneFrom(atlas).subAtlas(rectangle)
-                    .orElseThrow(
+            final Atlas saveMe = new PackedAtlasCloner().cloneFrom(atlas)
+                    .subAtlas(rectangle, AtlasCutType.SOFT_CUT).orElseThrow(
                             () -> new CoreException("There are no features in the sub rectangle."));
             final Path path = (Path) command.get(OUTPUT);
             Files.createDirectories(path.getParent());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
@@ -26,6 +26,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.index.RTree;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
@@ -192,8 +193,10 @@ public class MultiAtlas extends AbstractAtlas
             throw new CoreException("Can't create an atlas from zero resources");
         }
         return new MultiAtlas(
-                Iterables.translate(resources,
-                        resource -> PackedAtlas.load(resource).subAtlas(filter).get()),
+                Iterables
+                        .translate(resources,
+                                resource -> PackedAtlas.load(resource)
+                                        .subAtlas(filter, AtlasCutType.SOFT_CUT).get()),
                 lotsOfOverlap);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -537,7 +537,7 @@ public class WaySectionProcessor
             {
                 // The first shard is always the initial one. Use its bounds to build the atlas.
                 final Rectangle originalShardBounds = this.loadedShards.get(0).bounds();
-                return atlas.subAtlas(originalShardBounds)
+                return atlas.subAtlas(originalShardBounds, AtlasCutType.SOFT_CUT)
                         .orElseThrow(() -> new CoreException(
                                 "Cannot have an empty atlas after way sectioning {}",
                                 this.loadedShards.get(0).getName()));

--- a/src/main/java/org/openstreetmap/atlas/proto/builder/ProtoAtlasBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/proto/builder/ProtoAtlasBuilder.java
@@ -178,25 +178,13 @@ public class ProtoAtlasBuilder
         }
         protoMetaDataBuilder.setOriginal(atlasMetaData.isOriginal());
 
-        atlasMetaData.getCodeVersion().ifPresent(value ->
-        {
-            protoMetaDataBuilder.setCodeVersion(value);
-        });
+        atlasMetaData.getCodeVersion().ifPresent(protoMetaDataBuilder::setCodeVersion);
 
-        atlasMetaData.getDataVersion().ifPresent(value ->
-        {
-            protoMetaDataBuilder.setDataVersion(value);
-        });
+        atlasMetaData.getDataVersion().ifPresent(protoMetaDataBuilder::setDataVersion);
 
-        atlasMetaData.getCountry().ifPresent(value ->
-        {
-            protoMetaDataBuilder.setCountry(value);
-        });
+        atlasMetaData.getCountry().ifPresent(protoMetaDataBuilder::setCountry);
 
-        atlasMetaData.getShardName().ifPresent(value ->
-        {
-            protoMetaDataBuilder.setShardName(value);
-        });
+        atlasMetaData.getShardName().ifPresent(protoMetaDataBuilder::setShardName);
 
         if (atlasMetaData.getTags() != null)
         {

--- a/src/main/java/org/openstreetmap/atlas/streaming/readers/CsvReader.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/readers/CsvReader.java
@@ -77,8 +77,8 @@ public class CsvReader implements Iterator<CsvLine>
         }
         catch (final Exception e)
         {
-            logger.warn(
-                    "Ignoring malformed line: -- " + candidate + " --. Reason: " + e.getMessage());
+            logger.warn("Ignoring malformed line: -- {} --. Reason: {}", candidate, e.getMessage(),
+                    e);
             return null;
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/http/HttpResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/http/HttpResource.java
@@ -99,7 +99,7 @@ public abstract class HttpResource extends AbstractResource
     {
         // make sure that a connection attempt has been made
         final StringBuilder builder = new StringBuilder();
-        lines().forEach(x -> builder.append(x));
+        lines().forEach(builder::append);
         return builder.toString();
     }
     // ------------------------------------//

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/ExactMatchValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/ExactMatchValidator.java
@@ -50,8 +50,8 @@ public class ExactMatchValidator implements TagValidator
      */
     public ExactMatchValidator withRegularExpressions(final String... regexes)
     {
-        this.regexes.addAll(Arrays.asList(regexes).stream().map(regex -> Pattern.compile(regex))
-                .collect(Collectors.toSet()));
+        this.regexes.addAll(
+                Arrays.asList(regexes).stream().map(Pattern::compile).collect(Collectors.toSet()));
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -29,7 +29,9 @@ import org.openstreetmap.atlas.tags.cache.CachingValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 
 /**
  * Builds a table of {@link TagValidator}s using Java annotations and introspection.
@@ -208,12 +210,9 @@ public class Validators
             final Class<T> enumType, final Taggable taggable)
     {
         final Tag tag = tagType.getDeclaredAnnotation(Tag.class);
-        if (tag != null)
+        if (tag != null && Stream.of(tag.with()).anyMatch(possible -> possible == enumType))
         {
-            if (Stream.of(tag.with()).anyMatch(possible -> possible == enumType))
-            {
-                return fromHelper(findTagNameIn(tagType), enumType, taggable);
-            }
+            return fromHelper(findTagNameIn(tagType), enumType, taggable);
         }
         return Optional.empty();
     }
@@ -312,10 +311,8 @@ public class Validators
         {
             return taggable -> false;
         }
-        return taggable ->
-        {
-            return hasValuesFor(taggable, tagTypes);
-        };
+
+        return taggable -> hasValuesFor(taggable, tagTypes);
     }
 
     /**
@@ -492,9 +489,8 @@ public class Validators
         {
             final Field field = constant.getDeclaringClass().getField(constant.name());
             final TagValueAs substitutedValue = field.getAnnotation(TagValueAs.class);
-            final String returnValue = substitutedValue == null
-                    ? ((Enum<?>) field.get(null)).name().toLowerCase() : substitutedValue.value();
-            return returnValue;
+            return substitutedValue == null ? ((Enum<?>) field.get(null)).name().toLowerCase()
+                    : substitutedValue.value();
         }
         catch (final IllegalAccessException | NoSuchFieldException oops)
         {
@@ -581,8 +577,15 @@ public class Validators
         this.validators = new ValidatorMap();
         fillValidatorTypes(this.validatorTypes);
         final List<Class<?>> klasses = new ArrayList<>();
-        new FastClasspathScanner(packageName).matchClassesWithAnnotation(Tag.class, klasses::add)
-                .scan();
+
+        // Scan all classes in the given package with the Tag annotation
+        try (ScanResult scanResult = new ClassGraph().enableAllInfo().whitelistPackages(packageName)
+                .scan())
+        {
+            final ClassInfoList tagClassInfoList = scanResult
+                    .getClassesWithAnnotation("org.openstreetmap.atlas.tags.annotations.Tag");
+            tagClassInfoList.loadClasses().forEach(klasses::add);
+        }
         klasses.stream().forEach(this::processClass);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/tags/filters/LineFilterConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/filters/LineFilterConverter.java
@@ -21,7 +21,6 @@ public class LineFilterConverter implements TwoWayConverter<String, TaggableFilt
 {
     private static final String VALUES_SEPARATOR = ",";
     private static final String KEY_VALUE_SEPARATOR = "->";
-    @SuppressWarnings({ "unchecked" })
     private static final Predicate<Taggable> ALL_VALID = (Predicate<Taggable> & Serializable) taggable -> true;
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasMovingTooFastTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasMovingTooFastTest.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
 import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasMovingTooFastTestRule;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -63,14 +64,14 @@ public class DynamicAtlasMovingTooFastTest
     public void prepare(final DynamicAtlasPolicy policy)
     {
         this.store = new HashMap<>();
-        this.store.put(new SlippyTile(5, 34, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(5, 34, 6).bounds()).get());
-        this.store.put(new SlippyTile(6, 34, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(6, 34, 6).bounds()).get());
-        this.store.put(new SlippyTile(6, 35, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(6, 35, 6).bounds()).get());
-        this.store.put(new SlippyTile(5, 35, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(5, 35, 6).bounds()).get());
+        this.store.put(new SlippyTile(5, 34, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(5, 34, 6).bounds(), AtlasCutType.SOFT_CUT).get());
+        this.store.put(new SlippyTile(6, 34, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(6, 34, 6).bounds(), AtlasCutType.SOFT_CUT).get());
+        this.store.put(new SlippyTile(6, 35, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(6, 35, 6).bounds(), AtlasCutType.SOFT_CUT).get());
+        this.store.put(new SlippyTile(5, 35, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(5, 35, 6).bounds(), AtlasCutType.SOFT_CUT).get());
         this.dynamicAtlas = new DynamicAtlas(policy);
         this.dynamicAtlas.preemptiveLoad();
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasRestrainedExpansionWithPolygonTest.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
 import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasRestrainedExpansionWithPolygonTestRule;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -65,12 +66,12 @@ public class DynamicAtlasRestrainedExpansionWithPolygonTest
     public void prepare(final DynamicAtlasPolicy policy)
     {
         this.store = new HashMap<>();
-        this.store.put(new SlippyTile(5, 34, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(5, 34, 6).bounds()).get());
-        this.store.put(new SlippyTile(6, 34, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(6, 34, 6).bounds()).get());
-        this.store.put(new SlippyTile(4, 34, 6),
-                this.rule.getAtlas().subAtlas(new SlippyTile(4, 34, 6).bounds()).get());
+        this.store.put(new SlippyTile(5, 34, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(5, 34, 6).bounds(), AtlasCutType.SOFT_CUT).get());
+        this.store.put(new SlippyTile(6, 34, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(6, 34, 6).bounds(), AtlasCutType.SOFT_CUT).get());
+        this.store.put(new SlippyTile(4, 34, 6), this.rule.getAtlas()
+                .subAtlas(new SlippyTile(4, 34, 6).bounds(), AtlasCutType.SOFT_CUT).get());
         this.dynamicAtlas = new DynamicAtlas(policy);
         this.dynamicAtlas.preemptiveLoad();
     }


### PR DESCRIPTION
### Description:

There are three changes here:
1. Addressing issue #204 - porting over to the latest ClassGraph code. This involves multiple changes in the way we are doing the scanning. I followed this [wiki](https://github.com/classgraph/classgraph/wiki/Porting-FastClasspathScanner-code-to-ClassGraph) for the migration. There are also helpful examples for grabbing implementations of an interface or annotation based classes [here](https://github.com/classgraph/classgraph/wiki/Code-examples). Lastly, I chose the most frequently used version to depend on - 4.4.12. The most recent version is 4.6.12. I chose 4.4.12 because it has the most [dependencies](https://mvnrepository.com/artifact/io.github.classgraph/classgraph) out of all released versions (banking on stability) and none of the patch notes since it look too relevant. Happy to update to the most recent one if anyone has an issue with this. See all available releases and their notes [here](https://github.com/classgraph/classgraph/releases).
2. Removing deprecated `subAtlas` calls - this is a breaking change, so any downstream users will need to update their APIs when these changes are released.
3. Fixing various Sonar issues found along the way

### Potential Impact:

All downstream users relying on the `Atlas` `subAtlas` API call will be broken.

### Unit Test Approach:

All existing unit tests pass, no new ones are needed.

### Test Results:

All integration tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
