### PR TITLE
Added a protobuf conversion command, and tweaked atlas saving behaviour

### DIFF
--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -32,7 +32,7 @@ atlas\-config\-repo \-- Register and manage Atlas Shell Tools repositories
 \fIatlas\-config\fR \fIrepo\fR \fIadd\-gradle\-exclude\fR <repo\-name> <package>
 \fIatlas\-config\fR \fIrepo\fR \fIadd\-gradle\-skip\fR <repo\-name> <task>
 \fIatlas\-config\fR \fIrepo\fR \fIedit\fR <repo\-name>
-\fIatlas\-config\fR \fIrepo\fR \fIinstall\fR <repo\-name>
+\fIatlas\-config\fR \fIrepo\fR \fIinstall\fR <repo\-name> [\-\-ref=ref]
 \fIatlas\-config\fR \fIrepo\fR \fIlist\fR [repo\-name]
 \fIatlas\-config\fR \fIrepo\fR \fIremove\fR <repo\-name>
 .fi

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -510,6 +510,16 @@ public final class PackedAtlas extends AbstractAtlas
         return this.saveSerializationFormat;
     }
 
+    /**
+     * Get the serialization format with which this atlas was loaded.
+     *
+     * @return the format
+     */
+    public AtlasSerializationFormat getSerializationFormat()
+    {
+        return this.loadSerializationFormat;
+    }
+
     @Override
     public Line line(final long identifier)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -100,7 +100,7 @@ public final class PackedAtlasSerializer
         determineAtlasLoadFormat(atlas);
 
         return atlas;
