### PR TITLE
Force Atlas context to be applied in AtlasChangeGenerator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -84,6 +84,7 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
     default Set<FeatureChange> generate(final Atlas atlas)
     {
         final Set<FeatureChange> result = expandNodeBounds(atlas, generateWithoutValidation(atlas));
+        result.stream().forEach(featureChange -> featureChange.withAtlasContext(atlas));
 
         // Validate
         final ChangeBuilder builder = new ChangeBuilder();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -200,6 +200,22 @@ public class FeatureChange implements Located, Serializable
     }
 
     /**
+     * Specify the Atlas on which this {@link FeatureChange} is based. {@link FeatureChange} objects
+     * with a contextual Atlas are able to calculate their before view, and so are able to leverage
+     * richer and more robust merging mechanics.
+     *
+     * @param atlas
+     *            the contextual atlas
+     * @return the updated {@link FeatureChange}
+     */
+    FeatureChange withAtlasContext(final Atlas atlas)
+    {
+        computeBeforeViewUsingAtlasContext(atlas, this.changeType);
+        new FeatureChangeUsefulnessValidator(this).validate();
+        return this;
+    }
+
+    /**
      * Check if this {@link FeatureChange}'s afterView is full. A full afterView is a
      * {@link CompleteEntity} that has all its fields set to non-null values.
      *
@@ -654,21 +670,5 @@ public class FeatureChange implements Located, Serializable
         {
             throw new CoreException("{} was shallow (i.e. it contained only an identifier)", this);
         }
-    }
-
-    /**
-     * Specify the Atlas on which this {@link FeatureChange} is based. {@link FeatureChange} objects
-     * with a contextual Atlas are able to calculate their before view, and so are able to leverage
-     * richer and more robust merging mechanics.
-     *
-     * @param atlas
-     *            the contextual atlas
-     * @return the updated {@link FeatureChange}
-     */
-    private FeatureChange withAtlasContext(final Atlas atlas)
-    {
-        computeBeforeViewUsingAtlasContext(atlas, this.changeType);
-        new FeatureChangeUsefulnessValidator(this).validate();
-        return this;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -57,4 +57,14 @@ public class AtlasChangeGeneratorTest
             }
         }
     }
+
+    @Test
+    public void testValidBeforeView()
+    {
+        final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
+        final AtlasChangeGenerator generator = atlas -> Sets
+                .hashSet(FeatureChange.add(CompleteNode.shallowFrom(source.node(177628000000L))
+                        .withAddedTag("highway", "traffic_signals")));
+        Assert.assertNotNull(generator.apply(source).iterator().next().getBeforeView());
+    }
 }


### PR DESCRIPTION
### Description:

Force Atlas context to be applied in `AtlasChangeGenerator`

### Potential Impact:

Each `FeatureChange` created by `AtlasChangeGenerator` will have a before view.

### Unit Test Approach:

Added one test

### Test Results:

Test passes

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)