### PR TITLE
Allowed additional imports for predicates

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
@@ -52,6 +52,11 @@ public class SubAtlasCommand extends AtlasLoaderCommand
     private static final String SLICE_FIRST_OPTION_LONG = "slice-first";
     private static final String SLICE_FIRST_OPTION_DESCRIPTION = "Cut with supplied geometry before applying the predicate.";
 
+    private static final List<String> importsWhitelist = Arrays.asList(
+            "org.openstreetmap.atlas.geography.atlas.items",
+            "org.openstreetmap.atlas.tags.annotations.validation", "org.openstreetmap.atlas.tags",
+            "org.openstreetmap.atlas.geography");
+
     private final OptionAndArgumentDelegate optionAndArgumentDelegate;
     private final CommandOutputDelegate outputDelegate;
 
@@ -239,6 +244,7 @@ public class SubAtlasCommand extends AtlasLoaderCommand
         if (predicateParameter.isPresent())
         {
             return Optional.ofNullable(new StringToPredicateConverter<AtlasEntity>()
+                    .withAddedStarImportPackages(importsWhitelist)
                     .convert(predicateParameter.get()));
         }
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -36,7 +36,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         securityCustomizer.setStarImportsWhitelist(Arrays.asList("java.lang", "groovy.lang",
                 "java.util.function", "org.openstreetmap.atlas.geography.atlas.items",
                 "org.openstreetmap.atlas.tags.annotations.validation",
-                "org.openstreetmap.atlas.tags"));
+                "org.openstreetmap.atlas.tags", "org.openstreetmap.atlas.geography"));
         securityCustomizer.setPackageAllowed(false);
         securityCustomizer.setMethodDefinitionAllowed(false);
         securityCustomizer.setIndirectImportCheckEnabled(true);
