### PR TITLE
Throw exception when groovy predicate is unparseable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -82,7 +82,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         }
         catch (final Exception exception)
         {
-            return null;
+            throw new CoreException("Unable to parse {} into a predicate.", string, exception);
         }
     }
 


### PR DESCRIPTION
### Description:

The String parser returning a predicate would just quietly return null when the groovy string is unparseable. With that update, it returns the exception with detail.

### Potential Impact:

Downstream tools expecting to silently return null on error will have to handle the exception.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
