### PR TITLE
Add SyntheticDuplicateOsmNodeTag to AtlasTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/AtlasTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/AtlasTag.java
@@ -16,9 +16,9 @@ public final class AtlasTag
             new HashSet<>(Arrays.asList(LastEditTimeTag.KEY, LastEditUserIdentifierTag.KEY,
                     LastEditUserNameTag.KEY, LastEditVersionTag.KEY, LastEditChangesetTag.KEY)));
 
-    public static final Set<String> TAGS_FROM_ATLAS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(ISOCountryTag.KEY,
-                    SyntheticBoundaryNodeTag.KEY, SyntheticNearestNeighborCountryCodeTag.KEY)));
+    public static final Set<String> TAGS_FROM_ATLAS = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(ISOCountryTag.KEY, SyntheticBoundaryNodeTag.KEY,
+                    SyntheticDuplicateOsmNodeTag.KEY, SyntheticNearestNeighborCountryCodeTag.KEY)));
 
     private AtlasTag()
     {


### PR DESCRIPTION
### Description:

`SyntheticDuplicateOsmNodeTag` is a synthetic tag created by Atlas, and not a tag in the raw OSM data. It should not be returned by calls to `AtlasObject.getOsmTags()`.

### Potential Impact:

Checks that rely on `AtlasObject.getOsmTags()` to return tags for these synthetic nodes will be affected. See https://github.com/osmlab/atlas-checks/search?q=getOsmTags.

### Unit Test Approach:

No unit tests are added for this change.

### Test Results:

Atlas still builds with this change, and existing integration tests pass.