### PR TITLE
TaggableFilter with double negative

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/Taggable.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/Taggable.java
@@ -98,7 +98,10 @@ public interface Taggable
                     if (candidate.length() > 1)
                     {
                         final String forbiddenValue = candidate.substring(1);
-                        return !value.equalsIgnoreCase(forbiddenValue);
+                        if (!value.equalsIgnoreCase(forbiddenValue))
+                        {
+                            return true;
+                        }
                     }
                     else
                     {

--- a/src/main/java/org/openstreetmap/atlas/tags/filters/README.md
+++ b/src/main/java/org/openstreetmap/atlas/tags/filters/README.md
@@ -58,6 +58,12 @@ water->!pond,!lake
 Anything without water=pond or without water=lake. That one is not very useful as it is always true because one of the two will always be true (The water tag can have only one value).
 
 ```
+water->!pond&water->!lake
+```
+
+Anything without water=pond and without water=lake.
+
+```
 water->!
 ```
 

--- a/src/main/java/org/openstreetmap/atlas/tags/filters/README.md
+++ b/src/main/java/org/openstreetmap/atlas/tags/filters/README.md
@@ -55,7 +55,7 @@ Anything without water=pond
 water->!pond,!lake
 ```
 
-Anything without water=pond or water=lake
+Anything without water=pond or without water=lake. That one is not very useful as it is always true because one of the two will always be true (The water tag can have only one value).
 
 ```
 water->!

--- a/src/test/java/org/openstreetmap/atlas/tags/filters/TaggableFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/filters/TaggableFilterTest.java
@@ -60,6 +60,21 @@ public class TaggableFilterTest
     }
 
     @Test
+    public void testDoubleNegative()
+    {
+        final String definition = "water->!pond,!lake";
+        final TaggableFilter filter = TaggableFilter.forDefinition(definition);
+
+        Assert.assertTrue(filter.test(Taggable.with()));
+        // Pond, but not lake -> true
+        Assert.assertTrue(filter.test(Taggable.with("water", "pond")));
+        // Lake, but not pond -> true
+        Assert.assertTrue(filter.test(Taggable.with("water", "lake")));
+        // Not ponf, not lake. -> true
+        Assert.assertTrue(filter.test(Taggable.with("water", "sea")));
+    }
+
+    @Test
     public void testParsing()
     {
         // amenity=bus_station OR highway=bus_stop OR ( (bus=* OR trolleybus=*) AND


### PR DESCRIPTION
### Description:

Fix for issue #314.

The scheme `A->X,Y` means the tag `A` has value `X` OR value `Y`. In case of double negative (`A->!X,!Y`), the result is always true as it is equivalent "Tag A has (NOT value X OR NOT value Y)" thus "Tag A has NOT (value X AND value Y)". Because "Tag A has (value X AND value Y)" is impossible and always false, the former is always true.

### Potential Impact:

This might impact everything using `TaggableFilter` that might have benefited from that silent error. (`AtlasStatistics`, `ConfiguredTaggableFilter`)

### Unit Test Approach:

Added one extra unit test.

### Test Results:

Ran integration tests and they pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)