### PR TITLE
bug fix in Polygon isClockwise method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -720,7 +720,7 @@ public class Polygon extends PolyLine implements GeometricSurface
     }
 
     /**
-     * This method will return cartesian equivqlent coordinates for earth coordinates
+     * This method will return cartesian equivalent coordinates for earth coordinates
      * 
      * @return Tuple which represents X and Y on catesian plane
      * @see <a href=

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/GeodeticEarthCenteredEarthFixedConverter.java
@@ -61,6 +61,8 @@ public class GeodeticEarthCenteredEarthFixedConverter
 
         final double height = coordinate.getAltitude().asMeters();
 
+        // getting positive angles for latitude/longitude is okay as the angles would be the same.
+        // For example, cos(-30) == cos(330) and sin(-30) == sin(330)
         final double xValue = (radiusOfCurviture + height)
                 * Math.cos(coordinate.getLatitude().asPositiveRadians())
                 * Math.cos(coordinate.getLongitude().asPositiveRadians());

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -241,8 +241,8 @@ public class PolygonTest
     {
         // Shape represents a square with an additional smaller square on each corner, formed by 4
         // self intersections
-        final Polygon polygon = Polygon.wkt(
-                "POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
+        final Polygon polygon = Polygon
+                .wkt("POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
                         + "-0.0368309 -0.0268596, -0.03728 -0.0141933, 0.0270392 -0.0132052, 0.0273986 -0.0246138,"
                         + " 0.0171578 -0.0248833, 0.0153611 0.0342258, 0.0253324 0.0344953, 0.0257816 0.0256918, "
                         + "-0.0380885 0.0238053))");
@@ -675,8 +675,8 @@ public class PolygonTest
     public void testSelfIntersectingPolygon()
     {
         // shape is a figure 8, self intersecting in the middle
-        final Polygon polygon = Polygon.wkt(
-                "POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
+        final Polygon polygon = Polygon
+                .wkt("POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
                         + " -0.007995 -0.0128459, -0.0007186 -0.0194934, 0.0103306 -0.0186849, 0.0125764 -0.0098814, "
                         + "0.0026051 -0.0048509, -0.013834 -0.0050305, -0.0242545 -0.0008983, -0.0256918 0.0054797))");
         final Location area1 = Location.forString("0.0034136, -0.016529");

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -81,8 +81,10 @@ public class PolygonTest
     @Test
     public void testClockwise()
     {
-        Assert.assertTrue(this.quadrant.isClockwise());
-        Assert.assertFalse(this.quadrant.reversed().isClockwise());
+        String polygonWkt = "POLYGON ((-70.0020146 12.5265405, -70.0019978 12.5265112, -70.0019564 12.526534, -70.0019733 12.5265633, -70.0020146 12.5265405))";
+        Polygon polygon = Polygon.wkt(polygonWkt);
+        Assert.assertFalse(polygon.isClockwise());
+        Assert.assertTrue(polygon.reversed().isClockwise());
     }
 
     @Test
@@ -239,8 +241,8 @@ public class PolygonTest
     {
         // Shape represents a square with an additional smaller square on each corner, formed by 4
         // self intersections
-        final Polygon polygon = Polygon
-                .wkt("POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
+        final Polygon polygon = Polygon.wkt(
+                "POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
                         + "-0.0368309 -0.0268596, -0.03728 -0.0141933, 0.0270392 -0.0132052, 0.0273986 -0.0246138,"
                         + " 0.0171578 -0.0248833, 0.0153611 0.0342258, 0.0253324 0.0344953, 0.0257816 0.0256918, "
                         + "-0.0380885 0.0238053))");
@@ -673,8 +675,8 @@ public class PolygonTest
     public void testSelfIntersectingPolygon()
     {
         // shape is a figure 8, self intersecting in the middle
-        final Polygon polygon = Polygon
-                .wkt("POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
+        final Polygon polygon = Polygon.wkt(
+                "POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
                         + " -0.007995 -0.0128459, -0.0007186 -0.0194934, 0.0103306 -0.0186849, 0.0125764 -0.0098814, "
                         + "0.0026051 -0.0048509, -0.013834 -0.0050305, -0.0242545 -0.0008983, -0.0256918 0.0054797))");
         final Location area1 = Location.forString("0.0034136, -0.016529");

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -81,8 +81,8 @@ public class PolygonTest
     @Test
     public void testClockwise()
     {
-        String polygonWkt = "POLYGON ((-70.0020146 12.5265405, -70.0019978 12.5265112, -70.0019564 12.526534, -70.0019733 12.5265633, -70.0020146 12.5265405))";
-        Polygon polygon = Polygon.wkt(polygonWkt);
+        final String polygonWkt = "POLYGON ((-70.0020146 12.5265405, -70.0019978 12.5265112, -70.0019564 12.526534, -70.0019733 12.5265633, -70.0020146 12.5265405))";
+        final Polygon polygon = Polygon.wkt(polygonWkt);
         Assert.assertFalse(polygon.isClockwise());
         Assert.assertTrue(polygon.reversed().isClockwise());
     }
@@ -241,8 +241,8 @@ public class PolygonTest
     {
         // Shape represents a square with an additional smaller square on each corner, formed by 4
         // self intersections
-        final Polygon polygon = Polygon
-                .wkt("POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
+        final Polygon polygon = Polygon.wkt(
+                "POLYGON ((-0.0380885 0.0238053, -0.0381783 0.0334173, -0.0255121 0.0337766, -0.0247036 -0.0263206, "
                         + "-0.0368309 -0.0268596, -0.03728 -0.0141933, 0.0270392 -0.0132052, 0.0273986 -0.0246138,"
                         + " 0.0171578 -0.0248833, 0.0153611 0.0342258, 0.0253324 0.0344953, 0.0257816 0.0256918, "
                         + "-0.0380885 0.0238053))");
@@ -675,8 +675,8 @@ public class PolygonTest
     public void testSelfIntersectingPolygon()
     {
         // shape is a figure 8, self intersecting in the middle
-        final Polygon polygon = Polygon
-                .wkt("POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
+        final Polygon polygon = Polygon.wkt(
+                "POLYGON ((-0.0256918 0.0054797, -0.0220985 0.0120374, -0.0119475 0.0121272, -0.0054797 0.006917,"
                         + " -0.007995 -0.0128459, -0.0007186 -0.0194934, 0.0103306 -0.0186849, 0.0125764 -0.0098814, "
                         + "0.0026051 -0.0048509, -0.013834 -0.0050305, -0.0242545 -0.0008983, -0.0256918 0.0054797))");
         final Location area1 = Location.forString("0.0034136, -0.016529");


### PR DESCRIPTION
### Description:
```isClockwise``` method in polygon checks the locations in order to infer the directionality. It uses the **sum over edges** [http://stackoverflow.com/questions/1165647](url) method to get the orientation. But this method expects the points on a cartesian plane and we are using earth coordinates directly which causes some of the cases to fail.

Example Polygon which fails:   
**POLYGON ((-70.0020146 12.5265405, -70.0019978 12.5265112, -70.0019564 12.526534, -70.0019733 12.5265633, -70.0020146 12.5265405))**

To fix this we need to convert lat/long into cartesian coordinates. Please refer [https://www.grasshopper3d.com/forum/topics/best-way-to-translate-latitude-longitude-data-into-xyz-points?commentId=2985220%3AComment%3A1804229](url)

The conversion is:
x = R * cos(lat) * cos(lon)  y = R * cos(lat) * sin(lon)

### Potential Impact:

This should not impact any downstream processes as we are not changing the geometry of polygons

### Unit Test Approach:
Wrote a unit test which was failing for the previous code.

The polygon in the unit test has a counter clockwise orientation but isClockwise was returning true previously.

### Test Results:

All the unit tests passed.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
