### PR TITLE
Fix source-sink bug with DAG processGroups

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraph.java
@@ -3,12 +3,15 @@ package org.openstreetmap.atlas.utilities.graphs;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.utilities.maps.LinkedMultiMap;
@@ -142,12 +145,14 @@ public class DirectedAcyclicGraph<V> implements Serializable
      * @return The ordered groups of vertices that all belong to the same priority level within the
      *         DAG
      */
-    public List<Set<V>> processGroups()
+    // NOSONAR: Cognitive complexity 16 is ok.
+    public List<Set<V>> processGroups() // NOSONAR
     {
-        final Stack<Set<V>> stack = new Stack<>();
+        final Deque<Set<V>> stack = new LinkedList<>();
         stack.push(new HashSet<>(getSinks()));
         final Set<V> added = new HashSet<>(getSinks());
-        final Set<V> sourcesNotAdded = new HashSet<>(getSources());
+        final Set<V> sourcesNotAdded = getSources().stream().filter(value -> !added.contains(value))
+                .collect(Collectors.toSet());
         while (!sourcesNotAdded.isEmpty())
         {
             final Set<V> potentialCandidates = new HashSet<>();

--- a/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
@@ -24,6 +24,13 @@ import org.openstreetmap.atlas.utilities.collections.Sets;
  */
 public class DirectedAcyclicGraphTest
 {
+    private static final String PLATINUM = "Platinum";
+    private static final String GOLD = "Gold";
+    private static final String COPPER = "Copper";
+    private static final String PRECIOUS = "Precious";
+    private static final String COINAGE = "Coinage";
+    private static final String METAL = "Metal";
+
     private final DirectedAcyclicGraph<String> graph;
 
     public DirectedAcyclicGraphTest()
@@ -35,38 +42,38 @@ public class DirectedAcyclicGraphTest
     public void setup()
     {
         // Vertices
-        this.graph.addVertex("Platinum");
-        this.graph.addVertex("Gold");
-        this.graph.addVertex("Copper");
-        this.graph.addVertex("Precious");
-        this.graph.addVertex("Coinage");
-        this.graph.addVertex("Metal");
+        this.graph.addVertex(PLATINUM);
+        this.graph.addVertex(GOLD);
+        this.graph.addVertex(COPPER);
+        this.graph.addVertex(PRECIOUS);
+        this.graph.addVertex(COINAGE);
+        this.graph.addVertex(METAL);
 
         // Edges
-        this.graph.addEdge("Metal", "Coinage");
-        this.graph.addEdge("Metal", "Precious");
-        this.graph.addEdge("Precious", "Platinum");
-        this.graph.addEdge("Precious", "Gold");
-        this.graph.addEdge("Coinage", "Gold");
-        this.graph.addEdge("Coinage", "Copper");
+        this.graph.addEdge(METAL, COINAGE);
+        this.graph.addEdge(METAL, PRECIOUS);
+        this.graph.addEdge(PRECIOUS, PLATINUM);
+        this.graph.addEdge(PRECIOUS, GOLD);
+        this.graph.addEdge(COINAGE, GOLD);
+        this.graph.addEdge(COINAGE, COPPER);
     }
 
     @Test
     public void testDeepestLevel()
     {
-        assertEquals(this.graph.getDeepestLevel("Metal"), 1);
-        assertEquals(this.graph.getDeepestLevel("Gold"), 3);
+        assertEquals(this.graph.getDeepestLevel(METAL), 1);
+        assertEquals(this.graph.getDeepestLevel(GOLD), 3);
     }
 
     @Test
     public void testPaths()
     {
-        assertTrue(this.graph.hasPath("Metal", "Copper"));
-        assertTrue(this.graph.hasPath("Metal", "Platinum"));
-        assertFalse(this.graph.hasPath("Coinage", "Platinum"));
+        assertTrue(this.graph.hasPath(METAL, COPPER));
+        assertTrue(this.graph.hasPath(METAL, PLATINUM));
+        assertFalse(this.graph.hasPath(COINAGE, PLATINUM));
 
         // Adding this edge will cause a cycle, which is not allowed in a DAG
-        Assert.assertTrue(!this.graph.addEdge("Copper", "Metal"));
+        Assert.assertTrue(!this.graph.addEdge(COPPER, METAL));
     }
 
     @Test
@@ -74,9 +81,9 @@ public class DirectedAcyclicGraphTest
     {
         final List<Set<String>> processGroups = this.graph.processGroups();
         final List<Set<String>> expected = new ArrayList<>();
-        final Set<String> first = Sets.hashSet("Metal");
-        final Set<String> second = Sets.hashSet("Precious", "Coinage");
-        final Set<String> third = Sets.hashSet("Gold", "Platinum", "Copper");
+        final Set<String> first = Sets.hashSet(METAL);
+        final Set<String> second = Sets.hashSet(PRECIOUS, COINAGE);
+        final Set<String> third = Sets.hashSet(GOLD, PLATINUM, COPPER);
         expected.add(first);
         expected.add(second);
         expected.add(third);
@@ -84,32 +91,41 @@ public class DirectedAcyclicGraphTest
     }
 
     @Test
+    public void testProcessGroupsWithSourceSinks()
+    {
+        final DirectedAcyclicGraph<String> dag = new DirectedAcyclicGraph<>();
+        dag.addVertex("a");
+        dag.addVertex("b");
+        dag.addVertex("c");
+        final List<Set<String>> processGroups = dag.processGroups();
+        Assert.assertEquals(1, processGroups.size());
+    }
+
+    @Test
     public void testSinks()
     {
-        final Set<String> expectedSinks = new HashSet<>(
-                Arrays.asList("Platinum", "Gold", "Copper"));
-        assertTrue(this.graph.getSinks().stream().allMatch(sink -> expectedSinks.remove(sink))
+        final Set<String> expectedSinks = new HashSet<>(Arrays.asList(PLATINUM, GOLD, COPPER));
+        assertTrue(this.graph.getSinks().stream().allMatch(expectedSinks::remove)
                 && expectedSinks.isEmpty());
     }
 
     @Test
     public void testSources()
     {
-        final Set<String> expectedSources = new HashSet<>(Arrays.asList("Metal"));
-        assertTrue(
-                this.graph.getSources().stream().allMatch(source -> expectedSources.remove(source))
-                        && expectedSources.isEmpty());
+        final Set<String> expectedSources = new HashSet<>(Arrays.asList(METAL));
+        assertTrue(this.graph.getSources().stream().allMatch(expectedSources::remove)
+                && expectedSources.isEmpty());
     }
 
     @Test
     public void testTopologicalSort()
     {
         final Stack<String> topologicalSort = this.graph.getTopologicalSortedList();
-        Assert.assertEquals("Metal", topologicalSort.pop());
-        Assert.assertEquals("Coinage", topologicalSort.pop());
-        Assert.assertEquals("Precious", topologicalSort.pop());
-        Assert.assertEquals("Copper", topologicalSort.pop());
-        Assert.assertEquals("Gold", topologicalSort.pop());
-        Assert.assertEquals("Platinum", topologicalSort.pop());
+        Assert.assertEquals(METAL, topologicalSort.pop());
+        Assert.assertEquals(COINAGE, topologicalSort.pop());
+        Assert.assertEquals(PRECIOUS, topologicalSort.pop());
+        Assert.assertEquals(COPPER, topologicalSort.pop());
+        Assert.assertEquals(GOLD, topologicalSort.pop());
+        Assert.assertEquals(PLATINUM, topologicalSort.pop());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/graphs/DirectedAcyclicGraphTest.java
@@ -61,8 +61,8 @@ public class DirectedAcyclicGraphTest
     @Test
     public void testDeepestLevel()
     {
-        assertEquals(this.graph.getDeepestLevel(METAL), 1);
-        assertEquals(this.graph.getDeepestLevel(GOLD), 3);
+        assertEquals(1, this.graph.getDeepestLevel(METAL));
+        assertEquals(3, this.graph.getDeepestLevel(GOLD));
     }
 
     @Test


### PR DESCRIPTION
### Description:

DAG ProcessGroups would be stuck in the event of a Vertex being a source and a sink at the same time.

Also:
- Fixed some sonar issues.

### Potential Impact:

One less bug

### Unit Test Approach:

Added one unit test for the use case.

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
