### PR TITLE
Allow for empty changes in AtlasChangeGenerator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -85,6 +85,11 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
     {
         final Set<FeatureChange> result = expandNodeBounds(atlas, generateWithoutValidation(atlas));
 
+        if (result.isEmpty())
+        {
+            return result;
+        }
+
         // Validate
         final ChangeBuilder builder = new ChangeBuilder();
         result.forEach(builder::add);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -25,6 +25,14 @@ public class AtlasChangeGeneratorTest
     public final AtlasChangeGeneratorTestRule rule = new AtlasChangeGeneratorTestRule();
 
     @Test
+    public void testEmptyChange()
+    {
+        final AtlasChangeGenerator generator = atlas -> new HashSet<>();
+        final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
+        Assert.assertTrue(generator.apply(source).isEmpty());
+    }
+
+    @Test
     public void testExpandNode()
     {
         final Atlas source = this.rule.getNodeBoundsExpansionAtlas();


### PR DESCRIPTION
### Description:

Allow for empty changes in AtlasChangeGenerator. It would previously fail during validation which would wrongly create an empty Change object.

### Potential Impact:

One less bug for this corner case.

### Unit Test Approach:

Added one test for the new behavior.

### Test Results:

Test passes

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)