### PR TITLE
Added a command line tool for atlas diffing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
@@ -16,8 +16,8 @@ import org.openstreetmap.atlas.utilities.command.parsing.ArgumentOptionality;
 
 public class AtlasDiffCommand extends AbstractAtlasShellToolsCommand
 {
-    private static final String AFTER_ATLAS_ARGUMENT = "after-atlas";
     private static final String BEFORE_ATLAS_ARGUMENT = "before-atlas";
+    private static final String AFTER_ATLAS_ARGUMENT = "after-atlas";
     private static final String DIFF_FILE = "diff.geojson";
 
     private final OptionAndArgumentDelegate optArgDelegate;
@@ -47,10 +47,12 @@ public class AtlasDiffCommand extends AbstractAtlasShellToolsCommand
         if (!beforeAtlasFile.exists())
         {
             this.outputDelegate.printlnWarnMessage("file not found: " + beforeAtlasPath);
+            return 1;
         }
         if (!afterAtlasFile.exists())
         {
             this.outputDelegate.printlnWarnMessage("file not found: " + afterAtlasPath);
+            return 1;
         }
 
         final Atlas beforeAtlas = new AtlasResourceLoader().load(beforeAtlasFile);
@@ -88,7 +90,10 @@ public class AtlasDiffCommand extends AbstractAtlasShellToolsCommand
     @Override
     public void registerManualPageSections()
     {
-
+        addManualPageSection("DESCRIPTION", AtlasDiffCommand.class
+                .getResourceAsStream("AtlasDiffCommandDescriptionSection.txt"));
+        addManualPageSection("EXAMPLES",
+                AtlasDiffCommand.class.getResourceAsStream("AtlasDiffCommandExamplesSection.txt"));
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
@@ -1,0 +1,101 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.change.Change;
+import org.openstreetmap.atlas.geography.atlas.change.diff.AtlasDiff;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
+import org.openstreetmap.atlas.utilities.command.parsing.ArgumentArity;
+import org.openstreetmap.atlas.utilities.command.parsing.ArgumentOptionality;
+
+public class AtlasDiffCommand extends AbstractAtlasShellToolsCommand
+{
+    private static final String AFTER_ATLAS_ARGUMENT = "after-atlas";
+    private static final String BEFORE_ATLAS_ARGUMENT = "before-atlas";
+    private static final String DIFF_FILE = "diff.geojson";
+
+    private final OptionAndArgumentDelegate optArgDelegate;
+    private final CommandOutputDelegate outputDelegate;
+
+    public static void main(final String[] args)
+    {
+        new AtlasDiffCommand().runSubcommandAndExit(args);
+    }
+
+    public AtlasDiffCommand()
+    {
+        this.optArgDelegate = this.getOptionAndArgumentDelegate();
+        this.outputDelegate = this.getCommandOutputDelegate();
+    }
+
+    @Override
+    public int execute()
+    {
+        final String beforeAtlasPath = this.optArgDelegate.getUnaryArgument(BEFORE_ATLAS_ARGUMENT)
+                .orElseThrow(AtlasShellToolsException::new);
+        final String afterAtlasPath = this.optArgDelegate.getUnaryArgument(AFTER_ATLAS_ARGUMENT)
+                .orElseThrow(AtlasShellToolsException::new);
+        final File beforeAtlasFile = new File(beforeAtlasPath);
+        final File afterAtlasFile = new File(afterAtlasPath);
+
+        if (!beforeAtlasFile.exists())
+        {
+            this.outputDelegate.printlnWarnMessage("file not found: " + beforeAtlasPath);
+        }
+        if (!afterAtlasFile.exists())
+        {
+            this.outputDelegate.printlnWarnMessage("file not found: " + afterAtlasPath);
+        }
+
+        final Atlas beforeAtlas = new AtlasResourceLoader().load(beforeAtlasFile);
+        final Atlas afterAtlas = new AtlasResourceLoader().load(afterAtlasFile);
+
+        final AtlasDiff diff = new AtlasDiff(beforeAtlas, afterAtlas);
+        final Optional<Change> changeOptional = diff.generateChange();
+
+        if (changeOptional.isPresent())
+        {
+            final String changeJSON = changeOptional.get().toJson();
+            final File output = new File(DIFF_FILE);
+            output.writeAndClose(changeJSON);
+        }
+        else
+        {
+            this.outputDelegate.printlnWarnMessage("atlases are effectively identical");
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String getCommandName()
+    {
+        return "atlas-diff";
+    }
+
+    @Override
+    public String getSimpleDescription()
+    {
+        return "compare two atlas files";
+    }
+
+    @Override
+    public void registerManualPageSections()
+    {
+
+    }
+
+    @Override
+    public void registerOptionsAndArguments()
+    {
+        registerArgument(BEFORE_ATLAS_ARGUMENT, ArgumentArity.UNARY, ArgumentOptionality.REQUIRED);
+        registerArgument(AFTER_ATLAS_ARGUMENT, ArgumentArity.UNARY, ArgumentOptionality.REQUIRED);
+        super.registerOptionsAndArguments();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommand.java
@@ -14,6 +14,9 @@ import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgume
 import org.openstreetmap.atlas.utilities.command.parsing.ArgumentArity;
 import org.openstreetmap.atlas.utilities.command.parsing.ArgumentOptionality;
 
+/**
+ * @author lcram
+ */
 public class AtlasDiffCommand extends AbstractAtlasShellToolsCommand
 {
     private static final String BEFORE_ATLAS_ARGUMENT = "before-atlas";

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandDescriptionSection.txt
@@ -1,0 +1,3 @@
+Compute a diff between two atlases using the ChangeAtlas API. The command
+will write a geoJSON serialization of the diff to a file called 'diff.geojson' 
+in the current working directory.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandExamplesSection.txt
@@ -1,0 +1,2 @@
+Compute a diff between two atlases:
+#$ atlas-diff folder/atlas1.atlas atlas2.atlas


### PR DESCRIPTION
### Description:

A super simple tool to diff two atlases. Usage:
```
$ atlas atlas-diff before.atlas after.atlas
```
Output goes in a file called `diff.geojson` in the current working directory. The diff is the geojson-serialization of a [`Change` object.](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java)

### Potential Impact:

N/A

### Unit Test Approach:

Tested locally by running the command and checking the output.

### Test Results:

OK

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)