### PR TITLE
Tame too zealous validation on reverse edge v.2

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidator.java
@@ -61,36 +61,25 @@ public class ChangeValidator
                     final long forwardEdgeIdentifier = -backwardEdgeIdentifier;
 
                     final Edge backwardEdge = (Edge) backwardFeatureChange.getReference();
-                    final boolean backwardGeometryChange = backwardEdge.asPolyLine() != null
-                            || backwardEdge.start() != null || backwardEdge.end() != null;
                     final Optional<FeatureChange> forwardFeatureChangeOption = this.change
                             .changeFor(ItemType.EDGE, forwardEdgeIdentifier);
-                    if (backwardGeometryChange && !forwardFeatureChangeOption.isPresent())
+                    if (forwardFeatureChangeOption.isPresent())
                     {
-                        throw new CoreException(
-                                "Backward edge {} is {} but does not have a forward edge change reference present.",
-                                backwardEdgeIdentifier, backwardFeatureChange.getChangeType());
-                    }
-                    else if (!backwardGeometryChange && !forwardFeatureChangeOption.isPresent())
-                    {
-                        // This case is a non-geometry change on the backward edge only, which can
-                        // be ok.
-                        return;
-                    }
-
-                    final FeatureChange forwardFeatureChange = forwardFeatureChangeOption.get();
-                    if (forwardFeatureChange.getChangeType() != backwardFeatureChange
-                            .getChangeType())
-                    {
-                        throw new CoreException("Forward edge {} is {} when backward edge is {}",
-                                forwardEdgeIdentifier, forwardFeatureChange.getChangeType(),
-                                backwardFeatureChange.getChangeType());
-                    }
-                    if (forwardFeatureChange.getChangeType() == ChangeType.ADD)
-                    {
-                        final Edge forwardEdge = (Edge) forwardFeatureChange.getReference();
-                        validateEdgeConnectedNodesMatch(forwardEdge, backwardEdge);
-                        validateEdgePolyLinesMatch(forwardEdge, backwardEdge);
+                        final FeatureChange forwardFeatureChange = forwardFeatureChangeOption.get();
+                        if (forwardFeatureChange.getChangeType() != backwardFeatureChange
+                                .getChangeType())
+                        {
+                            throw new CoreException(
+                                    "Forward edge {} is {} when backward edge is {}",
+                                    forwardEdgeIdentifier, forwardFeatureChange.getChangeType(),
+                                    backwardFeatureChange.getChangeType());
+                        }
+                        if (forwardFeatureChange.getChangeType() == ChangeType.ADD)
+                        {
+                            final Edge forwardEdge = (Edge) forwardFeatureChange.getReference();
+                            validateEdgeConnectedNodesMatch(forwardEdge, backwardEdge);
+                            validateEdgePolyLinesMatch(forwardEdge, backwardEdge);
+                        }
                     }
                 });
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidatorTest.java
@@ -161,4 +161,13 @@ public class ChangeValidatorTest
                 new CompleteEdge(-123L, null, Maps.hashMap("key2", "value2"), null, null, null)));
         builder.get();
     }
+
+    @Test
+    public void testMissingForwardEdge()
+    {
+        final ChangeBuilder builder = new ChangeBuilder();
+        builder.add(new FeatureChange(ChangeType.ADD,
+                new CompleteEdge(-123L, PolyLine.TEST_POLYLINE, Maps.hashMap(), null, null, null)));
+        builder.get();
+    }
 }


### PR DESCRIPTION
### Description:

This is a followup to #331. It occurred to me that `AtlasDiff` has an option to forcefully add geometries to non-geometry updates, which means the geometry check on #331 was not working.

At that point, the only validation possible on Edges in ChangeValidator is when both forward and backward updates are present.

### Potential Impact:

Less AtlasDiff failures.

### Unit Test Approach:

Added one unit test, other tests pass.

### Test Results:

No other test.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)