### PR TITLE
Retrieve DAG process groups

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
@@ -150,19 +150,19 @@ public class DirectedAcyclicGraph<V> implements Serializable
         final Set<V> sourcesNotAdded = new HashSet<>(getSources());
         while (!sourcesNotAdded.isEmpty())
         {
-            final Set<V> allCandidates = new HashSet<>();
-            final Set<V> candidates = new HashSet<>();
+            final Set<V> potentialCandidates = new HashSet<>();
             for (final V alreadyAdded : added)
             {
                 for (final V parent : getParents(alreadyAdded))
                 {
                     if (!added.contains(parent))
                     {
-                        allCandidates.add(parent);
+                        potentialCandidates.add(parent);
                     }
                 }
             }
-            for (final V candidate : allCandidates)
+            final Set<V> candidates = new HashSet<>();
+            for (final V candidate : potentialCandidates)
             {
                 if (added.containsAll(getChildren(candidate)))
                 {

--- a/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
@@ -1,10 +1,12 @@
 package org.openstreetmap.atlas.utilities.graphs;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 
@@ -134,6 +136,50 @@ public class DirectedAcyclicGraph<V> implements Serializable
     public boolean isSource(final V vertex)
     {
         return this.inMap.get(vertex).isEmpty();
+    }
+
+    /**
+     * @return The ordered groups of vertices that all belong to the same priority level within the
+     *         DAG
+     */
+    public List<Set<V>> processGroups()
+    {
+        final Stack<Set<V>> stack = new Stack<>();
+        stack.push(new HashSet<>(getSinks()));
+        final Set<V> added = new HashSet<>(getSinks());
+        final Set<V> sourcesNotAdded = new HashSet<>(getSources());
+        while (!sourcesNotAdded.isEmpty())
+        {
+            final Set<V> allCandidates = new HashSet<>();
+            final Set<V> candidates = new HashSet<>();
+            for (final V alreadyAdded : added)
+            {
+                for (final V parent : getParents(alreadyAdded))
+                {
+                    if (!added.contains(parent))
+                    {
+                        allCandidates.add(parent);
+                    }
+                }
+            }
+            for (final V candidate : allCandidates)
+            {
+                if (added.containsAll(getChildren(candidate)))
+                {
+                    candidates.add(candidate);
+                    // Hit or miss, hit only at the end of the processing
+                    sourcesNotAdded.remove(candidate);
+                }
+            }
+            stack.push(candidates);
+            added.addAll(candidates);
+        }
+        final List<Set<V>> result = new ArrayList<>();
+        while (!stack.isEmpty())
+        {
+            result.add(stack.pop());
+        }
+        return result;
     }
 
     public void removeVertex(final V vertex)

--- a/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
@@ -4,14 +4,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 
 /**
  * Basic validation of DAG functionality
@@ -67,6 +70,20 @@ public class DirectedAcyclicGraphTest
     }
 
     @Test
+    public void testProcessGroups()
+    {
+        final List<Set<String>> processGroups = this.graph.processGroups();
+        final List<Set<String>> expected = new ArrayList<>();
+        final Set<String> first = Sets.hashSet("Metal");
+        final Set<String> second = Sets.hashSet("Precious", "Coinage");
+        final Set<String> third = Sets.hashSet("Gold", "Platinum", "Copper");
+        expected.add(first);
+        expected.add(second);
+        expected.add(third);
+        Assert.assertEquals(expected, processGroups);
+    }
+
+    @Test
     public void testSinks()
     {
         final Set<String> expectedSinks = new HashSet<>(
@@ -95,5 +112,4 @@ public class DirectedAcyclicGraphTest
         Assert.assertEquals("Gold", topologicalSort.pop());
         Assert.assertEquals("Platinum", topologicalSort.pop());
     }
-
 }


### PR DESCRIPTION
### Description:

Return a function that gets all the groups within the same priority level in a DAG. As tested in this class:
```
                  Copper
                /
        Coinage
      /         \
Metal              Gold
      \         /
        Precious
                \
                   Platinum
```

Returns:
```
1. Metal
2. Coinage, Precious
3. Copper, Gold, Platinum
```

### Potential Impact:

None, new method

### Unit Test Approach:

Added one extra unit test

### Test Results:

Passing

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)