### PR TITLE
A few slicing changes

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/AtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/AtlasIntegrationTest.java
@@ -57,9 +57,7 @@ public class AtlasIntegrationTest
                 MultiPolygon.forPolygon(polygon)).build();
         if (atlasLoadingOption.isCountrySlicing())
         {
-            atlas = new RawAtlasCountrySlicer(
-                    atlasLoadingOption.getCountryBoundaryMap().getLoadedCountries(),
-                    atlasLoadingOption.getCountryBoundaryMap()).slice(atlas);
+            atlas = new RawAtlasCountrySlicer(atlasLoadingOption).slice(atlas);
         }
         if (atlasLoadingOption.isWaySectioning())
         {

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestIntegrationTest.java
@@ -243,7 +243,8 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
 
         final AtlasLoadingOption loadingOption = AtlasLoadingOption.createOptionWithAllEnabled(map);
         Atlas atlas = new RawAtlasGenerator(pbf, loadingOption, loadingArea).build();
-        atlas = new RawAtlasCountrySlicer(map.getLoadedCountries(), map).slice(atlas);
+        loadingOption.setAdditionalCountryCodes(map.getLoadedCountries());
+        atlas = new RawAtlasCountrySlicer(loadingOption).slice(atlas);
         atlas = new WaySectionProcessor(atlas, loadingOption).run();
         // Make sure that the big bridge over water made it to the Atlas
         Assert.assertNotNull(atlas.edge(308541861000000L));

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AbstractAtlas.java
@@ -108,8 +108,10 @@ public abstract class AbstractAtlas extends BareAtlas
             final WritableResource atlasResource, final CountryBoundaryMap boundaryMap)
     {
         Atlas atlas = new RawAtlasGenerator(osmPbf).build();
-        atlas = new RawAtlasCountrySlicer(boundaryMap.getLoadedCountries(), boundaryMap)
-                .slice(atlas);
+        final AtlasLoadingOption loadingOption = AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaryMap);
+        loadingOption.setAdditionalCountryCodes(boundaryMap.getLoadedCountries());
+        atlas = new RawAtlasCountrySlicer(loadingOption).slice(atlas);
         atlas = new WaySectionProcessor(atlas,
                 AtlasLoadingOption.createOptionWithAllEnabled(boundaryMap)).run();
         atlas.save(atlasResource);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/converters/AtlasDebugTool.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/converters/AtlasDebugTool.java
@@ -114,8 +114,7 @@ public class AtlasDebugTool extends Command
             atlas = new RawAtlasGenerator(pbf, option, multiPolygon).build();
             if (option.isCountrySlicing())
             {
-                atlas = new RawAtlasCountrySlicer(option.getCountryCodes(),
-                        option.getCountryBoundaryMap()).slice(atlas);
+                atlas = new RawAtlasCountrySlicer(option).slice(atlas);
             }
             atlas = new WaySectionProcessor(atlas, option).run();
             atlas.save(atlasFile);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/AbstractIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/AbstractIdentifierFactory.java
@@ -9,15 +9,21 @@ import org.openstreetmap.atlas.exception.CoreException;
  */
 public abstract class AbstractIdentifierFactory
 {
-    public static final long IDENTIFIER_SCALE = 1000;
+    public static final long IDENTIFIER_SCALE_DEFAULT = 1000;
 
     private final long[] referenceIdentifiers;
     private int index;
     private long delta;
+    private final long identifierScale;
 
     public AbstractIdentifierFactory(final long referenceIdentifier)
     {
         this(new long[] { referenceIdentifier });
+    }
+
+    public AbstractIdentifierFactory(final long referenceIdentifier, final long identifierScale)
+    {
+        this(new long[] { referenceIdentifier }, identifierScale);
     }
 
     public AbstractIdentifierFactory(final long[] referenceIdentifierArray)
@@ -25,6 +31,16 @@ public abstract class AbstractIdentifierFactory
         this.referenceIdentifiers = referenceIdentifierArray;
         this.delta = 0;
         this.index = 0;
+        this.identifierScale = IDENTIFIER_SCALE_DEFAULT;
+    }
+
+    public AbstractIdentifierFactory(final long[] referenceIdentifierArray,
+            final long identifierScale)
+    {
+        this.referenceIdentifiers = referenceIdentifierArray;
+        this.delta = 0;
+        this.index = 0;
+        this.identifierScale = identifierScale;
     }
 
     public long getDelta()
