### PR TITLE
TurnRestriction: catch errors in TurnRestriction route()

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
@@ -331,19 +331,19 @@ public final class TurnRestriction implements Located, Serializable
                 viaMember = Route.buildFullRouteIgnoringReverseEdges(viaEdges,
                         fromMember.end().end(), toMember.start().start());
             }
-            // Make sure building the route works.
+            this.from = fromMember;
+            this.via = viaMember;
+            this.too = toMember;
+            // Make sure that the route can be built
             route();
         }
         catch (final CoreException e)
         {
             logger.trace("Could not build TurnRestriction from relation {}", relation, e);
-            fromMember = null;
-            viaMember = null;
-            toMember = null;
+            this.from = null;
+            this.via = null;
+            this.too = null;
         }
-        this.from = fromMember;
-        this.via = viaMember;
-        this.too = toMember;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
@@ -331,6 +331,8 @@ public final class TurnRestriction implements Located, Serializable
                 viaMember = Route.buildFullRouteIgnoringReverseEdges(viaEdges,
                         fromMember.end().end(), toMember.start().start());
             }
+            // Make sure building the route works.
+            route();
         }
         catch (final CoreException e)
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.items.complex.restriction;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -54,6 +55,16 @@ public class ComplexTurnRestrictionTest
 
         Assert.assertTrue(!bigNode.allPaths().isEmpty());
         Assert.assertTrue(bigNode.turnRestrictions().isEmpty());
+    }
+
+    @Test
+    public void testBrokenRoute()
+    {
+        final List<Integer> counter = new ArrayList<>();
+        counter.add(0);
+        new ComplexTurnRestrictionFinder(null).find(this.rule.getAtlasBrokenTurnRestrictionRoute(),
+                broken -> counter.set(0, counter.get(0) + 1)).forEach(System.out::println);
+        Assert.assertEquals(new Integer(1), counter.get(0));
     }
 
     @Test
@@ -171,6 +182,16 @@ public class ComplexTurnRestrictionTest
     }
 
     @Test
+    public void testTurnRestrictionNoUTurn()
+    {
+        // Test edge as via member
+        final Atlas testAtlas = this.rule.getAtlasNoUTurn();
+        final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
+                .from(testAtlas.relation(1L));
+        Assert.assertTrue(possibleTurnRestriction.isPresent());
+    }
+
+    @Test
     public void testTurnRestrictionsFromComplexBigNodes()
     {
         final int expectedCountOfRestrictedRoutes = 302;
@@ -206,15 +227,5 @@ public class ComplexTurnRestrictionTest
         final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
                 .from(testAtlas.relation(1L));
         Assert.assertEquals(Optional.empty(), possibleTurnRestriction);
-    }
-
-    @Test
-    public void testTurnRestrictionNoUTurn()
-    {
-        // Test edge as via member
-        final Atlas testAtlas = this.rule.getAtlasNoUTurn();
-        final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
-                .from(testAtlas.relation(1L));
-        Assert.assertTrue(possibleTurnRestriction.isPresent());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
@@ -31,7 +31,15 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "4", coordinates = @Loc(value = FOUR)),
                     @Node(id = "5", coordinates = @Loc(value = SIX)),
 