@@ -45,7 +45,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         importCustomizer.addStarImports("java.util.function",
                 "org.openstreetmap.atlas.geography.atlas.items", "java.lang",
                 "org.openstreetmap.atlas.tags.annotations.validation",
-                "org.openstreetmap.atlas.tags");
+                "org.openstreetmap.atlas.tags", "org.openstreetmap.atlas.geography");
 
         final CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
         compilerConfiguration.addCompilationCustomizers(securityCustomizer);

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.utilities.conversion;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.codehaus.groovy.control.CompilerConfiguration;
@@ -16,12 +18,10 @@ import groovy.lang.GroovyShell;
 import groovy.lang.Script;
 
 /**
- * Convert a boolean expression string to a {@link Predicate}. While the converter can handle
- * generic predicates, it includes some default imports that make it ideal for use as
- * Predicate&lt;AtlasEntity&gt;. The converter uses the Groovy interpreter to create a
- * {@link Predicate} from the boolean input expression. The type T is bound to a variable called
- * 'e', and so the expression string should use 'e'. E.g. "e.getType() == ItemType.POINT" (if T is
- * {@link AtlasEntity}) or 'e.equals("foo")' (if T is {@link String}).
+ * Convert a boolean expression string to a {@link Predicate}. The converter uses the Groovy
+ * interpreter to create a {@link Predicate} from the boolean input expression. The type T is bound
+ * to a variable called 'e', and so the expression string should use 'e'. E.g. "e.getType() ==
+ * ItemType.POINT" (if T is {@link AtlasEntity}) or 'e.equals("foo")' (if T is {@link String}).
  *
  * @author lcram
  * @param <T>
@@ -29,23 +29,28 @@ import groovy.lang.Script;
  */
 public class StringToPredicateConverter<T> implements Converter<String, Predicate<T>>
 {
+    private final List<String> additionalWhitelistPackages;
+
+    public StringToPredicateConverter()
+    {
+        this.additionalWhitelistPackages = new ArrayList<>();
+    }
+
     @Override
     public Predicate<T> convert(final String string)
     {
         final SecureASTCustomizer securityCustomizer = new SecureASTCustomizer();
-        securityCustomizer.setStarImportsWhitelist(Arrays.asList("java.lang", "groovy.lang",
-                "java.util.function", "org.openstreetmap.atlas.geography.atlas.items",
-                "org.openstreetmap.atlas.tags.annotations.validation",
-                "org.openstreetmap.atlas.tags", "org.openstreetmap.atlas.geography"));
+        final List<String> importsWhitelist = Arrays.asList("java.lang", "groovy.lang",
+                "java.util.function");
+        importsWhitelist.addAll(this.additionalWhitelistPackages);
+
+        securityCustomizer.setStarImportsWhitelist(importsWhitelist);
         securityCustomizer.setPackageAllowed(false);
         securityCustomizer.setMethodDefinitionAllowed(false);
         securityCustomizer.setIndirectImportCheckEnabled(true);
 
         final ImportCustomizer importCustomizer = new ImportCustomizer();
-        importCustomizer.addStarImports("java.util.function",
-                "org.openstreetmap.atlas.geography.atlas.items", "java.lang",
-                "org.openstreetmap.atlas.tags.annotations.validation",
-                "org.openstreetmap.atlas.tags", "org.openstreetmap.atlas.geography");
+        importCustomizer.addStarImports(importsWhitelist.toArray(new String[0]));
 
         final CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
         compilerConfiguration.addCompilationCustomizers(securityCustomizer);
@@ -79,5 +84,34 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         {
             return null;
         }
+    }
+
+    /**
+     * Add some imports to execute before the predicate.
+     *
+     * @param whitelist
+     *            the packages to star import.
+     * @return the updated converter
+     */
+    public StringToPredicateConverter<T> withAddedStarImportPackages(final List<String> whitelist)
+    {
+        this.additionalWhitelistPackages.addAll(whitelist);
+        return this;
+    }
+
+    /**
+     * Add some imports to execute before the predicate.
+     *
+     * @param whitelist
+     *            the packages to star import.
+     * @return the updated converter
+     */
+    public StringToPredicateConverter<T> withAddedStarImportPackages(final String... whitelist)
+    {
+        for (final String anImport : whitelist)
+        {
+            this.additionalWhitelistPackages.add(anImport);
+        }
+        return this;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -40,8 +40,8 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
     public Predicate<T> convert(final String string)
     {
         final SecureASTCustomizer securityCustomizer = new SecureASTCustomizer();
-        final List<String> importsWhitelist = Arrays.asList("java.lang", "groovy.lang",
-                "java.util.function");
+        final List<String> importsWhitelist = new ArrayList<>(
+                Arrays.asList("java.lang", "groovy.lang", "java.util.function"));
         importsWhitelist.addAll(this.additionalWhitelistPackages);
 
         securityCustomizer.setStarImportsWhitelist(importsWhitelist);

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -34,14 +34,18 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
     {
         final SecureASTCustomizer securityCustomizer = new SecureASTCustomizer();
         securityCustomizer.setStarImportsWhitelist(Arrays.asList("java.lang", "groovy.lang",
-                "java.util.function", "org.openstreetmap.atlas.geography.atlas.items"));
+                "java.util.function", "org.openstreetmap.atlas.geography.atlas.items",
+                "org.openstreetmap.atlas.tags.annotations.validation",
+                "org.openstreetmap.atlas.tags"));
         securityCustomizer.setPackageAllowed(false);
         securityCustomizer.setMethodDefinitionAllowed(false);
         securityCustomizer.setIndirectImportCheckEnabled(true);
 
         final ImportCustomizer importCustomizer = new ImportCustomizer();
         importCustomizer.addStarImports("java.util.function",
-                "org.openstreetmap.atlas.geography.atlas.items", "java.lang");
+                "org.openstreetmap.atlas.geography.atlas.items", "java.lang",
+                "org.openstreetmap.atlas.tags.annotations.validation",
+                "org.openstreetmap.atlas.tags");
 
         final CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
         compilerConfiguration.addCompilationCustomizers(securityCustomizer);

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.utilities.conversion;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -28,6 +29,13 @@ public class StringToPredicateConverterTest
                 .convert("e == 3");
         final Predicate<AtlasEntity> predicate4 = new StringToPredicateConverter<AtlasEntity>()
                 .convert("e.getTags().containsKey(\"mat\")");
+        final Predicate<Integer> predicate5 = new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages("org.openstreetmap.atlas.utilities.random")
+                .convert("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+        final Predicate<Integer> predicate6 = new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages(
+                        Arrays.asList("org.openstreetmap.atlas.utilities.random"))
+                .convert("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
 
         Assert.assertTrue(predicate1.test("foo"));
         Assert.assertFalse(predicate1.test("bar"));
@@ -40,5 +48,8 @@ public class StringToPredicateConverterTest
 
         Assert.assertTrue(predicate4.test(this.rule.getAtlas().point(3)));
         Assert.assertFalse(predicate4.test(this.rule.getAtlas().point(1)));
+
+        Assert.assertTrue(predicate5.test(5));
+        Assert.assertTrue(predicate6.test(5));
     }
 }


### PR DESCRIPTION
### Description:

Added some more imports for predicates. You can now use `Tag` classes and `Validator` classes.

Example:
```
$ atlas subatlas --predicate 'Validators.from(FootwayTag.class, e).isPresent()' myatlas.atlas
```
@jklamer if there are any more packages you think may be useful, please call them out so we can include them in this PR.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
