### PR TITLE
Fixed a class cast bug with Node merging

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -59,6 +59,7 @@ public class FeatureChange implements Located, Serializable
     private static final long serialVersionUID = 9172045162819925515L;
     private static final BinaryOperator<Map<String, String>> tagMerger = Maps::withMaps;
     private static final BinaryOperator<Set<Long>> directReferenceMerger = Sets::withSets;
+    private static final BinaryOperator<SortedSet<Long>> directReferenceMergerSorted = Sets::withSortedSets;
     private static final BinaryOperator<Set<Long>> directReferenceMergerLoose = (left,
             right) -> Sets.withSets(false, left, right);
     private static final BinaryOperator<RelationBean> relationBeanMerger = RelationBean::merge;
@@ -362,18 +363,18 @@ public class FeatureChange implements Located, Serializable
                 atlasEntity -> ((LocationItem) atlasEntity).getLocation(), Optional.empty());
         if (thisReference instanceof Node)
         {
-            final SortedSet<Long> mergedInEdgeIdentifiers = (SortedSet<Long>) mergedMember(
-                    "inEdgeIdentifiers", thisReference, thatReference,
+            final SortedSet<Long> mergedInEdgeIdentifiers = mergedMember("inEdgeIdentifiers",
+                    thisReference, thatReference,
                     atlasEntity -> ((Node) atlasEntity).inEdges() == null ? null
                             : ((Node) atlasEntity).inEdges().stream().map(Edge::getIdentifier)
                                     .collect(Collectors.toCollection(TreeSet::new)),
-                    Optional.of(directReferenceMerger));
-            final SortedSet<Long> mergedOutEdgeIdentifiers = (SortedSet<Long>) mergedMember(
-                    "outEdgeIdentifiers", thisReference, thatReference,
+                    Optional.of(directReferenceMergerSorted));
+            final SortedSet<Long> mergedOutEdgeIdentifiers = mergedMember("outEdgeIdentifiers",
+                    thisReference, thatReference,
                     atlasEntity -> ((Node) atlasEntity).outEdges() == null ? null
                             : ((Node) atlasEntity).outEdges().stream().map(Edge::getIdentifier)
                                     .collect(Collectors.toCollection(TreeSet::new)),
-                    Optional.of(directReferenceMerger));
+                    Optional.of(directReferenceMergerSorted));
             CompleteNode result = new CompleteNode(getIdentifier(), mergedLocation, mergedTags,
                     mergedInEdgeIdentifiers, mergedOutEdgeIdentifiers, mergedParentRelations);
             if (result.bounds() == null)

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/Sets.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/Sets.java
@@ -66,6 +66,32 @@ public final class Sets
         return withSets(true, items);
     }
 
+    @SafeVarargs
+    public static <V> SortedSet<V> withSortedSets(final SortedSet<V>... items)
+    {
+        if (items.length == 0)
+        {
+            return new TreeSet<>();
+        }
+        if (items.length == 1)
+        {
+            return items[0];
+        }
+        final SortedSet<V> result = new TreeSet<>();
+        for (final SortedSet<V> item : items)
+        {
+            for (final V entry : item)
+            {
+                if (result.contains(entry))
+                {
+                    throw new CoreException("Cannot merge sets! Collision on element.");
+                }
+                result.add(entry);
+            }
+        }
+        return result;
+    }
+
     private Sets()
     {
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +23,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.LineItem;
 import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.Maps;
@@ -109,6 +112,25 @@ public class FeatureChangeTest
                 new CompletePoint(123L, Location.COLOSSEUM, null, null));
         Assert.assertEquals(Location.COLOSSEUM,
                 ((LocationItem) featureChange1.merge(featureChange2).getReference()).getLocation());
+    }
+
+    @Test
+    public void testMergeNodes()
+    {
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
+                new CompleteNode(123L, Location.COLOSSEUM, null, Sets.treeSet(1L, 2L, 3L),
+                        Sets.treeSet(10L, 11L, 13L), null));
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD,
+                new CompleteNode(123L, Location.COLOSSEUM, null, Sets.treeSet(1L, 2L, 3L),
+                        Sets.treeSet(10L, 11L, 13L), null));
+
+        // Testing with a hashset instead of a treeset for ease of typing
+        Assert.assertEquals(Sets.hashSet(1L, 2L, 3L),
+                ((Node) featureChange1.merge(featureChange2).getReference()).inEdges().stream()
+                        .map(edge -> edge.getIdentifier()).collect(Collectors.toSet()));
+        Assert.assertEquals(Sets.hashSet(10L, 11L, 13L),
+                ((Node) featureChange1.merge(featureChange2).getReference()).outEdges().stream()
+                        .map(edge -> edge.getIdentifier()).collect(Collectors.toSet()));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Previously, the `LocationItem` merging code in `FeatureChange` would fail to merge `Node`s with different in/out edge sets due to a class cast exception (`HashSet` vs `SortedSet`). This has been resolved.

### Potential Impact:

Clients of `FeatureChange` depending on broken behavior may need to update.

### Unit Test Approach:

All current tests continue to pass. Added a new test to show this behaviour.

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)