### PR TITLE
Name a ChangeAtlas made only of changes

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -74,11 +74,16 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
 
     public ChangeAtlas(final Atlas source, final Change... changes)
     {
+        this(source, "", changes);
+    }
+
+    public ChangeAtlas(final Atlas source, final String name, final Change... changes)
+    {
         checkSource(source);
         checkChanges(changes);
         this.change = Change.merge(changes);
         this.source = source;
-        this.name = source.getName();
+        this.name = name == null || name.isEmpty() ? source.getName() : name;
         new AtlasValidator(this).validate();
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -84,6 +84,11 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
 
     public ChangeAtlas(final Change... changes)
     {
+        this("", changes);
+    }
+
+    public ChangeAtlas(final String name, final Change... changes)
+    {
         checkChanges(changes);
         final Change change = Change.merge(changes);
         boolean valid = false;
@@ -115,7 +120,7 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
             changeBuilder.add(dummy);
             this.change = changeBuilder.get();
             this.source = source;
-            this.name = source.getName();
+            this.name = name == null || name.isEmpty() ? source.getName() : name;
             new AtlasValidator(this).validate();
         }
         else


### PR DESCRIPTION
### Description:

This allows to name a ChangeAtlas made only of changes, and not have to use the default UUID name.

### Potential Impact:

Kept the old API, so this should have no impact.

### Unit Test Approach:

Kept existing unit test

### Test Results:

Kept existing unit test

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)