### PR TITLE
Deprecated a constructor in InputStreamResource

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
@@ -21,7 +21,8 @@ public class InputStreamResource extends AbstractResource
      * to many gotchas, since the resource becomes read-once. For e.g. loading an atlas from an
      * InputStreamResource will fail, since atlas uses an under-the-hood read to determine the
      * serialization format.
-     *
+     * 
+     * @deprecated
      * @param input
      *            the input stream
      */

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
@@ -33,7 +33,7 @@ public class InputStreamResource extends AbstractResource
 
     /**
      * The supplier given to this constructor should return a new input stream at each invocation to
-     * avoid any read-once gotchas. E.g. of a good supplier: () -> new FileInputStream("foo.txt")
+     * avoid any read-once gotchas. E.g. of a good supplier: () -&gt; new FileInputStream("foo.txt")
      *
      * @param inputStreamSupplier
      *            the stream supplier

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResource.java
@@ -16,11 +16,28 @@ public class InputStreamResource extends AbstractResource
 {
     private final Supplier<InputStream> inputStreamSupplier;
 
+    /**
+     * This constructor is deprecated. Creating an InputStreamResource using a raw InputStream leads
+     * to many gotchas, since the resource becomes read-once. For e.g. loading an atlas from an
+     * InputStreamResource will fail, since atlas uses an under-the-hood read to determine the
+     * serialization format.
+     *
+     * @param input
+     *            the input stream
+     */
+    @Deprecated
     public InputStreamResource(final InputStream input)
     {
         this(() -> input);
     }
 
+    /**
+     * The supplier given to this constructor should return a new input stream at each invocation to
+     * avoid any read-once gotchas. E.g. of a good supplier: () -> new FileInputStream("foo.txt")
+     *
+     * @param inputStreamSupplier
+     *            the stream supplier
+     */
     public InputStreamResource(final Supplier<InputStream> inputStreamSupplier)
     {
         this.inputStreamSupplier = inputStreamSupplier;


### PR DESCRIPTION
### Description:

The newly deprecated constructor often caused gotchas when reading atlases and other resources, since it created a read-once `InputStreamResource`

### Potential Impact:

N/A, other than the fact that some downstream code may now get notices they are using a deprecated API.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