-    };
+    }
 
     /*
      * Try loading the meta data to make sure the data format is appropriate. Keep trying formats

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -100,9 +100,8 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     SortedSet<Integer> getFilteredRegisteredContexts()
     {
         // filter out the default, hardcoded '--help' and '--version' contexts
-        final Set<Integer> set = this.parser.getRegisteredContexts().stream()
-                .filter(context -> context != HELP_OPTION_CONTEXT
-                        && context != VERSION_OPTION_CONTEXT)
+        final Set<Integer> set = this.parser.getRegisteredContexts().stream().filter(
+                context -> context != HELP_OPTION_CONTEXT && context != VERSION_OPTION_CONTEXT)
                 .collect(Collectors.toSet());
 
         return new TreeSet<>(set);

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -78,9 +78,9 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     private static final Character VERSION_OPTION_SHORT = 'V';
     private static final String VERSION_OPTION_DESCRIPTION = "Print the command version and exit.";
 
-    private static final int HELP_OPTION_CONTEXT_ID = 1;
-    private static final int VERSION_OPTION_CONTEXT_ID = 2;
-    private static final int DEFAULT_CONTEXT_ID = 3;
+    private static final int HELP_OPTION_CONTEXT = 1;
+    private static final int VERSION_OPTION_CONTEXT = 2;
+    public static final int DEFAULT_CONTEXT = 3;
 
     /*
      * Maximum allowed column width. If the user's terminal is very wide, we don't want to display
@@ -101,8 +101,8 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     {
         // filter out the default, hardcoded '--help' and '--version' contexts
         final Set<Integer> set = this.parser.getRegisteredContexts().stream()
-                .filter(context -> context != HELP_OPTION_CONTEXT_ID
-                        && context != VERSION_OPTION_CONTEXT_ID)
+                .filter(context -> context != HELP_OPTION_CONTEXT
+                        && context != VERSION_OPTION_CONTEXT)
                 .collect(Collectors.toSet());
 
         return new TreeSet<>(set);
@@ -244,10 +244,10 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     {
         // register --help and --version to contexts 1 and 2, respectively
         registerOption(HELP_OPTION_LONG, HELP_OPTION_SHORT, HELP_OPTION_DESCRIPTION,
-                OptionOptionality.REQUIRED, HELP_OPTION_CONTEXT_ID);
+                OptionOptionality.REQUIRED, HELP_OPTION_CONTEXT);
         registerOption(VERSION_OPTION_LONG, VERSION_OPTION_SHORT, VERSION_OPTION_DESCRIPTION,
-                OptionOptionality.REQUIRED, VERSION_OPTION_CONTEXT_ID);
-        registerEmptyContext(DEFAULT_CONTEXT_ID);
+                OptionOptionality.REQUIRED, VERSION_OPTION_CONTEXT);
+        registerEmptyContext(DEFAULT_CONTEXT);
 
         // register a default '--verbose' option in all contexts (except the --help and --version)
         final Integer[] contexts = this.getFilteredRegisteredContexts().toArray(new Integer[0]);
@@ -394,7 +394,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     {
         if (contexts.length == 0)
         {
-            this.parser.registerArgument(argumentHint, arity, optionality, DEFAULT_CONTEXT_ID);
+            this.parser.registerArgument(argumentHint, arity, optionality, DEFAULT_CONTEXT);
         }
         else
         {
@@ -438,7 +438,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         if (contexts.length == 0)
         {
             this.parser.registerOption(longForm, shortForm, description, optionality,
-                    DEFAULT_CONTEXT_ID);
+                    DEFAULT_CONTEXT);
         }
         else
         {
@@ -466,7 +466,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     {
         if (contexts.length == 0)
         {
-            this.parser.registerOption(longForm, description, optionality, DEFAULT_CONTEXT_ID);
+            this.parser.registerOption(longForm, description, optionality, DEFAULT_CONTEXT);
         }
         else
         {
@@ -503,7 +503,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         if (contexts.length == 0)
         {
             this.parser.registerOptionWithOptionalArgument(longForm, shortForm, description,
-                    optionality, argumentHint, DEFAULT_CONTEXT_ID);
+                    optionality, argumentHint, DEFAULT_CONTEXT);
         }
         else
         {
@@ -537,7 +537,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         if (contexts.length == 0)
         {
             this.parser.registerOptionWithOptionalArgument(longForm, description, optionality,
-                    argumentHint, DEFAULT_CONTEXT_ID);
+                    argumentHint, DEFAULT_CONTEXT);
         }
         else
         {
@@ -575,7 +575,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         if (contexts.length == 0)
         {
             this.parser.registerOptionWithRequiredArgument(longForm, shortForm, description,
-                    optionality, argumentHint, DEFAULT_CONTEXT_ID);
+                    optionality, argumentHint, DEFAULT_CONTEXT);
         }
         else
         {
@@ -610,7 +610,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         if (contexts.length == 0)
         {
             this.parser.registerOptionWithRequiredArgument(longForm, description, optionality,
-                    argumentHint, DEFAULT_CONTEXT_ID);
+                    argumentHint, DEFAULT_CONTEXT);
         }
         else
         {

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommand.java
@@ -18,7 +18,7 @@ import org.openstreetmap.atlas.utilities.command.subcommands.templates.VariadicA
  */
 public class ConcatenateAtlasCommand extends VariadicAtlasLoaderCommand
 {
-    private static final String OUTPUT_ATLAS = "output_fatlas.atlas";
+    private static final String OUTPUT_ATLAS = "output.atlas";
 
     private static final String DESCRIPTION_SECTION = "ConcatenateAtlasCommandDescriptionSection.txt";
     private static final String EXAMPLES_SECTION = "ConcatenateAtlasCommandExamplesSection.txt";

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
@@ -84,6 +84,6 @@ public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
     @Override
     public void registerManualPageSections()
     {
-        // TODO Auto-generated method stub
+        super.registerManualPageSections();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
@@ -11,10 +11,15 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas.AtlasSerializa
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
+import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.subcommands.templates.VariadicAtlasLoaderCommand;
 
 public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
 {
+    private static final String REVERSE_OPTION_LONG = "reverse";
+    private static final Character REVERSE_OPTION_SHORT = 'R';
+    private static final String REVERSE_OPTION_DESCRIPTION = "Convert a Protocol Buffers atlas back to Java serialization.";
+
     private static final String OUTPUT_ATLAS = "output.atlas";
 
     private final OptionAndArgumentDelegate optargDelegate;
@@ -55,7 +60,14 @@ public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
         }
         final PackedAtlas outputAtlas = (PackedAtlas) new AtlasResourceLoader()
                 .load(atlasResourceList);
-        outputAtlas.setSaveSerializationFormat(AtlasSerializationFormat.PROTOBUF);
+        if (this.optargDelegate.hasOption(REVERSE_OPTION_LONG))
+        {
+            outputAtlas.setSaveSerializationFormat(AtlasSerializationFormat.JAVA);
+        }
+        else
+        {
+            outputAtlas.setSaveSerializationFormat(AtlasSerializationFormat.PROTOBUF);
+        }
         final Path concatenatedPath = Paths.get(outputParentPath.get().toAbsolutePath().toString(),
                 OUTPUT_ATLAS);
         final File outputFile = new File(concatenatedPath.toAbsolutePath().toString());
@@ -72,18 +84,30 @@ public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
     @Override
     public String getCommandName()
     {
-        return "java-to-proto";
+        return "java2proto";
     }
 
     @Override
     public String getSimpleDescription()
     {
-        return "convert Java serialized atlases to protobuf format";
+        return "convert Java-serialized atlases to Protocol Buffers format";
     }
 
     @Override
     public void registerManualPageSections()
     {
+        addManualPageSection("DESCRIPTION", JavaToProtoSerializationCommand.class
+                .getResourceAsStream("JavaToProtoSerializationCommandDescriptionSection.txt"));
+        addManualPageSection("EXAMPLES", JavaToProtoSerializationCommand.class
+                .getResourceAsStream("JavaToProtoSerializationCommandExamplesSection.txt"));
         super.registerManualPageSections();
+    }
+
+    @Override
+    public void registerOptionsAndArguments()
+    {
+        registerOption(REVERSE_OPTION_LONG, REVERSE_OPTION_SHORT, REVERSE_OPTION_DESCRIPTION,
+                OptionOptionality.OPTIONAL);
+        super.registerOptionsAndArguments();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
@@ -15,6 +15,9 @@ import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.subcommands.templates.VariadicAtlasLoaderCommand;
 import org.openstreetmap.atlas.utilities.command.terminal.TTYAttribute;
 
+/**
+ * @author lcram
+ */
 public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
 {
     private static final String CHECK_OPTION_LONG = "check";

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommand.java
@@ -1,0 +1,89 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas.AtlasSerializationFormat;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
+import org.openstreetmap.atlas.utilities.command.subcommands.templates.VariadicAtlasLoaderCommand;
+
+public class JavaToProtoSerializationCommand extends VariadicAtlasLoaderCommand
+{
+    private static final String OUTPUT_ATLAS = "output.atlas";
+
+    private final OptionAndArgumentDelegate optargDelegate;
+    private final CommandOutputDelegate outputDelegate;
+
+    public static void main(final String[] args)
+    {
+        new JavaToProtoSerializationCommand().runSubcommandAndExit(args);
+    }
+
+    public JavaToProtoSerializationCommand()
+    {
+        super();
+        this.optargDelegate = this.getOptionAndArgumentDelegate();
+        this.outputDelegate = this.getCommandOutputDelegate();
+    }
+
+    @Override
+    public int execute()
+    {
+        final List<File> atlasResourceList = this.getInputAtlasResources();
+        if (atlasResourceList.isEmpty())
+        {
+            this.outputDelegate.printlnErrorMessage("no input atlases");
+            return 1;
+        }
+
+        final Optional<Path> outputParentPath = this.getOutputPath();
+        if (!outputParentPath.isPresent())
+        {
+            this.outputDelegate.printlnErrorMessage("invalid output path");
+            return 1;
+        }
+
+        if (this.optargDelegate.hasVerboseOption())
+        {
+            this.outputDelegate.printlnStdout("Cloning...");
+        }
+        final PackedAtlas outputAtlas = (PackedAtlas) new AtlasResourceLoader()
+                .load(atlasResourceList);
+        outputAtlas.setSaveSerializationFormat(AtlasSerializationFormat.PROTOBUF);
+        final Path concatenatedPath = Paths.get(outputParentPath.get().toAbsolutePath().toString(),
+                OUTPUT_ATLAS);
+        final File outputFile = new File(concatenatedPath.toAbsolutePath().toString());
+        outputAtlas.save(outputFile);
+
+        if (this.optargDelegate.hasVerboseOption())
+        {
+            this.outputDelegate.printlnStdout("Saved to " + concatenatedPath.toString());
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String getCommandName()
+    {
+        return "java-to-proto";
+    }
+
+    @Override
+    public String getSimpleDescription()
+    {
+        return "convert Java serialized atlases to protobuf format";
+    }
+
+    @Override
+    public void registerManualPageSections()
+    {
+        // TODO Auto-generated method stub
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
@@ -11,6 +11,7 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
@@ -145,52 +146,41 @@ public class PackedToTextAtlasCommand extends VariadicAtlasLoaderCommand
             return;
         }
 
+        final String filePath = this.getFileNameNoSuffix(resource);
+        final Path concatenatedPath = Paths.get(outputParentPath.get().toAbsolutePath().toString(),
+                filePath);
+        File outputFile = null;
+
         if (this.optargDelegate
                 .getParserContext() == AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT)
         {
-            final Path filePath = Paths.get(resource.getFile().getName() + FileSuffix.TEXT);
-            final Path concatenatedPath = Paths.get(
-                    outputParentPath.get().toAbsolutePath().toString(),
-                    filePath.getFileName().toString());
-            final File outputFile = new File(concatenatedPath.toAbsolutePath().toString());
+            outputFile = new File(concatenatedPath.toAbsolutePath().toString() + FileSuffix.TEXT);
             outputAtlas.saveAsText(outputFile);
-            if (this.optargDelegate.hasVerboseOption())
-            {
-                this.outputDelegate
-                        .printlnStdout(SAVED_TO + outputFile.getFile().getAbsolutePath());
-            }
         }
         else if (this.optargDelegate.getParserContext() == GEOJSON_CONTEXT)
         {
-            final Path filePath = Paths.get(resource.getFile().getName() + FileSuffix.GEO_JSON);
-            final Path concatenatedPath = Paths.get(
-                    outputParentPath.get().toAbsolutePath().toString(),
-                    filePath.getFileName().toString());
-            final File outputFile = new File(concatenatedPath.toAbsolutePath().toString());
+            outputFile = new File(
+                    concatenatedPath.toAbsolutePath().toString() + FileSuffix.GEO_JSON);
             outputAtlas.saveAsGeoJson(outputFile);
-            if (this.optargDelegate.hasVerboseOption())
-            {
-                this.outputDelegate
-                        .printlnStdout(SAVED_TO + outputFile.getFile().getAbsolutePath());
-            }
         }
-        else if (this.optargDelegate.getParserContext() == LDGEOJSON_CONTEXT
-                && this.optargDelegate.hasOption(LDGEOJSON_OPTION_LONG))
+        else if (this.optargDelegate.getParserContext() == LDGEOJSON_CONTEXT)
         {
-            final Path filePath = Paths.get(resource.getFile().getName() + FileSuffix.GEO_JSON);
-            final Path concatenatedPath = Paths.get(
-                    outputParentPath.get().toAbsolutePath().toString(),
-                    filePath.getFileName().toString());
-            final File outputFile = new File(concatenatedPath.toAbsolutePath().toString());
+            outputFile = new File(
+                    concatenatedPath.toAbsolutePath().toString() + FileSuffix.GEO_JSON);
             outputAtlas.saveAsLineDelimitedGeoJsonFeatures(outputFile, (entity, json) ->
             {
                 // Dummy consumer, we don't need to mutate the JSON
             });
-            if (this.optargDelegate.hasVerboseOption())
-            {
-                this.outputDelegate
-                        .printlnStdout(SAVED_TO + outputFile.getFile().getAbsolutePath());
-            }
+
+        }
+        else
+        {
+            throw new AtlasShellToolsException();
+        }
+
+        if (this.optargDelegate.hasVerboseOption())
+        {
+            this.outputDelegate.printlnStdout(SAVED_TO + outputFile.getFile().getAbsolutePath());
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
@@ -103,7 +103,7 @@ public class PackedToTextAtlasCommand extends VariadicAtlasLoaderCommand
     @Override
     public String getCommandName()
     {
-        return "packed-to-text";
+        return "packed2text";
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
@@ -33,7 +33,7 @@ public abstract class VariadicAtlasLoaderCommand extends AbstractAtlasShellTools
 
     private static final String OUTPUT_DIRECTORY_OPTION_LONG = "output";
     private static final Character OUTPUT_DIRECTORY_OPTION_SHORT = 'o';
-    private static final String OUTPUT_DIRECTORY_OPTION_DESCRIPTION = "Specify an alternate output directory for any output files. If the directory\n"
+    private static final String OUTPUT_DIRECTORY_OPTION_DESCRIPTION = "Specify an alternate output directory for any output files. If the directory "
             + "does not exist, it will be created.";
     private static final String OUTPUT_DIRECTORY_OPTION_HINT = "dir";
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
@@ -47,9 +47,26 @@ public abstract class VariadicAtlasLoaderCommand extends AbstractAtlasShellTools
         this.outputDelegate = this.getCommandOutputDelegate();
     }
 
+    public String getFileName(final File atlasResource)
+    {
+        return atlasResource.getName();
+    }
+
+    public String getFileNameNoSuffix(final File atlasResource)
+    {
+        final String name = getFileName(atlasResource);
+        final String[] split = name.split("\\.");
+        return split[0];
+    }
+
     public List<String> getFileNames(final List<File> atlasResources)
     {
-        return atlasResources.stream().map(File::getName).collect(Collectors.toList());
+        return atlasResources.stream().map(this::getFileName).collect(Collectors.toList());
+    }
+
+    public List<String> getFileNamesWithoutSuffixes(final List<File> atlasResources)
+    {
+        return atlasResources.stream().map(this::getFileNameNoSuffix).collect(Collectors.toList());
     }
 
     public List<File> getInputAtlasResources()

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/VariadicAtlasLoaderCommand.java
@@ -5,6 +5,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
@@ -44,6 +45,11 @@ public abstract class VariadicAtlasLoaderCommand extends AbstractAtlasShellTools
     {
         this.optargDelegate = this.getOptionAndArgumentDelegate();
         this.outputDelegate = this.getCommandOutputDelegate();
+    }
+
+    public List<String> getFileNames(final List<File> atlasResources)
+    {
+        return atlasResources.stream().map(File::getName).collect(Collectors.toList());
     }
 
     public List<File> getInputAtlasResources()

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasDiffCommandExamplesSection.txt
@@ -1,2 +1,2 @@
 Compute a diff between two atlases:
-#$ atlas-diff folder/atlas1.atlas atlas2.atlas
+#$ atlas-diff folder/before-atlas.atlas after-atlas.atlas

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommandDescriptionSection.txt
@@ -1,6 +1,6 @@
 The fatlas command provides an easy way to concatenate atlas files together
 using the MultiAtlas class. The command takes an arbitrary number of input
 atlas files, reads them into a MultiAtlas. and then saves that MultiAtlas to
-a file called 'output_fatlas.atlas' in the current working directory. The '--output'
+a file called 'output.atlas' in the current working directory. The '--output'
 option can be used to change this directory. See the ATLAS LOADER section
 for more info.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandDescriptionSection.txt
@@ -1,0 +1,2 @@
+Convert Java-serialized atlas(es) to Protocol Buffers format, in place. If desired, the reverse
+conversion can be performed using the '--reverse' option.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandDescriptionSection.txt
@@ -1,2 +1,3 @@
 Convert Java-serialized atlas(es) to Protocol Buffers format, in place. If desired, the reverse
-conversion can be performed using the '--reverse' option.
+conversion can be performed using the '--reverse' option. Additionally, the format can be checked
+using the '--check' option. When checking the format, no conversion will take place.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandExamplesSection.txt
@@ -2,3 +2,5 @@ Convert all atlases on your desktop to Protocol Buffers format:
 #$ java2proto ~/Desktop/*.atlas
 Convert an atlas from Protocol Buffers format back to Java format:
 #$ java2proto java.atlas --reverse
+Check the serialization format of some atlases in some folder:
+#$ java2proto --check some-folder/*.atlas

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/JavaToProtoSerializationCommandExamplesSection.txt
@@ -1,0 +1,4 @@
+Convert all atlases on your desktop to Protocol Buffers format:
+#$ java2proto ~/Desktop/*.atlas
+Convert an atlas from Protocol Buffers format back to Java format:
+#$ java2proto java.atlas --reverse

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandDescriptionSection.txt
@@ -1,9 +1,9 @@
 Transform a PackedAtlas (or multiple PackedAtlases) into a TextAtlas (or multiple TextAtlases).
 By default, the created text atlas files will be written to the current working directory.
-The names of the new text atlas files will be the same as the input files, but with an extra
-'.txt' extension.
+The names of the new text atlas files will be the same as the input files, but with a '.txt'
+extension instead of the usual '.atlas' extension.
 
 To save as GeoJSON instead of using the TextAtlas format, use the '--geojson' option.
 You can use line-delimited GeoJSON instead with '--ldgeojson'. Line-delimited GeoJSON
 is much easier to read, since the regular GeoJSON format is all on one line. When using
-GeoJSON, the new text atlas files will be created with the extra extension '.geojson'.
+GeoJSON, the new text atlas files will be created with the extension '.geojson'.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandExamplesSection.txt
@@ -1,12 +1,12 @@
 Transform 'file.atlas' into a text atlas:
-#$ packed-to-text file.atlas
+#$ packed2text file.atlas
 Transform all atlases on your desktop into text atlases, in parallel:
-#$ packed-to-text ~/Desktop/*.atlas --parallel
+#$ packed2text ~/Desktop/*.atlas --parallel
 Transform all atlases in your home folder to text atlases, and save
 them to a folder on your desktop
-#$ packed-to-text ~/*.atlas -o ~/Desktop/my-folder
+#$ packed2text ~/*.atlas -o ~/Desktop/my-folder
 Transform an atlas to GeoJSON:
-#$ packed-to-text file.atlas --geojson
+#$ packed2text file.atlas --geojson
 Transform an atlas to line-delimited GeoJSON, and fail fast if 
 it does not exist:
-#$ packed-to-text file.atlas -ls
+#$ packed2text file.atlas -l --strict


### PR DESCRIPTION
### Description:

Added a `java2proto` command. In-place conversion from Java-serialization to Protocol Buffers serialization. Can also do the reverse conversion or simply check/output the format without converting.

```
$ atlas java2proto *.atlas
$ atlas java2proto --reverse ~/Desktop/file.atlas
$ atlas java2proto --check some-folder/*.atlas
```

### Potential Impact:

N/A

### Unit Test Approach:

Extensively tested usage locally.

### Test Results:

Testing OK.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