-            }, edges = { @Edge(id = "102", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = { "highway=trunk" }), @Edge(id = "203", coordinates = { @Loc(value = TWO), @Loc(value = THREE) }, tags = { "highway=trunk" }), @Edge(id = "204", coordinates = { @Loc(value = TWO), @Loc(value = FOUR) }, tags = { "highway=trunk" }), @Edge(id = "205", coordinates = { @Loc(value = TWO), @Loc(value = SIX) }, tags = { "highway=trunk" })
+            }, edges = {
+                    @Edge(id = "102", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=trunk" }),
+                    @Edge(id = "203", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=trunk" }),
+                    @Edge(id = "204", coordinates = { @Loc(value = TWO),
+                            @Loc(value = FOUR) }, tags = { "highway=trunk" }),
+                    @Edge(id = "205", coordinates = { @Loc(value = TWO),
+                            @Loc(value = SIX) }, tags = { "highway=trunk" })
 
             }, relations = {
 
@@ -54,7 +62,17 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "4", coordinates = @Loc(value = FOUR)),
                     @Node(id = "5", coordinates = @Loc(value = FIVE))
 
-            }, edges = { @Edge(id = "102", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = { "highway=trunk" }), @Edge(id = "-102", coordinates = { @Loc(value = TWO), @Loc(value = ONE) }, tags = { "highway=trunk" }), @Edge(id = "203", coordinates = { @Loc(value = TWO), @Loc(value = THREE) }, tags = { "highway=trunk" }), @Edge(id = "204", coordinates = { @Loc(value = TWO), @Loc(value = FOUR) }, tags = { "highway=trunk" }), @Edge(id = "205", coordinates = { @Loc(value = TWO), @Loc(value = FIVE) }, tags = { "highway=trunk" })
+            }, edges = {
+                    @Edge(id = "102", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-102", coordinates = { @Loc(value = TWO),
+                            @Loc(value = ONE) }, tags = { "highway=trunk" }),
+                    @Edge(id = "203", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=trunk" }),
+                    @Edge(id = "204", coordinates = { @Loc(value = TWO),
+                            @Loc(value = FOUR) }, tags = { "highway=trunk" }),
+                    @Edge(id = "205", coordinates = { @Loc(value = TWO),
+                            @Loc(value = FIVE) }, tags = { "highway=trunk" })
 
             }, relations = {
 
@@ -77,7 +95,11 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "1", coordinates = @Loc(value = ONE)),
                     @Node(id = "2", coordinates = @Loc(value = TWO)),
 
-            }, edges = { @Edge(id = "102", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = { "highway=trunk" }), @Edge(id = "-102", coordinates = { @Loc(value = TWO), @Loc(value = ONE) }, tags = { "highway=trunk" })
+            }, edges = {
+                    @Edge(id = "102", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=trunk" }),
+                    @Edge(id = "-102", coordinates = { @Loc(value = TWO),
+                            @Loc(value = ONE) }, tags = { "highway=trunk" })
 
             }, relations = {
 
@@ -101,7 +123,15 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "4", coordinates = @Loc(value = FOUR)),
                     @Node(id = "6", coordinates = @Loc(value = SIX))
 
-            }, edges = { @Edge(id = "102", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = { "highway=trunk" }), @Edge(id = "203", coordinates = { @Loc(value = TWO), @Loc(value = THREE) }, tags = { "highway=trunk" }), @Edge(id = "304", coordinates = { @Loc(value = THREE), @Loc(value = FOUR) }, tags = { "highway=trunk" }), @Edge(id = "205", coordinates = { @Loc(value = TWO), @Loc(value = SIX) }, tags = { "highway=trunk" })
+            }, edges = {
+                    @Edge(id = "102", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=trunk" }),
+                    @Edge(id = "203", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=trunk" }),
+                    @Edge(id = "304", coordinates = { @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "highway=trunk" }),
+                    @Edge(id = "205", coordinates = { @Loc(value = TWO),
+                            @Loc(value = SIX) }, tags = { "highway=trunk" })
 
             }, relations = {
 
@@ -114,9 +144,22 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
             })
     private Atlas atlasNoUTurn;
 
+    @TestAtlas(loadFromJosmOsmResource = "atlasBrokenTurnRestrictionRoute.josm.osm")
+    private Atlas atlasBrokenTurnRestrictionRoute;
+
+    public Atlas getAtlasBrokenTurnRestrictionRoute()
+    {
+        return this.atlasBrokenTurnRestrictionRoute;
+    }
+
     public Atlas getAtlasNo()
     {
         return this.atlasNo;
+    }
+
+    public Atlas getAtlasNoUTurn()
+    {
+        return this.atlasNoUTurn;
     }
 
     public Atlas getAtlasOnly()
@@ -132,10 +175,5 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
     public Atlas getRelationWithTwoViaNodes()
     {
         return this.relationWithTwoViaNodes;
-    }
-
-    public Atlas getAtlasNoUTurn()
-    {
-        return this.atlasNoUTurn;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTestCaseRule.java
@@ -32,6 +32,7 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "5", coordinates = @Loc(value = SIX)),
 
             }, edges = {
+
                     @Edge(id = "102", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=trunk" }),
                     @Edge(id = "203", coordinates = { @Loc(value = TWO),
@@ -63,6 +64,7 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "5", coordinates = @Loc(value = FIVE))
 
             }, edges = {
+
                     @Edge(id = "102", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=trunk" }),
                     @Edge(id = "-102", coordinates = { @Loc(value = TWO),
@@ -96,6 +98,7 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "2", coordinates = @Loc(value = TWO)),
 
             }, edges = {
+
                     @Edge(id = "102", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=trunk" }),
                     @Edge(id = "-102", coordinates = { @Loc(value = TWO),
@@ -124,6 +127,7 @@ public class ComplexTurnRestrictionTestCaseRule extends CoreTestRule
                     @Node(id = "6", coordinates = @Loc(value = SIX))
 
             }, edges = {
+
                     @Edge(id = "102", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=trunk" }),
                     @Edge(id = "203", coordinates = { @Loc(value = TWO),

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/atlasBrokenTurnRestrictionRoute.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/atlasBrokenTurnRestrictionRoute.josm.osm
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-53448' action='modify' visible='true' lat='34.62756192874' lon='18.16333885978' />
+  <node id='-53450' action='modify' visible='true' lat='34.62784735183' lon='18.16365936012' />
+  <node id='-53452' action='modify' visible='true' lat='34.62764199447' lon='18.16434643406'>
+    <tag k='highway' v='traffic_signals' />
+  </node>
+  <node id='-53454' action='modify' visible='true' lat='34.62837215166' lon='18.16493183339' />
+  <node id='-53456' action='modify' visible='true' lat='34.62822003611' lon='18.16460524219' />
+  <way id='-53458' action='modify' visible='true'>
+    <nd ref='-53448' />
+    <nd ref='-53450' />
+    <nd ref='-53452' />
+    <tag k='highway' v='primary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-53460' action='modify' visible='true'>
+    <nd ref='-53452' />
+    <nd ref='-53456' />
+    <nd ref='-53454' />
+    <tag k='highway' v='secondary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <relation id='-53462' action='modify' visible='true'>
+    <member type='way' ref='-53460' role='via' />
+    <member type='way' ref='-53460' role='to' />
+    <member type='way' ref='-53458' role='from' />
+    <tag k='restriction' v='no_left_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>


### PR DESCRIPTION
### Description:

TurnRestriction could fail in some corner cases in the `route()` call. This allows catching this error early. See new unit test for details: The via and to edges are the same, and both are one way. This would have made it past the constructor, but not through the route call.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1944860/53135837-9c180400-3531-11e9-8af6-d2b5e9591347.png">

### Potential Impact:

The isValid call does not throw exceptions anymore.

### Unit Test Approach:

Added one unit test

### Test Results:

Verified that other unit tests still pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
