### PR TITLE
Make AtlasChangeGenerator serializable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -48,4 +48,9 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
      * @return The un-validated set of {@link FeatureChange}s
      */
     Set<FeatureChange> generateWithoutValidation(Atlas atlas);
+
+    default String getName()
+    {
+        return this.getClass().getSimpleName();
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.io.Serializable;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -12,7 +13,7 @@ import org.openstreetmap.atlas.utilities.conversion.Converter;
  *
  * @author matthieun
  */
-public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange>>
+public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange>>, Serializable
 {
     @Override
     default Set<FeatureChange> convert(final Atlas atlas)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorAddTurnRestrictions.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorAddTurnRestrictions.java
@@ -26,6 +26,8 @@ import com.google.common.collect.Lists;
  */
 public class AtlasChangeGeneratorAddTurnRestrictions implements AtlasChangeGenerator
 {
+    private static final long serialVersionUID = -518515697422424803L;
+
     @Override
     public Set<FeatureChange> generateWithoutValidation(final Atlas atlas)
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorRemoveReverseEdges.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorRemoveReverseEdges.java
@@ -13,6 +13,8 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  */
 public class AtlasChangeGeneratorRemoveReverseEdges implements AtlasChangeGenerator
 {
+    private static final long serialVersionUID = 2378086577050982603L;
+
     @Override
     public Set<FeatureChange> generateWithoutValidation(final Atlas atlas)
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorSplitRoundabout.java
@@ -22,6 +22,8 @@ import org.openstreetmap.atlas.utilities.collections.Sets;
  */
 public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
 {
+    private static final long serialVersionUID = -6596053817414805897L;
+
     @Override
     public Set<FeatureChange> generateWithoutValidation(final Atlas atlas)
     {


### PR DESCRIPTION
### Description:

Make `AtlasChangeGenerator` serializable so it can easily be used in Spark.

### Potential Impact:

None.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
