### PR TITLE
Fixed a bug in RawAtlasPointAndLineSlicer that prevented ferry slicing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -490,10 +490,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
      */
     private boolean slicesBelongToSingleCountry(final List<Geometry> slices)
     {
-        // TODO - this is an optimization that hides the corner case of not slicing any pier or
-        // ferry that extends into the ocean. Because the ocean isn't viewed as another country, the
-        // pier and ferries are not sliced at the country boundary and ocean. This should be fixed
-        // for consistency issues.
         return slices.size() == 1 || CountryBoundaryMap.isSameCountry(slices);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -26,12 +26,8 @@ import org.openstreetmap.atlas.geography.atlas.raw.temporary.TemporaryLine;
 import org.openstreetmap.atlas.geography.atlas.raw.temporary.TemporaryPoint;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
-import org.openstreetmap.atlas.tags.ManMadeTag;
-import org.openstreetmap.atlas.tags.RouteTag;
 import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.SyntheticNearestNeighborCountryCodeTag;
-import org.openstreetmap.atlas.tags.Taggable;
-import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
@@ -498,13 +494,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         // ferry that extends into the ocean. Because the ocean isn't viewed as another country, the
         // pier and ferries are not sliced at the country boundary and ocean. This should be fixed
         // for consistency issues.
-        final boolean slicesAreSingleCountry = slices.size() == 1
-                || CountryBoundaryMap.isSameCountry(slices);
-        final Map<String, String> tags = CountryBoundaryMap.getGeometryProperties(slices.get(0));
-        final boolean slicesAreFerryOrPier = Validators.isOfType(Taggable.with(tags),
-                RouteTag.class, RouteTag.FERRY)
-                || Validators.isOfType(Taggable.with(tags), ManMadeTag.class, ManMadeTag.PIER);
-        return slicesAreSingleCountry && !slicesAreFerryOrPier;
+        return slices.size() == 1 || CountryBoundaryMap.isSameCountry(slices);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -129,6 +129,11 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         List<Geometry> result;
         final long lineIdentifier = line.getIdentifier();
 
+        if (line.getOsmIdentifier() == 112715914L)
+        {
+            logger.error("convertToJtsGeomAndSlice line {}", line.getIdentifier());
+        }
+
         // Create the JTS Geometry from Line
         Geometry geometry;
 
@@ -144,14 +149,18 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         }
 
         // Slice the JTS Geometry
-        result = sliceGeometry(geometry, lineIdentifier);
+        result = sliceGeometry(geometry, line);
+        if (line.getOsmIdentifier() == 112715914L)
+        {
+            logger.error("result: {}", result);
+        }
 
         if ((result == null || result.isEmpty()) && line.isClosed())
         {
             // If we failed to slice an invalid Polygon (self-intersecting for example), let's try
             // to slice it as a PolyLine. Only if we cannot do that, then return an empty list.
             geometry = JTS_POLYLINE_CONVERTER.convert(line.asPolyLine());
-            result = sliceGeometry(geometry, lineIdentifier);
+            result = sliceGeometry(geometry, line);
         }
 
         if (result == null || result.isEmpty())
