### PR TITLE
Added in SilkCut with predicate and used that in relation slicing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -622,6 +622,8 @@ public abstract class BareAtlas implements Atlas
     {
         switch (cutType)
         {
+            case SILK_CUT:
+                return SubAtlasCreator.silkCut(this, matcher);
             case SOFT_CUT:
                 return SubAtlasCreator.softCut(this, matcher);
             case HARD_CUT_ALL:

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -421,7 +421,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
 
                 // filter out all AtlasEntities that are not in the list of countries being sliced
                 // for this shard
-                final Atlas countrySubAtlas = atlas.subAtlas(isInCountry, AtlasCutType.SOFT_CUT)
+                final Atlas countrySubAtlas = atlas.subAtlas(isInCountry, AtlasCutType.SILK_CUT)
                         .orElseThrow(() -> new CoreException(
                                 "Cannot have an empty atlas after relation slicing {}",
                                 this.initialShard.getName()));

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
@@ -230,7 +230,7 @@ public final class SubAtlasCreator
 
         final PackedAtlasBuilder builder = getPackedAtlasBuilder(atlas, sizeEstimates);
 
-        // Add all the individual nodes and edge start/stop nodes coming from the predicate
+        // Add all the individual nodes and edge start and end nodes coming from the predicate
         addNodes(nodesWithin, node -> !hasEntity(node, builder), builder);
         addNodesFromEdges(edgesIntersecting, builder);
 
@@ -274,11 +274,11 @@ public final class SubAtlasCreator
         // use the same size as the source Atlas, but we trim it at the end.
         final PackedAtlasBuilder builder = getPackedAtlasBuilder(atlas, atlas.size());
 
-        // First, add all the nodes contained by relations and all start/stop nodes from edges
+        // First, add all the nodes contained by relations and all start and end nodes from edges
         // contained by relations
         atlas.relations(matcher::test).forEach(relation -> addNodesFromRelation(relation, builder));
 
-        // Next, add all the individual nodes and edge start/stop nodes coming from the predicate
+        // Next, add all the individual nodes and edge start and end nodes coming from the predicate
         addNodes(atlas.nodes(matcher::test), node -> !hasEntity(node, builder), builder);
         addNodesFromEdges(atlas.edges(matcher::test), builder);
 
@@ -354,7 +354,7 @@ public final class SubAtlasCreator
 
         final PackedAtlasBuilder builder = getPackedAtlasBuilder(atlas, sizeEstimates);
 
-        // Add all the individual nodes and edge start/stop nodes coming from the predicate
+        // Add all the individual nodes and edge start and end nodes coming from the predicate
         addNodes(nodesWithin, node -> !hasEntity(node, builder), builder);
         addNodesFromEdges(edgesIntersecting, builder);
 
@@ -429,11 +429,11 @@ public final class SubAtlasCreator
         // use the same size as the source Atlas, but we trim it at the end.
         final PackedAtlasBuilder builder = getPackedAtlasBuilder(atlas, atlas.size());
 
-        // First, add all the nodes contained by relations and all start/stop nodes from edges
+        // First, add all the nodes contained by relations and all start and end nodes from edges
         // contained by relations
         atlas.relations(matcher::test).forEach(relation -> addNodesFromRelation(relation, builder));
 
-        // Next, add all the individual nodes and edge start/stop nodes coming from the predicate
+        // Next, add all the individual nodes and edge start and end nodes coming from the predicate
         addNodes(atlas.nodes(matcher::test), node -> !hasEntity(node, builder), builder);
         addNodesFromEdges(atlas.edges(matcher::test), builder);
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
@@ -251,6 +251,132 @@ public class SubAtlasTest
     }
 
     @Test
+    public void testSubAtlasPredicateSilkCut()
+    {
+        final Atlas source = this.rule.getAtlas();
+
+        // Should return back all entities in this atlas
+        final Predicate<AtlasEntity> allEntities = (entity) -> entity.getIdentifier() > 0
+                || entity.getIdentifier() < 0 || entity.getIdentifier() == 0;
+
+        // Should return back only Entities with identifier 0
+        final Predicate<AtlasEntity> entitiesWithIdentifierZero = (
+                entity) -> entity.getIdentifier() == 0;
+
+        final Atlas identicalSubAtlas = source.subAtlas(allEntities, AtlasCutType.SILK_CUT)
+                .orElseThrow(() -> new CoreException("SubAtlas was not present."));
+
+        final Atlas subAtlasWithZeroBasedIdentifiers = source
+                .subAtlas(entitiesWithIdentifierZero, AtlasCutType.SILK_CUT)
+                .orElseThrow(() -> new CoreException("SubAtlas was not present."));
+
+        // Nodes
+        Assert.assertNotNull(source.node(1));
+        Assert.assertNotNull(identicalSubAtlas.node(1));
+        Assert.assertNotNull(source.node(2));
+        Assert.assertNotNull(identicalSubAtlas.node(2));
+        Assert.assertNotNull(source.node(3));
+        Assert.assertNotNull(identicalSubAtlas.node(3));
+
+        // Edges
+        Assert.assertNotNull(source.edge(0));
+        Assert.assertNotNull(identicalSubAtlas.edge(0));
+        Assert.assertNotNull(source.edge(1));
+        Assert.assertNotNull(identicalSubAtlas.edge(1));
+
+        // Areas
+        Assert.assertNotNull(source.area(0));
+        Assert.assertNotNull(identicalSubAtlas.area(0));
+        Assert.assertNotNull(source.area(1));
+        Assert.assertNotNull(identicalSubAtlas.area(1));
+
+        // Lines
+        Assert.assertNotNull(source.line(0));
+        Assert.assertNotNull(identicalSubAtlas.line(0));
+        Assert.assertNotNull(source.line(1));
+        Assert.assertNotNull(identicalSubAtlas.line(1));
+
+        // Points
+        Assert.assertNotNull(source.point(0));
+        Assert.assertNotNull(identicalSubAtlas.point(0));
+        Assert.assertNotNull(source.point(1));
+        Assert.assertNotNull(identicalSubAtlas.point(1));
+        Assert.assertNotNull(source.point(2));
+        Assert.assertNotNull(identicalSubAtlas.point(2));
+        Assert.assertNotNull(source.point(3));
+        Assert.assertNotNull(identicalSubAtlas.point(3));
+
+        // Relations
+        Assert.assertNotNull(source.relation(1));
+        Assert.assertNotNull(identicalSubAtlas.relation(1));
+        Assert.assertNotNull(source.relation(2));
+        Assert.assertEquals(2, source.relation(2).members().size());
+        Assert.assertNotNull(identicalSubAtlas.relation(2));
+        Assert.assertEquals(2, identicalSubAtlas.relation(2).members().size());
+        Assert.assertNotNull(source.relation(3));
+        Assert.assertNotNull(identicalSubAtlas.relation(3));
+        Assert.assertNotNull(source.relation(4));
+        Assert.assertEquals(2, source.relation(4).members().size());
+        Assert.assertNotNull(identicalSubAtlas);
+        Assert.assertEquals(2, identicalSubAtlas.relation(4).members().size());
+        Assert.assertNotNull(source.relation(5));
+        Assert.assertEquals(1, source.relation(5).members().size());
+        Assert.assertNotNull(identicalSubAtlas.relation(5));
+        Assert.assertEquals(1, identicalSubAtlas.relation(5).members().size());
+
+        // Nodes
+        Assert.assertNotNull(source.node(1));
+        // Node 1 gets pulled in by Edge 0
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.node(1));
+        Assert.assertNotNull(source.node(2));
+        // Node 2 gets pulled in by Edge 0
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.node(2));
+        Assert.assertNotNull(source.node(3));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.node(3));
+
+        // Edges
+        Assert.assertNotNull(source.edge(0));
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.edge(0));
+        Assert.assertNotNull(source.edge(1));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.edge(1));
+
+        // Areas
+        Assert.assertNotNull(source.area(0));
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.area(0));
+        Assert.assertNotNull(source.area(1));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.area(1));
+
+        // Lines
+        Assert.assertNotNull(source.line(0));
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.line(0));
+        Assert.assertNotNull(source.line(1));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.line(1));
+
+        // Points
+        Assert.assertNotNull(source.point(0));
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.point(0));
+        // Point1 gets pulled in because it is part of the geometry of line0
+        Assert.assertNotNull(source.point(1));
+        Assert.assertNotNull(subAtlasWithZeroBasedIdentifiers.point(1));
+        Assert.assertNotNull(source.point(2));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.point(2));
+        Assert.assertNotNull(source.point(3));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.point(3));
+
+        // Relations
+        Assert.assertNotNull(source.relation(1));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.relation(1));
+        Assert.assertNotNull(source.relation(2));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.relation(2));
+        Assert.assertNotNull(source.relation(3));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.relation(3));
+        Assert.assertNotNull(source.relation(4));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.relation(4));
+        Assert.assertNotNull(source.relation(5));
+        Assert.assertNull(subAtlasWithZeroBasedIdentifiers.relation(5));
+    }
+
+    @Test
     public void testSubAtlasPredicateSoftCut()
     {
         final Atlas source = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/SubAtlasTest.java
@@ -256,8 +256,7 @@ public class SubAtlasTest
         final Atlas source = this.rule.getAtlas();
 
         // Should return back all entities in this atlas
-        final Predicate<AtlasEntity> allEntities = (entity) -> entity.getIdentifier() > 0
-                || entity.getIdentifier() < 0 || entity.getIdentifier() == 0;
+        final Predicate<AtlasEntity> allEntities = entity -> true;
 
         // Should return back only Entities with identifier 0
         final Predicate<AtlasEntity> entitiesWithIdentifierZero = (
@@ -382,8 +381,7 @@ public class SubAtlasTest
         final Atlas source = this.rule.getAtlas();
 
         // Should return back all entities in this atlas
-        final Predicate<AtlasEntity> allEntities = (entity) -> entity.getIdentifier() > 0
-                || entity.getIdentifier() < 0 || entity.getIdentifier() == 0;
+        final Predicate<AtlasEntity> allEntities = entity -> true;
 
         // Should return back only Entities with identifier 0
         final Predicate<AtlasEntity> entitiesWithIdentifierZero = (


### PR DESCRIPTION
### Description:

Adds in a Predicate match version of SilkCut -- as with the boundary-based SilkCut, behavior is the same as SoftCut, but with one change regarding Point behavior. Initially, Points are added to the SubAtlas based on whether they match the Predicate or not. However, afterwards, Lines that match the Predicate are scanned for underlying Points that did not match the Predicate; any Points found are added to the SubAtlas. This preserves the ability to do operations on Line items that expect the Lines to have Points underlying the locations for the line (i.e. WaySectioning).

Additionally, this new SilkCut is used during relation slicing.

### Potential Impact:
Very little, as it mostly adds a new Atlas cut type.

### Unit Test Approach:

Added a unit test that covers the expected behavior for SilkCut. The test is the same as the SoftCut with Predicate test, but one Point that doesn't match the Predicate will be included due to being a part of a Line that matches.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)