### PR TITLE
SnappedLocation: Equals method backwards compatability

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Snapper.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Iterables;
  * Snap a {@link Location} to a {@link PolyLine}.
  *
  * @author matthieun
+ * @author bbreithaupt
  */
 public class Snapper
 {
@@ -57,6 +58,10 @@ public class Snapper
             {
                 return this.origin.equals(((SnappedLocation) other).getOrigin())
                         && this.target.equals(((SnappedLocation) other).getTarget());
+            }
+            if (other instanceof Location)
+            {
+                return super.equals(other);
             }
             return false;
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
@@ -54,6 +54,7 @@ public class SnapperTest
     }
 
     @Test
+    @SuppressWarnings("squid:S3415")
     public void testSnappedLocationEqualsSnappedLocationTrue()
     {
         Assert.assertEquals(SNAP_1, SNAP_1);
@@ -66,6 +67,7 @@ public class SnapperTest
     }
 
     @Test
+    @SuppressWarnings("squid:S3415")
     public void testSnappedLocationEqualsLocationTrue()
     {
         Assert.assertEquals(SNAP_1, Location.TEST_2);

--- a/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/SnapperTest.java
@@ -5,9 +5,15 @@ import org.junit.Test;
 
 /**
  * @author matthieun
+ * @author bbreithaupt
  */
 public class SnapperTest
 {
+    private static final Snapper.SnappedLocation SNAP_1 = new Snapper.SnappedLocation(
+            Location.TEST_1, Location.TEST_2, new PolyLine(Location.TEST_2, Location.TEST_3));
+    private static final Snapper.SnappedLocation SNAP_2 = new Snapper.SnappedLocation(
+            Location.TEST_2, Location.TEST_1, new PolyLine(Location.TEST_3, Location.TEST_2));
+
     @Test
     public void testMultiPolygon()
     {
@@ -45,5 +51,29 @@ public class SnapperTest
         Assert.assertEquals(Location.forString("37.3268107,-122.030562"), origin.snapTo(shape));
         Assert.assertEquals(Location.TEST_6, shape.snapFrom(Location.TEST_3));
         Assert.assertEquals(Location.TEST_1, shape.snapFrom(Location.EIFFEL_TOWER));
+    }
+
+    @Test
+    public void testSnappedLocationEqualsSnappedLocationTrue()
+    {
+        Assert.assertEquals(SNAP_1, SNAP_1);
+    }
+
+    @Test
+    public void testSnappedLocationEqualsSnappedLocationFalse()
+    {
+        Assert.assertNotEquals(SNAP_1, SNAP_2);
+    }
+
+    @Test
+    public void testSnappedLocationEqualsLocationTrue()
+    {
+        Assert.assertEquals(SNAP_1, Location.TEST_2);
+    }
+
+    @Test
+    public void testSnappedLocationEqualsLocationFalse()
+    {
+        Assert.assertNotEquals(SNAP_1, Location.TEST_1);
     }
 }


### PR DESCRIPTION
### Description:

https://github.com/osmlab/atlas/pull/311 added an overriding equals method to SnappedLocation that was not backwards compatible. Specifically `SnappedLocation.equals(Location)` would never be true, when it had been before. This adds back the ability to compare SnappedLocations to Locations.

### Potential Impact:

Return the ability to compare a SnappedLocation to a Location using `SnappedLocation.equals()`.

### Unit Test Approach:

Four unit test are added. Two tests for comparing two SnappedLocations, and two for comparing SnappedLocations to Locations. 

### Test Results:

None

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