@@ -236,6 +245,14 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         else if (slicesBelongToSingleCountry(slices)
                 && !getCountryBoundaryMap().shouldForceSlicing(line))
         {
+            if (line.getOsmIdentifier() == 112715914L)
+            {
+                logger.error("Processing line {} CASE BAD", line.getIdentifier());
+                logger.error("slicesBelongToSingleCountry: {}",
+                        slicesBelongToSingleCountry(slices));
+                logger.error("getCountryBoundaryMap().shouldForceSlicing(line): {}",
+                        getCountryBoundaryMap().shouldForceSlicing(line));
+            }
             // This line belongs to a single country, check to make sure it's the right one
             if (isOutsideWorkingBound(slices.get(0)))
             {
@@ -251,6 +268,14 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         }
         else if (slices.size() < AbstractIdentifierFactory.IDENTIFIER_SCALE)
         {
+            if (line.getOsmIdentifier() == 112715914L)
+            {
+                logger.error("Processing line {} CASE GOOD", line.getIdentifier());
+                logger.error("slicesBelongToSingleCountry: {}",
+                        slicesBelongToSingleCountry(slices));
+                logger.error("getCountryBoundaryMap().shouldForceSlicing(line): {}",
+                        getCountryBoundaryMap().shouldForceSlicing(line));
+            }
             // Used to generate identifiers for new points and lines
             final CountrySlicingIdentifierFactory lineIdentifierFactory = new CountrySlicingIdentifierFactory(
                     line.getIdentifier());
@@ -407,19 +432,19 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
      *
      * @param geometry
      *            The {@link Geometry} to slice
-     * @param identifier
-     *            The {@link Line} identifier being sliced
+     * @param line
+     *            The {@link Line} being sliced
      * @return a list of {@link Geometry} slices
      */
-    private List<Geometry> sliceGeometry(final Geometry geometry, final long identifier)
+    private List<Geometry> sliceGeometry(final Geometry geometry, final Line line)
     {
         try
         {
-            return getCountryBoundaryMap().slice(identifier, geometry);
+            return getCountryBoundaryMap().slice(line.getIdentifier(), geometry, line);
         }
         catch (final TopologyException e)
         {
-            logger.error("Topology Exception when slicing Line {}", identifier, e);
+            logger.error("Topology Exception when slicing Line {}", line.getIdentifier(), e);
             return Collections.emptyList();
         }
     }
@@ -433,6 +458,10 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
      */
     private void sliceLine(final Line line)
     {
+        if (line.getOsmIdentifier() == 112715914L)
+        {
+            logger.error("Slicing line {}", line.getIdentifier());
+        }
         getStatistics().recordProcessedLine();
         final List<Geometry> slices = convertToJtsGeometryAndSlice(line);
         processLineSlices(line, slices);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -26,8 +26,12 @@ import org.openstreetmap.atlas.geography.atlas.raw.temporary.TemporaryLine;
 import org.openstreetmap.atlas.geography.atlas.raw.temporary.TemporaryPoint;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.tags.ManMadeTag;
+import org.openstreetmap.atlas.tags.RouteTag;
 import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.SyntheticNearestNeighborCountryCodeTag;
+import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
@@ -494,7 +498,13 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         // ferry that extends into the ocean. Because the ocean isn't viewed as another country, the
         // pier and ferries are not sliced at the country boundary and ocean. This should be fixed
         // for consistency issues.
-        return slices.size() == 1 || CountryBoundaryMap.isSameCountry(slices);
+        final boolean slicesAreSingleCountry = slices.size() == 1
+                || CountryBoundaryMap.isSameCountry(slices);
+        final Map<String, String> tags = CountryBoundaryMap.getGeometryProperties(slices.get(0));
+        final boolean slicesAreFerryOrPier = Validators.isOfType(Taggable.with(tags),
+                RouteTag.class, RouteTag.FERRY)
+                || Validators.isOfType(Taggable.with(tags), ManMadeTag.class, ManMadeTag.PIER);
+        return slicesAreSingleCountry && !slicesAreFerryOrPier;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -129,11 +129,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         List<Geometry> result;
         final long lineIdentifier = line.getIdentifier();
 
-        if (line.getOsmIdentifier() == 112715914L)
-        {
-            logger.error("convertToJtsGeomAndSlice line {}", line.getIdentifier());
-        }
-
         // Create the JTS Geometry from Line
         Geometry geometry;
 
@@ -150,10 +145,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
 
         // Slice the JTS Geometry
         result = sliceGeometry(geometry, line);
-        if (line.getOsmIdentifier() == 112715914L)
-        {
-            logger.error("result: {}", result);
-        }
 
         if ((result == null || result.isEmpty()) && line.isClosed())
         {
@@ -245,14 +236,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         else if (slicesBelongToSingleCountry(slices)
                 && !getCountryBoundaryMap().shouldForceSlicing(line))
         {
-            if (line.getOsmIdentifier() == 112715914L)
-            {
-                logger.error("Processing line {} CASE BAD", line.getIdentifier());
-                logger.error("slicesBelongToSingleCountry: {}",
-                        slicesBelongToSingleCountry(slices));
-                logger.error("getCountryBoundaryMap().shouldForceSlicing(line): {}",
-                        getCountryBoundaryMap().shouldForceSlicing(line));
-            }
             // This line belongs to a single country, check to make sure it's the right one
             if (isOutsideWorkingBound(slices.get(0)))
             {
@@ -268,14 +251,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         }
         else if (slices.size() < AbstractIdentifierFactory.IDENTIFIER_SCALE)
         {
-            if (line.getOsmIdentifier() == 112715914L)
-            {
-                logger.error("Processing line {} CASE GOOD", line.getIdentifier());
-                logger.error("slicesBelongToSingleCountry: {}",
-                        slicesBelongToSingleCountry(slices));
-                logger.error("getCountryBoundaryMap().shouldForceSlicing(line): {}",
-                        getCountryBoundaryMap().shouldForceSlicing(line));
-            }
             // Used to generate identifiers for new points and lines
             final CountrySlicingIdentifierFactory lineIdentifierFactory = new CountrySlicingIdentifierFactory(
                     line.getIdentifier());
@@ -458,10 +433,6 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
      */
     private void sliceLine(final Line line)
     {
-        if (line.getOsmIdentifier() == 112715914L)
-        {
-            logger.error("Slicing line {}", line.getIdentifier());
-        }
         getStatistics().recordProcessedLine();
         final List<Geometry> slices = convertToJtsGeometryAndSlice(line);
         processLineSlices(line, slices);

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -40,6 +40,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.complex.boundaries.ComplexBoundary;
 import org.openstreetmap.atlas.geography.atlas.items.complex.boundaries.ComplexBoundaryFinder;
+import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.CountryCodeProperties;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.RuntimeCounter;
 import org.openstreetmap.atlas.geography.boundary.converters.CountryListTwoWayStringConverter;
@@ -1220,6 +1221,12 @@ public class CountryBoundaryMap implements Serializable
             return null;
         }
 
+        if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+        {
+            logger.error("countryBoundaryMap slice line {}", identifier);
+            logger.error("geom {}", geometry);
+        }
+
         Geometry target = geometry;
         final List<Geometry> results = new ArrayList<>();
         List<Polygon> candidates = this.query(target.getEnvelopeInternal());
@@ -1229,6 +1236,10 @@ public class CountryBoundaryMap implements Serializable
         // In this method, source contains only one element.
         if (shouldSkipSlicing(candidates, source))
         {
+            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+            {
+                logger.error("skipping slicing line {}, WHY 1", identifier);
+            }
             final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             addResult(target, results);
@@ -1262,6 +1273,12 @@ public class CountryBoundaryMap implements Serializable
                         .groupingBy(polygon -> getGeometryProperty(polygon, ISOCountryTag.KEY)));
                 countries.forEach((key, value) -> logger.trace("{} : {}", key, value.size()));
             }
+        }
+
+        if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+        {
+            logger.error("countryBoundaryMap still slicing line {}", identifier);
+            logger.error("candidates: {}", candidates);
         }
 
         // Check relation of target to all polygons
@@ -1317,6 +1334,10 @@ public class CountryBoundaryMap implements Serializable
         // (except when geometry has to be sliced at all costs)
         if (shouldSkipSlicing(candidates, source))
         {
+            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+            {
+                logger.error("skipping slicing line {}, WHY 2", identifier);
+            }
             final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             this.addResult(target, results);
@@ -1371,8 +1392,16 @@ public class CountryBoundaryMap implements Serializable
         // Part or all of the geometry is not inside any country, assign with nearest country.
         if (!fullyMatched)
         {
+            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+            {
+                logger.error("NOT fullyMatched line {}", identifier);
+            }
             final Geometry nearestGeometry = nearestNeighbour(target.getEnvelopeInternal(), target,
                     new GeometryItemDistance());
+            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+            {
+                logger.error("nearest geom for line {}: {}", identifier, nearestGeometry);
+            }
             if (nearestGeometry != null)
             {
                 final String nearestCountryCode = getGeometryProperty(nearestGeometry,
@@ -1381,6 +1410,13 @@ public class CountryBoundaryMap implements Serializable
                 setGeometryProperty(target, SyntheticNearestNeighborCountryCodeTag.KEY,
                         SyntheticNearestNeighborCountryCodeTag.YES.toString());
                 this.addResult(target, results);
+            }
+        }
+        else
+        {
+            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
+            {
+                logger.error("fullyMatched line {}", identifier);
             }
         }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -40,7 +40,6 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.complex.boundaries.ComplexBoundary;
 import org.openstreetmap.atlas.geography.atlas.items.complex.boundaries.ComplexBoundaryFinder;
-import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.CountryCodeProperties;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.RuntimeCounter;
 import org.openstreetmap.atlas.geography.boundary.converters.CountryListTwoWayStringConverter;
@@ -1221,12 +1220,6 @@ public class CountryBoundaryMap implements Serializable
             return null;
         }
 
-        if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-        {
-            logger.error("countryBoundaryMap slice line {}", identifier);
-            logger.error("geom {}", geometry);
-        }
-
         Geometry target = geometry;
         final List<Geometry> results = new ArrayList<>();
         List<Polygon> candidates = this.query(target.getEnvelopeInternal());
@@ -1236,10 +1229,6 @@ public class CountryBoundaryMap implements Serializable
         // In this method, source contains only one element.
         if (shouldSkipSlicing(candidates, source))
         {
-            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-            {
-                logger.error("skipping slicing line {}, WHY 1", identifier);
-            }
             final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             addResult(target, results);
@@ -1273,12 +1262,6 @@ public class CountryBoundaryMap implements Serializable
                         .groupingBy(polygon -> getGeometryProperty(polygon, ISOCountryTag.KEY)));
                 countries.forEach((key, value) -> logger.trace("{} : {}", key, value.size()));
             }
-        }
-
-        if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-        {
-            logger.error("countryBoundaryMap still slicing line {}", identifier);
-            logger.error("candidates: {}", candidates);
         }
 
         // Check relation of target to all polygons
@@ -1334,10 +1317,6 @@ public class CountryBoundaryMap implements Serializable
         // (except when geometry has to be sliced at all costs)
         if (shouldSkipSlicing(candidates, source))
         {
-            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-            {
-                logger.error("skipping slicing line {}, WHY 2", identifier);
-            }
             final String countryCode = getGeometryProperty(candidates.get(0), ISOCountryTag.KEY);
             setGeometryProperty(target, ISOCountryTag.KEY, countryCode);
             this.addResult(target, results);
@@ -1392,16 +1371,8 @@ public class CountryBoundaryMap implements Serializable
         // Part or all of the geometry is not inside any country, assign with nearest country.
         if (!fullyMatched)
         {
-            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-            {
-                logger.error("NOT fullyMatched line {}", identifier);
-            }
             final Geometry nearestGeometry = nearestNeighbour(target.getEnvelopeInternal(), target,
                     new GeometryItemDistance());
-            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-            {
-                logger.error("nearest geom for line {}: {}", identifier, nearestGeometry);
-            }
             if (nearestGeometry != null)
             {
                 final String nearestCountryCode = getGeometryProperty(nearestGeometry,
@@ -1410,13 +1381,6 @@ public class CountryBoundaryMap implements Serializable
                 setGeometryProperty(target, SyntheticNearestNeighborCountryCodeTag.KEY,
                         SyntheticNearestNeighborCountryCodeTag.YES.toString());
                 this.addResult(target, results);
-            }
-        }
-        else
-        {
-            if (new ReverseIdentifierFactory().getOsmIdentifier(identifier) == 112715914L)
-            {
-                logger.error("fullyMatched line {}", identifier);
             }
         }
 


### PR DESCRIPTION
### Description:

`RawAtlasPointAndLineSlicer` was mis-calling `CountryBoundaryMap::slice`, which caused `CountryBoundaryMap` to incorrectly slice ferry routes even when forcing slicing on `route->ferry`.

What caused the bug? `RawAtlasPointAndLineSlicer` was calling `CountryBoundaryMap::slice` with an empty `Taggable` parameter. This caused `CountryBoundaryMap::slice` to always take one of its shortcut optimizations, which skips slicing for lines that are part of a single country. Since the `Taggable` parameter was empty, it could not verify that the geometry matched the force slicing predicate.

### Potential Impact:

Any downstream code that expects correct slicing will now be happy.

### Unit Test Approach:

Built and verified a world ferry atlas using `WorldAtlasGenerator`.

### Test Results:

Results are correct.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)