@@ -39,7 +55,7 @@ public abstract class AbstractIdentifierFactory
 
     public boolean hasMore()
     {
-        return this.delta < IDENTIFIER_SCALE - 1
+        return this.delta < this.identifierScale - 1
                 || this.index < this.referenceIdentifiers.length - 1;
     }
 
@@ -49,7 +65,7 @@ public abstract class AbstractIdentifierFactory
     {
         this.delta++;
 
-        if (this.delta >= IDENTIFIER_SCALE)
+        if (this.delta >= this.identifierScale)
         {
             if (this.index < this.referenceIdentifiers.length - 1)
             {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/AbstractIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/AbstractIdentifierFactory.java
@@ -79,4 +79,9 @@ public abstract class AbstractIdentifierFactory
             }
         }
     }
+
+    public long getIdentifierScale()
+    {
+        return this.identifierScale;
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/CountrySlicingIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/CountrySlicingIdentifierFactory.java
@@ -21,7 +21,8 @@ public class CountrySlicingIdentifierFactory extends AbstractIdentifierFactory
     public long nextIdentifier()
     {
         incrementDelta();
-        return (getReferenceIdentifier() / IDENTIFIER_SCALE + getDelta()) * IDENTIFIER_SCALE;
+        return (getReferenceIdentifier() / IDENTIFIER_SCALE_DEFAULT + getDelta())
+                * IDENTIFIER_SCALE_DEFAULT;
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/PointIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/PointIdentifierFactory.java
@@ -7,9 +7,11 @@ package org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier;
  */
 public class PointIdentifierFactory extends AbstractIdentifierFactory
 {
+    private static final long IDENFITIER_SCALE = 1000000;
+
     public PointIdentifierFactory(final long referenceIdentifier)
     {
-        super(referenceIdentifier);
+        super(referenceIdentifier, IDENFITIER_SCALE);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactory.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/pbf/slicing/identifier/ReverseIdentifierFactory.java
@@ -17,8 +17,9 @@ public class ReverseIdentifierFactory
      */
     public long getCountryCode(final long countryCodeAndWaySectionedIdentifier)
     {
-        return countryCodeAndWaySectionedIdentifier / AbstractIdentifierFactory.IDENTIFIER_SCALE
-                % AbstractIdentifierFactory.IDENTIFIER_SCALE;
+        return countryCodeAndWaySectionedIdentifier
+                / AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT
+                % AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT;
     }
 
     /**
@@ -31,8 +32,8 @@ public class ReverseIdentifierFactory
      */
     public long getCountryOsmIdentifier(final long countryCodeAndWaySectionedIdentifier)
     {
-        return Math.abs(
-                countryCodeAndWaySectionedIdentifier / AbstractIdentifierFactory.IDENTIFIER_SCALE);
+        return Math.abs(countryCodeAndWaySectionedIdentifier
+                / AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT);
     }
 
     /**
@@ -47,8 +48,8 @@ public class ReverseIdentifierFactory
     public long getFirstAtlasIdentifier(final long countryCodeAndWaySectionedIdentifier)
     {
         return Math.abs(getOsmIdentifier(countryCodeAndWaySectionedIdentifier)
-                * AbstractIdentifierFactory.IDENTIFIER_SCALE
-                * AbstractIdentifierFactory.IDENTIFIER_SCALE);
+                * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT
+                * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT);
     }
 
     /**
@@ -61,9 +62,9 @@ public class ReverseIdentifierFactory
      */
     public long getOsmIdentifier(final long countryCodeAndWaySectionedIdentifier)
     {
-        return Math.abs(
-                countryCodeAndWaySectionedIdentifier / (AbstractIdentifierFactory.IDENTIFIER_SCALE
-                        * AbstractIdentifierFactory.IDENTIFIER_SCALE));
+        return Math.abs(countryCodeAndWaySectionedIdentifier
+                / (AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT
+                        * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT));
     }
 
     /**
@@ -77,7 +78,7 @@ public class ReverseIdentifierFactory
      */
     public long getStartIdentifier(final long countryOsmIdentifier)
     {
-        return countryOsmIdentifier * AbstractIdentifierFactory.IDENTIFIER_SCALE;
+        return countryOsmIdentifier * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT;
     }
 
     /**
@@ -93,8 +94,8 @@ public class ReverseIdentifierFactory
      */
     public long getStartIdentifier(final long osmIdentifier, final long countryCode)
     {
-        return (osmIdentifier * AbstractIdentifierFactory.IDENTIFIER_SCALE + countryCode)
-                * AbstractIdentifierFactory.IDENTIFIER_SCALE;
+        return (osmIdentifier * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT + countryCode)
+                * AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT;
     }
 
     /**
@@ -106,6 +107,7 @@ public class ReverseIdentifierFactory
      */
     public long getWaySectionIndex(final long countryCodeAndWaySectionedIdentifier)
     {
-        return countryCodeAndWaySectionedIdentifier % AbstractIdentifierFactory.IDENTIFIER_SCALE;
+        return countryCodeAndWaySectionedIdentifier
+                % AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -28,6 +28,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.AbstractIdentifierFactory;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.CountrySlicingIdentifierFactory;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
@@ -109,15 +110,13 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
      * @param initialShard
      *            The initial shard being sliced-- should be the same as the line sliced Atlas
      *            passed in
-     * @param countries
-     *            The list of countries to slice
-     * @param countryBoundaryMap
-     *            The country boundaries
+     * @param loadingOption
+     *            The {@link AtlasLoadingOption} to use
      */
     public RawAtlasRelationSlicer(final Atlas atlas, final Shard initialShard,
-            final Set<String> countries, final CountryBoundaryMap countryBoundaryMap)
+            final AtlasLoadingOption loadingOption)
     {
-        super(countries, countryBoundaryMap, new CoordinateToNewPointMapping());
+        super(loadingOption, new CoordinateToNewPointMapping());
         this.partiallySlicedRawAtlas = atlas;
         this.initialShard = initialShard;
         this.slicedRelationChanges = new RelationChangeSet();
@@ -368,7 +367,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
         {
             throw new CoreException(
                     "Country Slicing exceeded maximum number {} of supported new points at Coordinate {}",
-                    AbstractIdentifierFactory.IDENTIFIER_SCALE, coordinate);
+                    AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT, coordinate);
         }
         else
         {
@@ -972,7 +971,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                         return;
                     }
 
-                    if (borderLines.size() >= AbstractIdentifierFactory.IDENTIFIER_SCALE)
+                    if (borderLines.size() >= AbstractIdentifierFactory.IDENTIFIER_SCALE_DEFAULT)
                     {
                         logger.error("Borderline got cut into more than 999 pieces for relation {}",
                                 relationIdentifier);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -14,10 +14,10 @@ import org.locationtech.jts.precision.PrecisionReducerCoordinateOperation;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
-import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.AbstractIdentifierFactory;
-import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.CountrySlicingIdentifierFactory;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.temporary.TemporaryPoint;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.converters.MultiplePolyLineToPolygonsConverter;
@@ -57,11 +57,7 @@ public abstract class RawAtlasSlicer
     protected static final PrecisionReducerCoordinateOperation PRECISION_REDUCER = new PrecisionReducerCoordinateOperation(
             PRECISION_MODEL, false);
 
-    // The countries we're interested in slicing against
-    private final Set<String> countries;
-
-    // Contains boundary MultiPolygons
-    private final CountryBoundaryMap countryBoundaryMap;
+    private final AtlasLoadingOption loadingOption;
 
     // Tracks all changes during the slicing process
     private final RawAtlasSlicingStatistic statistics = new RawAtlasSlicingStatistic(logger);
@@ -104,30 +100,20 @@ public abstract class RawAtlasSlicer
      *
      * @param coordinate
      *            The {@link Coordinate} of the new point
-     * @param pointIdentifierFactory
-     *            The {@link CountrySlicingIdentifierFactory} to calculate new point identifier
+     * @param pointIdentifier
+     *            The identifier to give the new point
      * @param pointTags
      *            The tags for this new point
      * @return the {@link TemporaryPoint}
      */
     protected static TemporaryPoint createNewPoint(final Coordinate coordinate,
-            final AbstractIdentifierFactory pointIdentifierFactory,
-            final Map<String, String> pointTags)
+            final long pointIdentifier, final Map<String, String> pointTags)
     {
-        if (!pointIdentifierFactory.hasMore())
-        {
-            throw new CoreException(
-                    "Country Slicing exceeded maximum number {} of supported new points at Coordinate {}",
-                    AbstractIdentifierFactory.IDENTIFIER_SCALE, coordinate);
-        }
-        else
-        {
-            // Add the synthetic boundary node tags
-            pointTags.put(SyntheticBoundaryNodeTag.KEY, SyntheticBoundaryNodeTag.YES.toString());
+        // Add the synthetic boundary node tags
+        pointTags.put(SyntheticBoundaryNodeTag.KEY, SyntheticBoundaryNodeTag.YES.toString());
 
-            return new TemporaryPoint(pointIdentifierFactory.nextIdentifier(),
-                    JTS_LOCATION_CONVERTER.backwardConvert(coordinate), pointTags);
-        }
+        return new TemporaryPoint(pointIdentifier,
+                JTS_LOCATION_CONVERTER.backwardConvert(coordinate), pointTags);
     }
 
     /**
@@ -158,11 +144,10 @@ public abstract class RawAtlasSlicer
                 one.getIdentifier(), two.getIdentifier());
     }
 
-    public RawAtlasSlicer(final Set<String> countries, final CountryBoundaryMap countryBoundaryMap,
+    public RawAtlasSlicer(final AtlasLoadingOption loadingOption,
             final CoordinateToNewPointMapping newPointCoordinates)
     {
-        this.countries = countries;
-        this.countryBoundaryMap = countryBoundaryMap;
+        this.loadingOption = loadingOption;
         this.newPointCoordinates = newPointCoordinates;
     }
 
@@ -242,17 +227,32 @@ public abstract class RawAtlasSlicer
 
     protected Set<String> getCountries()
     {
-        return this.countries;
+        return this.loadingOption.getCountryCodes();
     }
 
     protected CountryBoundaryMap getCountryBoundaryMap()
     {
-        return this.countryBoundaryMap;
+        return this.loadingOption.getCountryBoundaryMap();
     }
 
     protected RawAtlasSlicingStatistic getStatistics()
     {
         return this.statistics;
+    }
+
+    /**
+     * Determines if the given raw atlas {@link Line} qualifies to be an {@link Edge} in the final
+     * atlas. Relies on the underlying {@link AtlasLoadingOption} configuration to make the
+     * decision.
+     *
+     * @param line
+     *            The {@link Line} to check
+     * @return {@code true} if the given raw atlas {@link Line} qualifies to be an {@link Edge} in
+     *         the final atlas.
+     */
+    protected boolean isAtlasEdge(final Line line)
+    {
+        return this.loadingOption.getEdgeFilter().test(line);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -67,6 +67,10 @@ public abstract class RawAtlasSlicer
     // requiring the temporary point as a Line shape point
     private final CoordinateToNewPointMapping newPointCoordinates;
 
+    private final String shardOrAtlasName;
+
+    private final Atlas startingAtlas;
+
     /**
      * Assigns {@link ISOCountryTag} and {@link SyntheticNearestNeighborCountryCodeTag} values for a
      * given {@link Geometry}, which is a {@link Line} since we don't have other non-Point
@@ -145,10 +149,12 @@ public abstract class RawAtlasSlicer
     }
 
     public RawAtlasSlicer(final AtlasLoadingOption loadingOption,
-            final CoordinateToNewPointMapping newPointCoordinates)
+            final CoordinateToNewPointMapping newPointCoordinates, final Atlas startingAtlas)
     {
         this.loadingOption = loadingOption;
         this.newPointCoordinates = newPointCoordinates;
+        this.startingAtlas = startingAtlas;
+        this.shardOrAtlasName = getShardOrAtlasName(startingAtlas);
     }
 
     /**
@@ -275,5 +281,23 @@ public abstract class RawAtlasSlicer
 
         // Assume it's inside the bound
         return false;
+    }
+
+    private String getShardOrAtlasName(final Atlas atlas)
+    {
+        return atlas.metaData().getShardName().orElse(atlas.getName());
+    }
+
+    public String getShardOrAtlasName()
+    {
+        return this.shardOrAtlasName;
+    }
+
+    /**
+     * @return the {@link Atlas} to be sliced
+     */
+    public Atlas getStartingAtlas()
+    {
+        return this.startingAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestTest.java
@@ -184,8 +184,8 @@ public class OsmPbfIngestTest
                 new ConfiguredTaggableFilter(new StandardConfiguration(new InputStreamResource(
                         () -> OsmPbfIngestTest.class.getResourceAsStream("edge-filter.json")))));
         Atlas atlas = new RawAtlasGenerator(pbfFile, option, boundary).build();
-        atlas = new RawAtlasCountrySlicer(countryBoundaryMap.getLoadedCountries(),
-                countryBoundaryMap).slice(atlas);
+        option.setAdditionalCountryCodes(countryBoundaryMap.getLoadedCountries());
+        atlas = new RawAtlasCountrySlicer(option).slice(atlas);
         atlas = new WaySectionProcessor(atlas, option).run();
         logger.debug("Atlas: {}", atlas);
 
@@ -208,8 +208,7 @@ public class OsmPbfIngestTest
                     .setAdditionalCountryCodes(COUNTRY_1_NAME);
             Atlas atlas = new RawAtlasGenerator(() -> osmosis, loadingOption, MultiPolygon.MAXIMUM)
                     .build();
-            atlas = new RawAtlasCountrySlicer(COUNTRY_1_NAME, loadingOption.getCountryBoundaryMap())
-                    .slice(atlas);
+            atlas = new RawAtlasCountrySlicer(loadingOption).slice(atlas);
             atlas = new WaySectionProcessor(atlas, AtlasLoadingOption.createOptionWithNoSlicing())
                     .run();
             logger.info("{}", atlas);
@@ -245,8 +244,7 @@ public class OsmPbfIngestTest
                     .setAdditionalCountryCodes(COUNTRY_1_NAME);
             Atlas atlas = new RawAtlasGenerator(() -> osmosis, loadingOption, MultiPolygon.MAXIMUM)
                     .build();
-            atlas = new RawAtlasCountrySlicer(COUNTRY_1_NAME, loadingOption.getCountryBoundaryMap())
-                    .slice(atlas);
+            atlas = new RawAtlasCountrySlicer(loadingOption).slice(atlas);
             atlas = new WaySectionProcessor(atlas, AtlasLoadingOption.createOptionWithNoSlicing())
                     .run();
             logger.info("{}", atlas);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasTest.java
@@ -48,8 +48,8 @@ public class RawAtlasTest
         final Atlas rawAtlas = generator.build();
         logger.debug("Raw Atlas: {}", rawAtlas);
 
-        final Atlas slicedAtlas = new RawAtlasCountrySlicer("DNK", countryBoundaryMap)
-                .slice(rawAtlas);
+        option.setAdditionalCountryCodes("DNK");
+        final Atlas slicedAtlas = new RawAtlasCountrySlicer(option).slice(rawAtlas);
         logger.debug("Sliced Atlas: {}", slicedAtlas);
 
         // Check the top node 3089123457 has the proper tagging - nearest neighbor and on the
@@ -98,8 +98,8 @@ public class RawAtlasTest
         // 39019000000
         Assert.assertNotNull(rawAtlas.line(39019000000L));
 
-        final Atlas slicedAtlas = new RawAtlasCountrySlicer("DMA", countryBoundaryMap)
-                .slice(rawAtlas);
+        option.setAdditionalCountryCodes("DMA");
+        final Atlas slicedAtlas = new RawAtlasCountrySlicer(option).slice(rawAtlas);
         logger.debug("Sliced Atlas: {}", slicedAtlas);
 
         // Line partially inside, should be included

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/InvalidMultipolygonSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/InvalidMultipolygonSlicingTest.java
@@ -1,13 +1,11 @@
 package org.openstreetmap.atlas.geography.atlas.raw.slicing;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.complex.buildings.ComplexBuildingFinder;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
@@ -19,23 +17,18 @@ import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
  */
 public class InvalidMultipolygonSlicingTest
 {
-    private static CountryBoundaryMap COUNTRY_BOUNDARY_MAP;
-    private static Set<String> COUNTRIES;
-    private static RawAtlasCountrySlicer RAW_ATLAS_SLICER;
+    private static RawAtlasCountrySlicer rawAtlasSlicer;
 
     static
     {
-        COUNTRIES = new HashSet<>();
-        COUNTRIES.add("CIV");
-        COUNTRIES.add("GIN");
-        COUNTRIES.add("LBR");
+        final AtlasLoadingOption loadingOption = AtlasLoadingOption.createOptionWithAllEnabled(
+                CountryBoundaryMap.fromPlainText(new InputStreamResource(
+                        () -> InvalidMultipolygonSlicingTest.class.getResourceAsStream(
+                                "CIV_GIN_LBR_osm_boundaries_with_grid_index.txt.gz"))
+                                        .withDecompressor(Decompressor.GZIP)));
+        loadingOption.setAdditionalCountryCodes("CIV", "GIN", "LBR");
+        rawAtlasSlicer = new RawAtlasCountrySlicer(loadingOption);
 
-        COUNTRY_BOUNDARY_MAP = CountryBoundaryMap
-                .fromPlainText(new InputStreamResource(() -> InvalidMultipolygonSlicingTest.class
-                        .getResourceAsStream("CIV_GIN_LBR_osm_boundaries_with_grid_index.txt.gz"))
-                                .withDecompressor(Decompressor.GZIP));
-
-        RAW_ATLAS_SLICER = new RawAtlasCountrySlicer(COUNTRIES, COUNTRY_BOUNDARY_MAP);
     }
 
     @Rule
@@ -52,7 +45,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(8, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         Assert.assertEquals(rawAtlas.numberOfPoints(), slicedAtlas.numberOfPoints());
         Assert.assertEquals(rawAtlas.numberOfLines(), slicedAtlas.numberOfLines());
@@ -70,7 +63,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(8, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -101,7 +94,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(4, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -126,7 +119,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(4, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -150,7 +143,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(4, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -175,7 +168,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(4, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -200,7 +193,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(8, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we cannot build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
@@ -224,14 +217,15 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(10, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
+        System.out.println(slicedAtlas);
 
         // Assert that we CAN build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)
                 .forEach(building -> Assert.assertFalse(building.getError().isPresent()));
 
         Assert.assertEquals(29, slicedAtlas.numberOfPoints());
-        Assert.assertEquals(8, slicedAtlas.numberOfLines());
+        Assert.assertEquals(7, slicedAtlas.numberOfLines());
         Assert.assertEquals(rawAtlas.numberOfRelations() * 2, slicedAtlas.numberOfRelations());
     }
 
@@ -246,7 +240,7 @@ public class InvalidMultipolygonSlicingTest
         Assert.assertEquals(10, rawAtlas.numberOfPoints());
         Assert.assertEquals(1, rawAtlas.numberOfRelations());
 
-        final Atlas slicedAtlas = RAW_ATLAS_SLICER.slice(rawAtlas);
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
 
         // Assert that we CAN build a valid building with this relation
         new ComplexBuildingFinder().find(slicedAtlas)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTestRule.java
@@ -70,6 +70,19 @@ public class LineAndPointSlicingTestRule extends CoreTestRule
 
     @TestAtlas(
 
+            points = { @Point(id = "1", coordinates = @Loc(value = AREA_CIV_SIDE_1)),
+                    @Point(id = "2", coordinates = @Loc(value = AREA_CIV_SIDE_2)),
+                    @Point(id = "3", coordinates = @Loc(value = AREA_LBR_SIDE_3)),
+                    @Point(id = "4", coordinates = @Loc(value = AREA_LBR_SIDE_4)) },
+
+            lines = { @Line(id = "1", coordinates = { @Loc(value = AREA_CIV_SIDE_1),
+                    @Loc(value = AREA_CIV_SIDE_2), @Loc(value = AREA_LBR_SIDE_3),
+                    @Loc(value = AREA_LBR_SIDE_4),
+                    @Loc(value = AREA_CIV_SIDE_1) }, tags = { "highway=primary" }) })
+    private Atlas closedEdgeSpanningTwoCountries;
+
+    @TestAtlas(
+
             points = { @Point(id = "1", coordinates = @Loc(value = OUTSIDE_ALL_COUNTRIES_1)),
                     @Point(id = "2", coordinates = @Loc(value = OUTSIDE_ALL_COUNTRIES_2)) },
 
@@ -106,7 +119,7 @@ public class LineAndPointSlicingTestRule extends CoreTestRule
             points = { @Point(id = "1", coordinates = @Loc(value = LIBERIA_END)),
                     @Point(id = "2", coordinates = @Loc(value = IVORY_COAST_END)) },
 
-            lines = { @Line(id = "1", coordinates = { @Loc(value = LIBERIA_END),
+            lines = { @Line(id = "1000", coordinates = { @Loc(value = LIBERIA_END),
                     @Loc(value = IVORY_COAST_END) }, tags = { "highway=primary" }) })
     private Atlas roadAcrossTwoCountries;
 
@@ -129,6 +142,11 @@ public class LineAndPointSlicingTestRule extends CoreTestRule
                     @Loc(value = ON_LIBERIA_AND_IVORY_COAST_BORDER),
                     @Loc(value = IVORY_COAST_END) }, tags = { "highway=primary" }) })
     private Atlas roadAcrossTwoCountriesWithPointOnBorder;
+
+    public Atlas getClosedEdgeSpanningTwoCountriesAtlas()
+    {
+        return this.closedEdgeSpanningTwoCountries;
+    }
 
     public Atlas getClosedLineFullyInOneCountryAtlas()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTestRule.java
@@ -176,12 +176,12 @@ public class RelationSlicingTestRule extends CoreTestRule
 
             lines = { @Line(id = "106036000000", coordinates = { @Loc(value = LOCATION_28),
                     @Loc(value = LOCATION_21), @Loc(value = LOCATION_27), @Loc(value = LOCATION_26),
-                    @Loc(value = LOCATION_28) }, tags = { "highway=primary" }),
+                    @Loc(value = LOCATION_28) }, tags = { "water=natural" }),
 
                     @Line(id = "106034000000", coordinates = { @Loc(value = LOCATION_23),
                             @Loc(value = LOCATION_29), @Loc(value = LOCATION_24),
                             @Loc(value = LOCATION_25), @Loc(value = LOCATION_22),
-                            @Loc(value = LOCATION_23) }, tags = { "highway=secondary" }) },
+                            @Loc(value = LOCATION_23) }, tags = { "water=natural" }) },
 
             relations = {
 


### PR DESCRIPTION
### Description:

This PR makes a number of changes around country slicing for lines. First, an issue has been fixed with respect to closed Line slicing. Previously, all closed Lines were being cast to Polygon geometry, then sliced. While this makes sense initially, as the closed line is a valid Polygon geometry, there is an Edge case (ha!) that must be consider-- some closed Lines will later become Edges during way-sectioning. If these Lines (future Edges) are sliced as Polygons, then the slicer will attempt to preserve closed geometry by using the lines in the boundary map. For example, in the unit test LineAndPointSlicingTest.testClosedLineSpanningTwoCountries(), the following closed Line spans two countries:

<img width="898" alt="closedLineSpanningTwoCountriesUnitTestRaw" src="https://user-images.githubusercontent.com/1475347/54894015-da2c7e80-4e75-11e9-91c5-99be947caa57.png">

After slicing, it's bisected by the country boundary line as two closed shapes:

<img width="663" alt="closedLineSpanningTwoCountriesUnitTestSliced1" src="https://user-images.githubusercontent.com/1475347/54894163-8d957300-4e76-11e9-9be0-5bf4daf36d84.png">
<img width="658" alt="closedLineSpanningTwoCountriesUnitTestSliced2" src="https://user-images.githubusercontent.com/1475347/54894165-9128fa00-4e76-11e9-9531-ce7cc4311245.png">

For many closed Lines, this makes sense-- this is treating them like a future Area object. However, for Lines that are future Edges, this is problematic; Edges are intended for navigable Lines, and this logic will unintentionally create a navigable Edge along the boundary. In order to fix this, all Lines are now checked against the Line to Edge configuration filter; should a closed Line qualify as an Edge, it is simply sliced as a Line. The result can be seen in the unit test LineAndPointSlicingTest.testClosedEdgeSpanningTwoCountries(), which uses the same test data as above but with tagging that ensures the Line qualifies as an Edge. The resulting sliced Line looks like this:

<img width="673" alt="closedEdgeSpanningTwoCountriesUnitTestSliced1" src="https://user-images.githubusercontent.com/1475347/54894471-00ebb480-4e78-11e9-9da1-050d1fb6ef8a.png">
<img width="730" alt="closedEdgeSpanningTwoCountriesUnitTestSliced2" src="https://user-images.githubusercontent.com/1475347/54894472-02b57800-4e78-11e9-8246-a84a60cff6ec.png">


The second major fix included in this PR changes the output of Line slicing to be more consistent. Previously, all returned slices from the JTS geometry calls were treated as independent valid Line slices. However, this approach is naive; there are cases in which slices are both within the same country and also intersect. Given that the original geometry is a single line, it makes sense to attempt to preserve this by condensing any intersecting Line slices. For example, in the unit test above for the closed Edge spanning two countries, the original slicing behavior returned the following output:

<img width="1005" alt="closedEdgeSpanningTwoCountriesUnitTestSlicedUnmerged1" src="https://user-images.githubusercontent.com/1475347/54894739-4492ee00-4e79-11e9-82fa-6ad5caec54b4.png">
<img width="935" alt="closedEdgeSpanningTwoCountriesUnitTestSlicedUnmerged2" src="https://user-images.githubusercontent.com/1475347/54894741-478dde80-4e79-11e9-93e3-e57a82046ac6.png">
<img width="933" alt="closedEdgeSpanningTwoCountriesUnitTestSlicedUnmerged3" src="https://user-images.githubusercontent.com/1475347/54894743-4957a200-4e79-11e9-9af8-16c37c358fc6.png">

This output isn't ideal-- the two Line slices for the right hand side are really just an artifact of the way the Line is divided during the slicing operation, not due to any necessity. The fix for this simply uses JTS intersect calls on all slices return for the same country; any intersecting geometry will be merged, and any non-intersecting geometry will be left as-is. 

While this could be a concerning change given that it will pass all sliced geometry through this merge logic, testing shows almost entirely unchanged behavior, other than the above listed unit test. Only two other test data changed, the first of which was the following Line from RawAtlasIntegrationTest. Previously, slicing on Line 313508037 resulted in two sliced Lines with intersecting coordinates:

`[Line: id=313508037004000, polyLine=LINESTRING (-8.204767 7.549113, -8.204767 7.549113), [Tags: [last_edit_user_name => Daniel Specht], [last_edit_changeset => 26878374], [last_edit_time => 1416361534000], [last_edit_user_id => 2393795], [iso_country_code => GIN], [highway => unclassified], [last_edit_version => 1]]]`
And
`[Line: id=313508037003000, polyLine=LINESTRING (-8.2051141 7.5487909, -8.204767 7.549113), [Tags: [last_edit_user_name => Daniel Specht], [last_edit_changeset => 26878374], [last_edit_time => 1416361534000], [last_edit_user_id => 2393795], [iso_country_code => GIN], [highway => unclassified], [last_edit_version => 1]]]`

After the merge code, the result is the much more reasonable single joined line 
`[Line: id=313508037003000, polyLine=LINESTRING (-8.2051141 7.5487909, -8.204767 7.549113), [Tags: [last_edit_user_name => Daniel Specht], [last_edit_changeset => 26878374], [last_edit_time => 1416361534000], [last_edit_user_id => 2393795], [iso_country_code => GIN], [highway => unclassified], [last_edit_version => 1]]]`

The second test change from this was for InvalidMultipolygonSlicingTest.testSelfIntersectingOuterRelationAcrossBoundary(). This change is because while the Line being sliced is closed, it's an invalid Polygon geometry due to being a self-intersecting Line. When a closed Line can't be cast to Polygon because of this, it is sliced like a standard Polyline; this is the same behavior that is now default for Edge slicing. The merge code will now close the slices from the beginning and end of the Line, resulting in a cleaner look. Here's the before:

<img width="746" alt="invalidPolygonSlice1Before" src="https://user-images.githubusercontent.com/1475347/54949016-4a311800-4efb-11e9-8246-7bc1c1b87397.png">
<img width="819" alt="invalidPolygonSlice2Before" src="https://user-images.githubusercontent.com/1475347/54949017-4bfadb80-4efb-11e9-839d-f1c56c69f31c.png">

And here's after, joined since they intersect:

<img width="693" alt="invalidPolygonSlice1After" src="https://user-images.githubusercontent.com/1475347/54949029-5321e980-4efb-11e9-9947-c4996ac55b38.png">


Lastly, the number of allowable Points per Line has been upped to 100000, and the PointAndLineSlicer code has been somewhat refactored to increase readability. 

### Potential Impact:
Hopefully none, as data should be largely the same. 

### Unit Test Approach:

Unit tests detailed above.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)