### PR TITLE
AtlasDiff now uses atlas context

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffHelper.java
@@ -552,44 +552,6 @@ public final class AtlasDiffHelper
         return false;
     }
 
-    private static boolean entitiesWereDifferentInRelations(final AtlasEntity beforeEntity, // NOSONAR
-            final AtlasEntity afterEntity)
-    {
-        try
-        {
-            final Set<Relation> beforeRelations = beforeEntity.relations();
-            final Set<Relation> afterRelations = afterEntity.relations();
-
-            if (beforeRelations.size() != afterRelations.size())
-            {
-                return true;
-            }
-            for (final Relation beforeRelation : beforeRelations)
-            {
-                Relation afterRelation = null;
-                for (final Relation afterRelationCandidate : afterRelations)
-                {
-                    if (afterRelationCandidate.getIdentifier() == beforeRelation.getIdentifier())
-                    {
-                        afterRelation = afterRelationCandidate;
-                        break;
-                    }
-                }
-                if (afterRelation == null)
-                {
-                    // The two relation sets are different
-                    return true;
-                }
-            }
-            return false;
-        }
-        catch (final Exception exception)
-        {
-            throw new CoreException("Unable to compare relations for {} and {}", beforeEntity,
-                    afterEntity, exception);
-        }
-    }
-
     private AtlasDiffHelper()
     {
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
@@ -10,7 +10,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,11 +34,7 @@ public class FeatureChangeUsefulnessValidator
 
     public void validate()
     {
-        logger.info("Starting validation of FeatureChange {}", this.featureChange);
-        final Time start = Time.now();
         validateFeatureChange();
-        logger.info("Finished validation of FeatureChange {} in {}", this.featureChange,
-                start.elapsedSince());
     }
 
     private void validateFeatureChange()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
@@ -18,6 +18,8 @@ public class AtlasDiffTest
 {
     private static final Logger logger = LoggerFactory.getLogger(AtlasDiffTest.class);
 
+    private static final int IGNORE_EXPECTED_NUMBER_CHANGES = -1;
+
     @Rule
     public AtlasDiffTestRule rule = new AtlasDiffTestRule();
 
@@ -32,7 +34,7 @@ public class AtlasDiffTest
 
         atlasX = this.rule.simpleAtlas3();
         atlasY = this.rule.simpleAtlas4();
-        expectedNumberOfChanges = 16;
+        expectedNumberOfChanges = 15;
 
         assertChangeAtlasConsistency(atlasX, atlasY, expectedNumberOfChanges);
     }
@@ -80,7 +82,7 @@ public class AtlasDiffTest
 
         atlasX = this.rule.differentRelations3();
         atlasY = this.rule.differentRelations4();
-        expectedNumberOfChanges = 7;
+        expectedNumberOfChanges = 5;
 
         assertChangeAtlasConsistency(atlasX, atlasY, expectedNumberOfChanges);
     }
@@ -101,9 +103,13 @@ public class AtlasDiffTest
         final Change changeBeforeToAfter = new AtlasDiff(beforeAtlas, afterAtlas).generateChange()
                 .orElseThrow(() -> new CoreException(
                         "This Change should never be empty. The unit test may be broken."));
-        changeBeforeToAfter.changes()
-                .forEach(change -> logger.trace("{}: {}", change, change.getAfterView()));
-        Assert.assertEquals(expectedNumberOfChanges, changeBeforeToAfter.changeCount());
+        changeBeforeToAfter.changes().forEach(change -> logger.trace("{}:\n{} ->\n{}", change,
+                change.getBeforeView(), change.getAfterView()));
+
+        if (expectedNumberOfChanges != IGNORE_EXPECTED_NUMBER_CHANGES)
+        {
+            Assert.assertEquals(expectedNumberOfChanges, changeBeforeToAfter.changeCount());
+        }
         final ChangeAtlas changeAfterAtlas = new ChangeAtlas(beforeAtlas, changeBeforeToAfter);
 
         // test both ways to catch any slip-ups in the code

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
@@ -76,7 +76,7 @@ public class AtlasDiffTest
     {
         Atlas atlasX = this.rule.differentRelations1();
         Atlas atlasY = this.rule.differentRelations2();
-        int expectedNumberOfChanges = 7;
+        int expectedNumberOfChanges = 9;
 
         assertChangeAtlasConsistency(atlasX, atlasY, expectedNumberOfChanges);
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTestRule.java
@@ -390,6 +390,9 @@ public class AtlasDiffTestRule extends CoreTestRule
 
             },
 
+            points = {
+                    @Point(id = "5", coordinates = @Loc(value = FIVE), tags = { "tag1=value1" }), },
+
             lines = {
 
                     @Line(id = "12", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
@@ -400,7 +403,7 @@ public class AtlasDiffTestRule extends CoreTestRule
 
                     @Relation(id = "31", tags = { "type=relation" }, members = {
 
-                            @Member(id = "5", role = "a", type = "node"),
+                            @Member(id = "5", role = "a", type = "point"),
                             @Member(id = "7", role = "a", type = "node")
 
                     }),


### PR DESCRIPTION
### Description:

`AtlasDiff` now uses the `before` atlas as context for the `FeatureChange`s it creates. This creates lighter weight diffs, since it can now leverage the more robust merging code provided by `FeatureChange` when a beforeView is present. Additionally, once `FeatureChange` GeoJSON supports the beforeView properties, the `AtlasDiff` GeoJSON output will be much richer (and include a detailed beforeView for the user's convenience).

### Potential Impact:

The only impact is that `AtlasDiff` now produces `Change` objects with fewer constituent `FeatureChange`s in some cases.

### Unit Test Approach:

Updated some unit tests to handle the impact outline in the **Potential Impact** section.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
