### PR TITLE
Allow for ChangeAtlas to have no source and node bound expansion

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -34,9 +34,12 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
                 final CompleteNode originalCompleteNode = (CompleteNode) featureChange
                         .getReference();
                 final Node originalNode = atlas.node(originalNodeIdentifier);
-                for (final Edge originalEdge : originalNode.connectedEdges())
+                if (originalNode != null)
                 {
-                    newBounds = newBounds.combine(originalEdge.bounds());
+                    for (final Edge originalEdge : originalNode.connectedEdges())
+                    {
+                        newBounds = newBounds.combine(originalEdge.bounds());
+                    }
                 }
                 for (final FeatureChange featureChangeInner : featureChanges)
                 {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -1,10 +1,16 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.conversion.Converter;
 
 /**
@@ -15,6 +21,50 @@ import org.openstreetmap.atlas.utilities.conversion.Converter;
  */
 public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange>>, Serializable
 {
+    static Set<FeatureChange> expandNodeBounds(final Atlas atlas,
+            final Set<FeatureChange> featureChanges)
+    {
+        final Set<FeatureChange> result = new HashSet<>();
+        for (final FeatureChange featureChange : featureChanges)
+        {
+            if (featureChange.getItemType() == ItemType.NODE)
+            {
+                Rectangle newBounds = featureChange.bounds();
+                final long originalNodeIdentifier = featureChange.getIdentifier();
+                final CompleteNode originalCompleteNode = (CompleteNode) featureChange
+                        .getReference();
+                final Node originalNode = atlas.node(originalNodeIdentifier);
+                for (final Edge originalEdge : originalNode.connectedEdges())
+                {
+                    newBounds = newBounds.combine(originalEdge.bounds());
+                }
+                for (final FeatureChange featureChangeInner : featureChanges)
+                {
+                    if (featureChangeInner.getItemType() == ItemType.EDGE)
+                    {
+                        final Edge changedEdge = (Edge) featureChangeInner.getReference();
+                        if (changedEdge.start() != null
+                                && changedEdge.start().getIdentifier() == originalNodeIdentifier
+                                || changedEdge.end() != null && changedEdge.end()
+                                        .getIdentifier() == originalNodeIdentifier)
+                        {
+                            newBounds = newBounds.combine(changedEdge.bounds());
+                        }
+                    }
+                }
+                final FeatureChange newFeatureChange = new FeatureChange(
+                        featureChange.getChangeType(),
+                        originalCompleteNode.withAggregateBoundsExtendedUsing(newBounds));
+                result.add(newFeatureChange);
+            }
+            else
+            {
+                result.add(featureChange);
+            }
+        }
+        return result;
+    }
+
     @Override
     default Set<FeatureChange> convert(final Atlas atlas)
     {
@@ -30,7 +80,8 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
      */
     default Set<FeatureChange> generate(final Atlas atlas)
     {
-        final Set<FeatureChange> result = generateWithoutValidation(atlas);
+        final Set<FeatureChange> result = expandNodeBounds(atlas, generateWithoutValidation(atlas));
+
         // Validate
         final ChangeBuilder builder = new ChangeBuilder();
         result.forEach(builder::add);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -43,18 +43,6 @@ public class Change implements Located, Serializable
     private Rectangle bounds;
     private String name;
 
-    protected Change()
-    {
-        this.featureChanges = new ArrayList<>();
-        this.identifierToIndex = new HashMap<>();
-        this.identifier = CHANGE_IDENTIFIER_FACTORY.getAndIncrement();
-    }
-
-    public static Change newInstance()
-    {
-        return new Change();
-    }
-
     /**
      * Merge {@link FeatureChange}s inside {@link Change} objects and create a
      * {@link Change#newInstance()} with the merged {@link FeatureChange}s. The
@@ -67,6 +55,10 @@ public class Change implements Located, Serializable
      */
     public static Change merge(final Change... changeInstances)
     {
+        if (changeInstances.length == 1)
+        {
+            return changeInstances[0];
+        }
         final FeatureChange[] mergedFeatureChanges = Arrays.stream(changeInstances)
                 .flatMap(Change::changes)
                 .collect(Collectors.groupingBy(FeatureChangeMergeGroup::from, LinkedHashMap::new,
@@ -74,6 +66,18 @@ public class Change implements Located, Serializable
                 .values().stream().map(Optional::get).toArray(FeatureChange[]::new);
 
         return Change.newInstance().withName("Merged Change").addAll(mergedFeatureChanges);
+    }
+
+    public static Change newInstance()
+    {
+        return new Change();
+    }
+
+    protected Change()
+    {
+        this.featureChanges = new ArrayList<>();
+        this.identifierToIndex = new HashMap<>();
+        this.identifier = CHANGE_IDENTIFIER_FACTORY.getAndIncrement();
     }
 
     List<FeatureChange> getFeatureChanges()
@@ -114,6 +118,40 @@ public class Change implements Located, Serializable
                 .map(tuple -> this.featureChanges.get(this.identifierToIndex.get(tuple)));
     }
 
+    /**
+     * An Object{@link #equals(Object)} implementation based on {@link #featureChanges} in the
+     * {@link Change} objects being compared.
+     *
+     * @param other
+     *            - the object to compare.
+     * @return boolean - true if the objects are equal
+     * @see Objects#equals(Object, Object)
+     * @see Object#equals(Object)
+     */
+    @Override
+    public boolean equals(final Object other)
+    {
+        // self check
+        if (this == other)
+        {
+            return true;
+        }
+        // null check
+        if (other == null)
+        {
+            return false;
+        }
+        // type check and cast
+        if (getClass() != other.getClass())
+        {
+            return false;
+        }
+
+        final Change that = (Change) other;
+
+        return Objects.equals(this.featureChanges, that.featureChanges);
+    }
+
     public int getIdentifier()
     {
         return this.identifier;
@@ -129,6 +167,20 @@ public class Change implements Located, Serializable
         {
             return this.name;
         }
+    }
+
+    /**
+     * An Object{@link #hashCode()} implementation based on {@link #featureChanges} in the
+     * {@link Change}.
+     *
+     * @return - the hash code.
+     * @see Objects#hashCode(Object)
+     * @see Object#hashCode()
+     */
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(this.featureChanges);
     }
 
     /**
@@ -208,53 +260,5 @@ public class Change implements Located, Serializable
     {
         Arrays.stream(featureChanges).forEach(this::add);
         return this;
-    }
-
-    /**
-     * An Object{@link #equals(Object)} implementation based on {@link #featureChanges} in the
-     * {@link Change} objects being compared.
-     *
-     * @param other
-     *            - the object to compare.
-     * @return boolean - true if the objects are equal
-     * @see Objects#equals(Object, Object)
-     * @see Object#equals(Object)
-     */
-    @Override
-    public boolean equals(final Object other)
-    {
-        // self check
-        if (this == other)
-        {
-            return true;
-        }
-        // null check
-        if (other == null)
-        {
-            return false;
-        }
-        // type check and cast
-        if (getClass() != other.getClass())
-        {
-            return false;
-        }
-
-        final Change that = (Change) other;
-
-        return Objects.equals(this.featureChanges, that.featureChanges);
-    }
-
-    /**
-     * An Object{@link #hashCode()} implementation based on {@link #featureChanges} in the
-     * {@link Change}.
-     *
-     * @return - the hash code.
-     * @see Objects#hashCode(Object)
-     * @see Object#hashCode()
-     */
-    @Override
-    public int hashCode()
-    {
-        return Objects.hashCode(this.featureChanges);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -55,10 +55,6 @@ public class Change implements Located, Serializable
      */
     public static Change merge(final Change... changeInstances)
     {
-        if (changeInstances.length == 1)
-        {
-            return changeInstances[0];
-        }
         final FeatureChange[] mergedFeatureChanges = Arrays.stream(changeInstances)
                 .flatMap(Change::changes)
                 .collect(Collectors.groupingBy(FeatureChangeMergeGroup::from, LinkedHashMap::new,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -153,6 +153,8 @@ public class FeatureChange implements Located, Serializable
                     return false;
                 }
                 break;
+            default:
+                throw new CoreException("Unknown Item Type {}", this.getItemType());
         }
         return true;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -109,46 +109,47 @@ public class FeatureChange implements Located, Serializable
         switch (this.getItemType())
         {
             case NODE:
-                final Node reference1 = (Node) this.getReference();
-                if (reference1.inEdges() == null || reference1.outEdges() == null
-                        || reference1.getLocation() == null)
+                final Node nodeReference = (Node) this.getReference();
+                if (nodeReference.inEdges() == null || nodeReference.outEdges() == null
+                        || nodeReference.getLocation() == null)
                 {
                     return false;
                 }
                 break;
             case EDGE:
-                final Edge reference2 = (Edge) this.getReference();
-                if (reference2.start() == null || reference2.end() == null
-                        || reference2.asPolyLine() == null)
+                final Edge edgeReference = (Edge) this.getReference();
+                if (edgeReference.start() == null || edgeReference.end() == null
+                        || edgeReference.asPolyLine() == null)
                 {
                     return false;
                 }
                 break;
             case AREA:
-                final Area reference3 = (Area) this.getReference();
-                if (reference3.asPolygon() == null)
+                final Area areaReference = (Area) this.getReference();
+                if (areaReference.asPolygon() == null)
                 {
                     return false;
                 }
                 break;
             case LINE:
-                final Line reference4 = (Line) this.getReference();
-                if (reference4.asPolyLine() == null)
+                final Line lineReference = (Line) this.getReference();
+                if (lineReference.asPolyLine() == null)
                 {
                     return false;
                 }
                 break;
             case POINT:
-                final Point reference5 = (Point) this.getReference();
-                if (reference5.getLocation() == null)
+                final Point pointReference = (Point) this.getReference();
+                if (pointReference.getLocation() == null)
                 {
                     return false;
                 }
                 break;
             case RELATION:
-                final Relation reference6 = (Relation) this.getReference();
-                if (reference6.members() == null || reference6.allKnownOsmMembers() == null
-                        || reference6.allRelationsWithSameOsmIdentifier() == null)
+                final Relation relationReference = (Relation) this.getReference();
+                if (relationReference.members() == null
+                        || relationReference.allKnownOsmMembers() == null
+                        || relationReference.allRelationsWithSameOsmIdentifier() == null)
                 {
                     return false;
                 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -31,9 +31,11 @@ import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.LineItem;
 import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.tags.Taggable;
@@ -98,6 +100,63 @@ public class FeatureChange implements Located, Serializable
         this.validateUsefulFeatureChange();
     }
 
+    public boolean afterViewIsFull()
+    {
+        if (this.getReference().getTags() == null || this.getReference().relations() == null)
+        {
+            return false;
+        }
+        switch (this.getItemType())
+        {
+            case NODE:
+                final Node reference1 = (Node) this.getReference();
+                if (reference1.inEdges() == null || reference1.outEdges() == null
+                        || reference1.getLocation() == null)
+                {
+                    return false;
+                }
+                break;
+            case EDGE:
+                final Edge reference2 = (Edge) this.getReference();
+                if (reference2.start() == null || reference2.end() == null
+                        || reference2.asPolyLine() == null)
+                {
+                    return false;
+                }
+                break;
+            case AREA:
+                final Area reference3 = (Area) this.getReference();
+                if (reference3.asPolygon() == null)
+                {
+                    return false;
+                }
+                break;
+            case LINE:
+                final Line reference4 = (Line) this.getReference();
+                if (reference4.asPolyLine() == null)
+                {
+                    return false;
+                }
+                break;
+            case POINT:
+                final Point reference5 = (Point) this.getReference();
+                if (reference5.getLocation() == null)
+                {
+                    return false;
+                }
+                break;
+            case RELATION:
+                final Relation reference6 = (Relation) this.getReference();
+                if (reference6.members() == null || reference6.allKnownOsmMembers() == null
+                        || reference6.allRelationsWithSameOsmIdentifier() == null)
+                {
+                    return false;
+                }
+                break;
+        }
+        return true;
+    }
+
     @Override
     public Rectangle bounds()
     {
@@ -137,16 +196,6 @@ public class FeatureChange implements Located, Serializable
     }
 
     /**
-     * Get the changed tags.
-     *
-     * @return Map - the changed tags.
-     */
-    public Map<String, String> getTags()
-    {
-        return this.getReference().getTags();
-    }
-
-    /**
      * Get a tag based on key post changes.
      *
      * @param key
@@ -156,6 +205,16 @@ public class FeatureChange implements Located, Serializable
     public Optional<String> getTag(final String key)
     {
         return this.getReference().getTag(key);
+    }
+
+    /**
+     * Get the changed tags.
+     *
+     * @return Map - the changed tags.
+     */
+    public Map<String, String> getTags()
+    {
+        return this.getReference().getTags();
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -6,10 +6,12 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
@@ -37,9 +39,12 @@ public class AtlasChangeGeneratorTest
             result.add(FeatureChange.add((AtlasEntity) completeEntity));
         }
         // bonus!
-        result.add(FeatureChange.add(new CompleteEdge(123L, PolyLine
-                .wkt("LINESTRING (4.2194855 38.8231656, 4.2202479 38.8233871,4.219666 38.8235147)"),
-                Maps.hashMap("highway", "primary"), 177633000000L, 177649000000L, Sets.hashSet())));
+        result.add(FeatureChange.add(new CompleteEdge(123L, PolyLine.wkt(
+                "LINESTRING (4.2194855 38.8231656, 4.2202479 38.8233871, 4.2200000 38.8235147)"),
+                Maps.hashMap("highway", "primary"), 177633000000L, 456L, Sets.hashSet())));
+        result.add(FeatureChange.add(new CompleteNode(456L,
+                Location.forWkt("POINT (4.2200000 38.8235147)"), Maps.hashMap("highway", "primary"),
+                Sets.treeSet(), Sets.treeSet(123L), Sets.hashSet())));
         final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
         for (final FeatureChange featureChange : changes)
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -1,0 +1,55 @@
+package org.openstreetmap.atlas.geography.atlas.change;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
+
+/**
+ * @author matthieun
+ */
+public class AtlasChangeGeneratorTest
+{
+    @Rule
+    public final AtlasChangeGeneratorTestRule rule = new AtlasChangeGeneratorTestRule();
+
+    @Test
+    public void testExpandNode()
+    {
+        final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
+
+        final Set<FeatureChange> result = new HashSet<>();
+        final String key = "changed";
+        final String value = "yes";
+        for (final AtlasEntity entity : source)
+        {
+            final CompleteEntity completeEntity = ((CompleteEntity) CompleteEntity.from(entity))
+                    .withAddedTag(key, value);
+            result.add(FeatureChange.add((AtlasEntity) completeEntity));
+        }
+        // bonus!
+        result.add(FeatureChange.add(new CompleteEdge(123L, PolyLine
+                .wkt("LINESTRING (4.2194855 38.8231656, 4.2202479 38.8233871,4.219666 38.8235147)"),
+                Maps.hashMap("highway", "primary"), 177633000000L, 177649000000L, Sets.hashSet())));
+        final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
+        for (final FeatureChange featureChange : changes)
+        {
+            if (featureChange.getIdentifier() == 177633000000L)
+            {
+                Assert.assertEquals(
+                        "POLYGON ((4.2177433 38.8228217, 4.2177433 38.8235147, 4.2202479 38.8235147,"
+                                + " 4.2202479 38.8228217, 4.2177433 38.8228217))",
+                        featureChange.bounds().toWkt());
+            }
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTestRule.java
@@ -1,0 +1,19 @@
+package org.openstreetmap.atlas.geography.atlas.change;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * @author matthieun
+ */
+public class AtlasChangeGeneratorTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "nodeBoundsExpansionAtlas.josm.osm")
+    private Atlas nodeBoundsExpansionAtlas;
+
+    public Atlas getNodeBoundsExpansionAtlas()
+    {
+        return this.nodeBoundsExpansionAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -30,6 +30,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.collections.Sets;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 import org.openstreetmap.atlas.utilities.tuples.Tuple;
 
@@ -71,6 +72,30 @@ public class ChangeAtlasTest
         Assert.assertEquals("POLYGON ((-122.2450237 37.5920679, -122.2450237 37.5938873, "
                 + "-122.2412753 37.5938873, -122.2412753 37.5920679, -122.2450237 37.5920679))",
                 changeAtlas.bounds().toWkt());
+    }
+
+    @Test
+    public void testBuildFromScratch()
+    {
+        final ChangeBuilder changeBuilder = new ChangeBuilder();
+        final FeatureChange featureChange1 = FeatureChange.add(new CompleteArea(123L,
+                Polygon.SILICON_VALLEY, Maps.hashMap("k", "v"), Sets.hashSet(123L)));
+        changeBuilder.add(featureChange1);
+        final Change change = changeBuilder.get();
+        final Atlas result = new ChangeAtlas(change);
+        Assert.assertNotNull(result.area(123L));
+        Assert.assertEquals(0, Iterables.size(result.points()));
+    }
+
+    @Test
+    public void testBuildFromScratchError()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("ChangeAtlas needs all ADD featureChanges to be full");
+        final ChangeBuilder changeBuilder = new ChangeBuilder();
+        changeBuilder.add(getFeatureChangeUpdatedEdgePolyLine().getFirst());
+        final Change change = changeBuilder.get();
+        new ChangeAtlas(change);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
@@ -40,6 +40,17 @@ public class FeatureChangeTest
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
+    public void testAfterViewIsFull()
+    {
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
+                new CompleteArea(123L, null, Maps.hashMap("key1", "value1"), null));
+        Assert.assertFalse(featureChange1.afterViewIsFull());
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, new CompleteArea(
+                123L, Polygon.SILICON_VALLEY, Maps.hashMap("key1", "value2"), Sets.hashSet(123L)));
+        Assert.assertTrue(featureChange2.afterViewIsFull());
+    }
+
+    @Test
     public void testAreaSuperShallow()
     {
         this.expectedException.expect(CoreException.class);

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/nodeBoundsExpansionAtlas.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/nodeBoundsExpansionAtlas.josm.osm
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-177628' action='modify' visible='true' lat='38.82293376857' lon='4.21774333824' />
+  <node id='-177629' action='modify' visible='true' lat='38.82322294505' lon='4.21823823725' />
+  <node id='-177631' action='modify' visible='true' lat='38.82289990097' lon='4.2189103636' />
+  <node id='-177633' action='modify' visible='true' lat='38.82316563089' lon='4.2194855165' />
+  <node id='-177647' action='modify' visible='true' lat='38.82282174493' lon='4.21976974904' />
+  <node id='-177649' action='modify' visible='true' lat='38.82351472554' lon='4.21966608776' />
+  <way id='-177630' action='modify' visible='true'>
+    <nd ref='-177628' />
+    <nd ref='-177629' />
+    <nd ref='-177631' />
+    <nd ref='-177633' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-177648' action='modify' visible='true'>
+    <nd ref='-177647' />
+    <nd ref='-177633' />
+    <nd ref='-177649' />
+    <tag k='highway' v='footway' />
+  </way>
+</osm>


### PR DESCRIPTION
### Description:

With this update
- A ChangeAtlas can be created with no source Atlas. It needs to have at least one ADD FeatureChange, and all the ADD FeatureChanges need to be full.
- A Node feature change's bounds expand to contain all the attached Edge's bounds.

### Potential Impact:

New feature

### Unit Test Approach:

Added new tests

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
