### PR TITLE
use UUID as Atlas identifier to fix related serialization issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -279,7 +280,7 @@ public interface Atlas extends Located, Iterable<AtlasEntity>, Serializable
     /**
      * @return This Atlas' identifier
      */
-    int getIdentifier();
+    UUID getIdentifier();
 
     /**
      * @return This Atlas' optional name. If not specified, should return a String version of the

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -62,7 +62,6 @@ public abstract class BareAtlas implements Atlas
     private static final long serialVersionUID = 4733707438968864018L;
     public static final int MAXIMUM_RELATION_DEPTH = 500;
     private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
-    private static final AtomicInteger ATLAS_IDENTIFIER_FACTORY = new AtomicInteger();
 
     static
     {
@@ -71,13 +70,13 @@ public abstract class BareAtlas implements Atlas
 
     // Transient name
     private transient String name;
+    private final UUID identifier;
 
-    private final transient int identifier;
     private final transient SubAtlasCreator subAtlas;
 
     protected BareAtlas()
     {
-        this.identifier = ATLAS_IDENTIFIER_FACTORY.getAndIncrement();
+        this.identifier = UUID.randomUUID();
         this.subAtlas = new SubAtlasCreator(this);
     }
 
@@ -249,7 +248,7 @@ public abstract class BareAtlas implements Atlas
     }
 
     @Override
-    public int getIdentifier()
+    public UUID getIdentifier()
     {
         return this.identifier;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.complete;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -211,7 +212,7 @@ public class EmptyAtlas implements Atlas
     }
 
     @Override
-    public int getIdentifier()
+    public UUID getIdentifier()
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasBorderFixer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasBorderFixer.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -424,7 +425,7 @@ public class MultiAtlasBorderFixer implements Serializable
      *            nodes to be created
      * @param newEdges
      *            edges to be created
-     * @param relationIdentifiersToNewMembers
+     * @param newRelations
      *            relation identifiers to edges to be used for new relation creation
      */
     private Optional<Atlas> applyFixesToAtlas(final Map<Long, Node> newNodes,
@@ -634,7 +635,7 @@ public class MultiAtlasBorderFixer implements Serializable
     private List<TemporaryRoad> createRoadsPerSubAtlas(final long osmIdentifier,
             final List<Edge> edges)
     {
-        final Map<Integer, TemporaryRoad> edgesPerSubAtlas = new HashMap<>();
+        final Map<UUID, TemporaryRoad> edgesPerSubAtlas = new HashMap<>();
         for (final Atlas subAtlas : this.subAtlases)
         {
             edgesPerSubAtlas.put(subAtlas.getIdentifier(),

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -1,7 +1,13 @@
 package org.openstreetmap.atlas.geography.atlas;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.junit.Assert;
@@ -15,6 +21,7 @@ import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader.AtlasFileSele
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
@@ -182,5 +189,45 @@ public class AtlasResourceLoaderTest
                 .load(new InputStreamResource(() -> AtlasResourceLoaderTest.class
                         .getResourceAsStream("ECU_6-16-31.atlas")).withName("ECU_6-16-31.atlas"));
         Assert.assertEquals(null, atlasWithEdgesTertiaryOrGreater);
+    }
+
+    @Test
+    public void testAtlasSerialization() throws IOException, ClassNotFoundException
+    {
+        final String ATLAS_FILE_NAME = "ECU_6-16-31.atlas";
+
+        PackedAtlas atlas = (PackedAtlas) new AtlasResourceLoader().load(new InputStreamResource(
+                () -> AtlasResourceLoaderTest.class.getResourceAsStream(ATLAS_FILE_NAME))
+                        .withName("ECU_6-16-31.atlas"));
+        final UUID identifier = atlas.getIdentifier();
+        final long numOfEdges = atlas.numberOfEdges();
+        final long numOfNodes = atlas.numberOfNodes();
+
+        // plain simple serialization and deserialization
+        byte[] serialized = serialize(atlas);
+        PackedAtlas deserialized = (PackedAtlas) deserialize(serialized);
+
+        final UUID deserializedIdentifier = deserialized.getIdentifier();
+        final long deserializedNumOfEdges = deserialized.numberOfEdges();
+        final long deserializedNumOfNodes = deserialized.numberOfNodes();
+
+        assert (identifier.equals(deserializedIdentifier));
+        assert (numOfEdges == deserializedNumOfEdges);
+        assert (numOfNodes == deserializedNumOfNodes);
+    }
+
+    private static byte[] serialize(Object obj) throws IOException
+    {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        ObjectOutputStream o = new ObjectOutputStream(b);
+        o.writeObject(obj);
+        return b.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException
+    {
+        ByteArrayInputStream b = new ByteArrayInputStream(bytes);
+        ObjectInputStream o = new ObjectInputStream(b);
+        return o.readObject();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -196,9 +196,10 @@ public class AtlasResourceLoaderTest
     {
         final String atlasFileName = "ECU_6-16-31.atlas";
 
-        final PackedAtlas atlas = (PackedAtlas) new AtlasResourceLoader().load(new InputStreamResource(
-                () -> AtlasResourceLoaderTest.class.getResourceAsStream(atlasFileName))
-                        .withName("ECU_6-16-31.atlas"));
+        final PackedAtlas atlas = (PackedAtlas) new AtlasResourceLoader()
+                .load(new InputStreamResource(
+                        () -> AtlasResourceLoaderTest.class.getResourceAsStream(atlasFileName))
+                                .withName("ECU_6-16-31.atlas"));
         final UUID identifier = atlas.getIdentifier();
         final long numOfEdges = atlas.numberOfEdges();
         final long numOfNodes = atlas.numberOfNodes();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -194,40 +194,40 @@ public class AtlasResourceLoaderTest
     @Test
     public void testAtlasSerialization() throws IOException, ClassNotFoundException
     {
-        final String ATLAS_FILE_NAME = "ECU_6-16-31.atlas";
+        final String atlasFileName = "ECU_6-16-31.atlas";
 
-        PackedAtlas atlas = (PackedAtlas) new AtlasResourceLoader().load(new InputStreamResource(
-                () -> AtlasResourceLoaderTest.class.getResourceAsStream(ATLAS_FILE_NAME))
+        final PackedAtlas atlas = (PackedAtlas) new AtlasResourceLoader().load(new InputStreamResource(
+                () -> AtlasResourceLoaderTest.class.getResourceAsStream(atlasFileName))
                         .withName("ECU_6-16-31.atlas"));
         final UUID identifier = atlas.getIdentifier();
         final long numOfEdges = atlas.numberOfEdges();
         final long numOfNodes = atlas.numberOfNodes();
 
         // plain simple serialization and deserialization
-        byte[] serialized = serialize(atlas);
-        PackedAtlas deserialized = (PackedAtlas) deserialize(serialized);
+        final byte[] serialized = serialize(atlas);
+        final PackedAtlas deserialized = (PackedAtlas) deserialize(serialized);
 
         final UUID deserializedIdentifier = deserialized.getIdentifier();
         final long deserializedNumOfEdges = deserialized.numberOfEdges();
         final long deserializedNumOfNodes = deserialized.numberOfNodes();
 
-        assert (identifier.equals(deserializedIdentifier));
-        assert (numOfEdges == deserializedNumOfEdges);
-        assert (numOfNodes == deserializedNumOfNodes);
+        assert identifier.equals(deserializedIdentifier);
+        assert numOfEdges == deserializedNumOfEdges;
+        assert numOfNodes == deserializedNumOfNodes;
     }
 
-    private static byte[] serialize(Object obj) throws IOException
+    private static byte[] serialize(final Object obj) throws IOException
     {
-        ByteArrayOutputStream b = new ByteArrayOutputStream();
-        ObjectOutputStream o = new ObjectOutputStream(b);
-        o.writeObject(obj);
-        return b.toByteArray();
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+        objectOutputStream.writeObject(obj);
+        return byteArrayOutputStream.toByteArray();
     }
 
-    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException
+    private static Object deserialize(final byte[] bytes) throws IOException, ClassNotFoundException
     {
-        ByteArrayInputStream b = new ByteArrayInputStream(bytes);
-        ObjectInputStream o = new ObjectInputStream(b);
-        return o.readObject();
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        final ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+        return objectInputStream.readObject();
     }
 }


### PR DESCRIPTION
### Description:

Primitive type `int` was used as Atlas identifier and the field is marked as `transient`. During an experiment, an issue was triggered in `MultiAtlasBorderFixer`, since serialized Atlas object will not retain the identifier; reloaded Atlas will be assigned an integer as an identifier. 

This PR is intended to solve this problem by changing Atlas identifier to `java.util.UUID` and remove the `transient` identifier.

The change will guarantee that every single Atlas object will have a unique identifier and serialization/deserialization will not impact the identifier value.

### Potential Impact:

Should not have downstream impact.

### Unit Test Approach:

All the unit tests in the current project are passed, which means there is no regression.

New unit test with plain simple serialization/deserialization has been added.

### Test Results:
All unit tests (including newly added) has passed.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)