### PR TITLE
Improved dynamic slicing performance

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasCountrySlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasCountrySlicer.java
@@ -301,7 +301,8 @@ public class RawAtlasCountrySlicer
         }
         else
         {
-            throw new CoreException("Error while preparing subatlas for relation slicing shard {}!",
+            throw new CoreException(
+                    "No data after sub-atlasing to remove new relations from partially expanded Atlas {}!",
                     partiallySlicedExpandedAtlas.getName());
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSetHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/RelationChangeSetHandler.java
@@ -61,7 +61,7 @@ public class RelationChangeSetHandler extends ChangeSetHandler
         // Log original Atlas statistics
         if (logger.isInfoEnabled())
         {
-            logger.info("Before Slicing Relations: " + atlasStatistics(super.getAtlas()));
+            logger.info("Before Slicing Relations: {}", atlasStatistics(super.getAtlas()));
         }
 
         // Prepare the builder
@@ -84,7 +84,7 @@ public class RelationChangeSetHandler extends ChangeSetHandler
 
         if (logger.isInfoEnabled())
         {
-            logger.info("After Slicing Relations: " + atlasStatistics(atlasWithUpdates));
+            logger.info("After Slicing Relations: {}", atlasStatistics(atlasWithUpdates));
         }
 
         logger.info("Finished Applying Relation Changes for {} in {}", getShardOrAtlasName(),

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
@@ -475,7 +475,7 @@ public final class SubAtlasCreator
         for (final Relation relation : atlas.relationsLowerOrderFirst())
         {
             final Long relationId = relation.getIdentifier();
-            if (subrelations.contains(relationId))
+            if (subrelations.contains(relationId) && !hasEntity(relation, builder))
             {
                 builder.addRelation(relationId, relation.getOsmIdentifier(), relation.getBean(),
                         relation.getTags());


### PR DESCRIPTION
### Description:

This PR makes a two smaller changes to improve performance around dynamic relation slicing. First, the filter for DynamicAtlas policy now exclusively uses Relations to determine whether to expand to a shard. The previous policy mistakenly checked for any points, which triggered false-positive expansions to unnecessary shards. Second, the RawAtlasCountrySlicer will now sub atlas out all relations from the DynamicAtlas that weren't a part of the original shard before slicing relations. This prevents the unnecessary computation of slicing relations picked up by the expanded DyanmicAtlas, as these relation will all have been cut out of the final fully sliced atlas anyway. Note that this works because the relations are removed with the SubAtlas SILK_CUT policy, which will preserve any relations that are members of relations that will be kept-- this means if the DynamicAtlas loads a relation that wasn't part of the original shard but *is* a member of a relation that was a part of the original shard, it will be kept. 

Additionally, a small fix was included for certain corner cases of SilkCut.

### Potential Impact:

None, as this should not change the final output Atlas, only improve the performance of the slicing operation!

### Unit Test Approach:

None, as this doesn't change output data at all, only performance.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)