### PR TITLE
Improvements in ChangeBuilder and Change classes.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -188,13 +188,19 @@ public class Change implements Located, Serializable
     {
         // self check
         if (this == other)
+        {
             return true;
+        }
         // null check
         if (other == null)
+        {
             return false;
+        }
         // type check and cast
         if (getClass() != other.getClass())
+        {
             return false;
+        }
 
         final Change that = (Change) other;
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -170,5 +171,47 @@ public class Change implements Located, Serializable
         {
             this.bounds = featureBounds;
         }
+    }
+
+    /**
+     * An Object{@link #equals(Object)} implementation based on {@link #featureChanges} in the
+     * {@link Change} objects being compared.
+     *
+     * @param other
+     *            - the object to compare.
+     * @return boolean - true if the objects are equal
+     * @see Objects#equals(Object, Object)
+     * @see Object#equals(Object)
+     */
+    @Override
+    public boolean equals(final Object other)
+    {
+        // self check
+        if (this == other)
+            return true;
+        // null check
+        if (other == null)
+            return false;
+        // type check and cast
+        if (getClass() != other.getClass())
+            return false;
+
+        final Change that = (Change) other;
+
+        return Objects.equals(this.featureChanges, that.featureChanges);
+    }
+
+    /**
+     * An Object{@link #hashCode()} implementation based on {@link #featureChanges} in the
+     * {@link Change}.
+     *
+     * @return - the hash code.
+     * @see Objects#hashCode(Object)
+     * @see Object#hashCode()
+     */
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(this.featureChanges);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeBuilder.java
@@ -7,6 +7,7 @@ import org.openstreetmap.atlas.geography.atlas.change.validators.ChangeValidator
  * Construct a {@link Change}. This is a gatekeeper that ensures validation.
  *
  * @author matthieun
+ * @author Yazad Khambata
  */
 public class ChangeBuilder
 {
@@ -19,7 +20,23 @@ public class ChangeBuilder
         this.open = true;
     }
 
-    public synchronized void add(final FeatureChange featureChange)
+    /**
+     * A factory-method to construct a new {@link ChangeBuilder}. Constructs a {@code new}
+     * {@link ChangeBuilder} with default values.
+     *
+     * @return - a new ChangeBuilder.
+     */
+    public static ChangeBuilder newInstance()
+    {
+        return new ChangeBuilder();
+    }
+
+    /**
+     * @param featureChange
+     *            - teh {@link FeatureChange} to add to the builder.
+     * @return ChangeBuilder - returns itself to allow fluency in calls.
+     */
+    public synchronized ChangeBuilder add(final FeatureChange featureChange)
     {
         if (!this.open)
         {
@@ -27,6 +44,8 @@ public class ChangeBuilder
                     "Cannot append to a Change object that has already been validated");
         }
         this.change.add(featureChange);
+
+        return this;
     }
 
     public synchronized Change get()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeBuilderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeBuilderTest.java
@@ -1,0 +1,36 @@
+package org.openstreetmap.atlas.geography.atlas.change;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteArea;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteLine;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+
+/**
+ * @author Yazad Khambata
+ */
+public class ChangeBuilderTest
+{
+
+    public static final long TEST_IDENTIFIER = 123L;
+
+    @Test
+    public void fluency()
+    {
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
+                new CompleteArea(TEST_IDENTIFIER, null, Maps.hashMap(), null));
+
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
+                new CompleteLine(TEST_IDENTIFIER, null, Maps.hashMap(), null));
+
+        final ChangeBuilder verboseBuilder = new ChangeBuilder();
+        verboseBuilder.add(featureChange1);
+        verboseBuilder.add(featureChange2);
+        final Change verboseChange = verboseBuilder.get();
+
+        final Change fluentChange = ChangeBuilder.newInstance().add(featureChange1)
+                .add(featureChange2).get();
+
+        Assert.assertEquals(verboseChange, fluentChange);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeTest.java
@@ -14,26 +14,21 @@ import org.openstreetmap.atlas.utilities.collections.Maps;
 
 /**
  * @author matthieun
+ * @author Yazad Khambata
  */
 public class ChangeTest
 {
+    public static final long TEST_IDENTIFIER = 123L;
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testAdd()
     {
-        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
-                new CompleteArea(123L, null, Maps.hashMap(), null));
-        final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
-                new CompleteLine(123L, null, null, null));
-        final ChangeBuilder builder = new ChangeBuilder();
-        builder.add(featureChange1);
-        builder.add(featureChange2);
-        final Change change = builder.get();
+        final Change change = newChangeWithAreaAndLine();
 
-        Assert.assertTrue(change.changeFor(ItemType.AREA, 123L).isPresent());
-        Assert.assertTrue(change.changeFor(ItemType.LINE, 123L).isPresent());
+        Assert.assertTrue(change.changeFor(ItemType.AREA, TEST_IDENTIFIER).isPresent());
+        Assert.assertTrue(change.changeFor(ItemType.LINE, TEST_IDENTIFIER).isPresent());
     }
 
     @Test
@@ -43,9 +38,9 @@ public class ChangeTest
         this.expectedException.expectMessage("Cannot merge two feature changes");
 
         final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
-                new CompleteArea(123L, null, Maps.hashMap(), null));
+                new CompleteArea(TEST_IDENTIFIER, null, Maps.hashMap(), null));
         final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
-                new CompleteArea(123L, null, null, null));
+                new CompleteArea(TEST_IDENTIFIER, null, null, null));
         final ChangeBuilder builder = new ChangeBuilder();
         builder.add(featureChange1);
         builder.add(featureChange2);
@@ -54,17 +49,57 @@ public class ChangeTest
     @Test
     public void testAddSameIdentifierMerge()
     {
-        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
-                new CompleteArea(123L, null, Maps.hashMap("key", "value"), null));
-        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD,
-                new CompleteArea(123L, Polygon.TEST_BUILDING, null, null));
-        final ChangeBuilder builder = new ChangeBuilder();
-        builder.add(featureChange1);
-        builder.add(featureChange2);
-        final Change result = builder.get();
-        final FeatureChange merged = result.changeFor(ItemType.AREA, 123L).get();
+        final Change result = newChangeWith2Areas();
+        final FeatureChange merged = result.changeFor(ItemType.AREA, TEST_IDENTIFIER).get();
         final Area area = (Area) merged.getReference();
         Assert.assertEquals(Polygon.TEST_BUILDING, area.asPolygon());
         Assert.assertEquals(Maps.hashMap("key", "value"), area.getTags());
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        final Change changeWithAreaAndLine1 = newChangeWithAreaAndLine();
+        final Change changeWithAreaAndLine2 = newChangeWithAreaAndLine();
+
+        Assert.assertTrue(changeWithAreaAndLine1 != changeWithAreaAndLine2);
+
+        Assert.assertEquals(changeWithAreaAndLine1, changeWithAreaAndLine2);
+        Assert.assertEquals(changeWithAreaAndLine1.hashCode(), changeWithAreaAndLine2.hashCode());
+
+        final Change changeWith2Areas1 = newChangeWith2Areas();
+        final Change changeWith2Areas2 = newChangeWith2Areas();
+
+        Assert.assertTrue(changeWith2Areas1 != changeWith2Areas2);
+
+        Assert.assertEquals(changeWith2Areas1, changeWith2Areas2);
+        Assert.assertEquals(changeWith2Areas1.hashCode(), changeWith2Areas2.hashCode());
+
+        Assert.assertNotEquals(changeWithAreaAndLine1, changeWith2Areas1);
+        Assert.assertNotEquals(changeWithAreaAndLine1.hashCode(), changeWith2Areas1.hashCode());
+    }
+
+    private Change newChangeWithAreaAndLine()
+    {
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
+                new CompleteArea(TEST_IDENTIFIER, null, Maps.hashMap(), null));
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
+                new CompleteLine(TEST_IDENTIFIER, null, null, null));
+        final ChangeBuilder builder = new ChangeBuilder();
+        builder.add(featureChange1);
+        builder.add(featureChange2);
+        return builder.get();
+    }
+
+    private Change newChangeWith2Areas()
+    {
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
+                new CompleteArea(TEST_IDENTIFIER, null, Maps.hashMap("key", "value"), null));
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD,
+                new CompleteArea(TEST_IDENTIFIER, Polygon.TEST_BUILDING, null, null));
+        final ChangeBuilder builder = new ChangeBuilder();
+        builder.add(featureChange1);
+        builder.add(featureChange2);
+        return builder.get();
     }
 }


### PR DESCRIPTION
### Description:

Minor improvements in ChangeBuilder and related classes,

1. `ChangeBuilder` is now _fluent_,

example,

instead of writing,
```java
        final ChangeBuilder verboseBuilder = new ChangeBuilder();
        verboseBuilder.add(featureChange1);
        verboseBuilder.add(featureChange2);
        final Change verboseChange = verboseBuilder.get();
```

one can now write,

```java
final Change fluentChange = ChangeBuilder.newInstance()
                                               .add(featureChange1)
                                               .add(featureChange2)
                                               .get();
```

2. Added missing `equals` and `hashCode` in `Change`, based on `featureChanges`.

3. Added a new test case for the above.

### Potential Impact:

None expected, besides improvement in usage of the API.

### Unit Test Approach:

Created various changes and then compared them as a part of the testing.

### Test Results:

`ChangeBuilder` when used fluently or otherwise does not lead to any differences in the underlying `Change` created. `Change`(s) can now be checked for equity.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
