### PR TITLE
ChangeAtlas performance improvements

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.conversion.Converter;
+import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
 
 /**
  * Something that takes an {@link Atlas} and produces a set of {@link FeatureChange} that should be
@@ -21,49 +22,63 @@ import org.openstreetmap.atlas.utilities.conversion.Converter;
  */
 public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange>>, Serializable
 {
-    static Set<FeatureChange> expandNodeBounds(final Atlas atlas,
+    static Set<FeatureChange> expandNodeBounds(final Atlas atlas, // NOSONAR
             final Set<FeatureChange> featureChanges)
     {
         final Set<FeatureChange> result = new HashSet<>();
+        final Set<FeatureChange> nodes = new HashSet<>();
+        final MultiMapWithSet<Long, Rectangle> nodeIdentifierToConnectedEdgeBounds = new MultiMapWithSet<>();
         for (final FeatureChange featureChange : featureChanges)
         {
-            if (featureChange.getItemType() == ItemType.NODE)
+            final ItemType itemType = featureChange.getItemType();
+            if (itemType == ItemType.NODE)
             {
-                Rectangle newBounds = featureChange.bounds();
-                final long originalNodeIdentifier = featureChange.getIdentifier();
-                final CompleteNode originalCompleteNode = (CompleteNode) featureChange
-                        .getAfterView();
-                final Node originalNode = atlas.node(originalNodeIdentifier);
-                if (originalNode != null)
-                {
-                    for (final Edge originalEdge : originalNode.connectedEdges())
-                    {
-                        newBounds = newBounds.combine(originalEdge.bounds());
-                    }
-                }
-                for (final FeatureChange featureChangeInner : featureChanges)
-                {
-                    if (featureChangeInner.getItemType() == ItemType.EDGE)
-                    {
-                        final Edge changedEdge = (Edge) featureChangeInner.getAfterView();
-                        if (changedEdge.start() != null
-                                && changedEdge.start().getIdentifier() == originalNodeIdentifier
-                                || changedEdge.end() != null && changedEdge.end()
-                                        .getIdentifier() == originalNodeIdentifier)
-                        {
-                            newBounds = newBounds.combine(changedEdge.bounds());
-                        }
-                    }
-                }
-                final FeatureChange newFeatureChange = new FeatureChange(
-                        featureChange.getChangeType(),
-                        originalCompleteNode.withBoundsExtendedBy(newBounds));
-                result.add(newFeatureChange);
+                nodes.add(featureChange);
             }
             else
             {
                 result.add(featureChange);
+                if (itemType == ItemType.EDGE)
+                {
+                    final Edge changedEdge = (Edge) featureChange.getAfterView();
+                    final Node start = changedEdge.start();
+                    final Node end = changedEdge.end();
+                    final Rectangle bounds = changedEdge.bounds();
+                    if (start != null)
+                    {
+                        nodeIdentifierToConnectedEdgeBounds.add(start.getIdentifier(), bounds);
+                    }
+                    if (end != null)
+                    {
+                        nodeIdentifierToConnectedEdgeBounds.add(end.getIdentifier(), bounds);
+                    }
+                }
             }
+        }
+        for (final FeatureChange featureChange : nodes)
+        {
+            Rectangle newBounds = featureChange.bounds();
+            final Long originalNodeIdentifier = featureChange.getIdentifier();
+            final CompleteNode originalCompleteNode = (CompleteNode) featureChange.getAfterView();
+            final Node originalNode = atlas.node(originalNodeIdentifier);
+            if (originalNode != null)
+            {
+                for (final Edge originalEdge : originalNode.connectedEdges())
+                {
+                    newBounds = newBounds.combine(originalEdge.bounds());
+                }
+            }
+            if (nodeIdentifierToConnectedEdgeBounds.containsKey(originalNodeIdentifier))
+            {
+                for (final Rectangle bounds : nodeIdentifierToConnectedEdgeBounds
+                        .get(originalNodeIdentifier))
+                {
+                    newBounds = newBounds.combine(bounds);
+                }
+            }
+            final FeatureChange newFeatureChange = new FeatureChange(featureChange.getChangeType(),
+                    originalCompleteNode.withBoundsExtendedBy(newBounds));
+            result.add(newFeatureChange);
         }
         return result;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -106,11 +106,12 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
             return result;
         }
 
-        // Validate
         final ChangeBuilder builder = new ChangeBuilder();
         result.forEach(builder::add);
         final Change change = builder.get();
-        new ChangeAtlas(atlas, change);
+
+        // Validate
+        validate(atlas, change);
         // Return the already merged changes
         return change.changes().collect(Collectors.toSet());
     }
@@ -127,5 +128,10 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
     default String getName()
     {
         return this.getClass().getSimpleName();
+    }
+
+    default void validate(final Atlas source, final Change change)
+    {
+        new ChangeAtlas(source, change).validate();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
@@ -58,9 +59,9 @@ public class ChangeArea extends Area // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
-                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                        getChangeAtlas()));
+        final Supplier<Set<Relation>> creator = () -> ChangeEntity
+                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Area, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
@@ -61,7 +61,8 @@ public class ChangeArea extends Area // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Area, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
@@ -58,21 +58,9 @@ public class ChangeArea extends Area // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     private <T extends Object> T attribute(final Function<Area, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -511,12 +511,13 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
      *            relation with no members.
      * @return
      */
-    private <E> E getFromCacheOrCreate(Map<Long, E> cache, final Consumer<Map<Long, E>> cacheSetter,
-            final Object lock, final E nullPlaceholder, final Long identifier,
-            final Supplier<E> creator, final Optional<Predicate<E>> entityNullable)
+    private <E> E getFromCacheOrCreate(final Map<Long, E> cache,
+            final Consumer<Map<Long, E>> cacheSetter, final Object lock, final E nullPlaceholder,
+            final Long identifier, final Supplier<E> creator,
+            final Optional<Predicate<E>> entityNullable)
     {
         // Get or create the cache (in case it was null)
-        cache = ChangeEntity.getOrCreateCache(cache, cacheSetter, lock, ConcurrentHashMap::new);
+        ChangeEntity.getOrCreateCache(cache, cacheSetter, lock, ConcurrentHashMap::new);
         E result;
         if (cache.containsKey(identifier))
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -53,6 +53,7 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
     private final Change change;
     private final Atlas source;
     private String name;
+    private boolean validated = false;
 
     private transient Rectangle bounds;
     private transient AtlasMetaData metaData;
@@ -119,7 +120,7 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
         this.change = Change.merge(changes);
         this.source = source;
         this.name = name == null || name.isEmpty() ? source.getName() : name;
-        new AtlasValidator(this).validate();
+        this.validate();
     }
 
     public ChangeAtlas(final Change... changes)
@@ -390,6 +391,15 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
     public Iterable<Relation> relations()
     {
         return entitiesFor(ItemType.RELATION, this::relation, this.source.relations());
+    }
+
+    public void validate()
+    {
+        if (!this.validated)
+        {
+            new AtlasValidator(this).validate();
+            this.validated = true;
+        }
     }
 
     public ChangeAtlas withName(final String name)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlas.java
@@ -517,12 +517,13 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
             final Optional<Predicate<E>> entityNullable)
     {
         // Get or create the cache (in case it was null)
-        ChangeEntity.getOrCreateCache(cache, cacheSetter, lock, ConcurrentHashMap::new);
+        final Map<Long, E> cacheIn = ChangeEntity.getOrCreateCache(cache, cacheSetter, lock,
+                ConcurrentHashMap::new);
         E result;
-        if (cache.containsKey(identifier))
+        if (cacheIn.containsKey(identifier))
         {
             // Retrieve an existing object
-            result = cache.get(identifier);
+            result = cacheIn.get(identifier);
             result = result == nullPlaceholder ? null : result;
         }
         else
@@ -532,12 +533,12 @@ public class ChangeAtlas extends AbstractAtlas // NOSONAR
             if (result == null || entityNullable.isPresent() && entityNullable.get().test(result))
             {
                 // If the created object is null, or nullable, use the null placeholder
-                cache.put(identifier, nullPlaceholder);
+                cacheIn.put(identifier, nullPlaceholder);
                 result = null;
             }
             else
             {
-                cache.put(identifier, result);
+                cacheIn.put(identifier, result);
             }
         }
         return result;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
@@ -56,6 +56,7 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public Node end()
     {
+        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
         Node localEndNode = this.endNodeCache;
         if (localEndNode == null)
         {
@@ -92,26 +93,15 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     @Override
     public Node start()
     {
+        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
         Node localStartNode = this.startNodeCache;
         if (localStartNode == null)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -56,21 +57,8 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public Node end()
     {
-        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
-        Node localEndNode = this.endNodeCache;
-        if (localEndNode == null)
-        {
-            synchronized (this.endNodeCacheLock)
-            {
-                localEndNode = this.endNodeCache;
-                if (localEndNode == null)
-                {
-                    localEndNode = getChangeAtlas().node(endNodeIdentifier());
-                    this.endNodeCache = localEndNode;
-                }
-            }
-        }
-        return localEndNode;
+        final Supplier<Node> creator = () -> getChangeAtlas().node(endNodeIdentifier());
+        return ChangeEntity.getOrCreateCache(this.endNodeCache, this.endNodeCacheLock, creator);
     }
 
     public long endNodeIdentifier()
@@ -93,29 +81,16 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
-                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                        getChangeAtlas()));
+        final Supplier<Set<Relation>> creator = () -> ChangeEntity
+                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
     }
 
     @Override
     public Node start()
     {
-        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
-        Node localStartNode = this.startNodeCache;
-        if (localStartNode == null)
-        {
-            synchronized (this.startNodeCacheLock)
-            {
-                localStartNode = this.startNodeCache;
-                if (localStartNode == null)
-                {
-                    localStartNode = getChangeAtlas().node(startNodeIdentifier());
-                    this.startNodeCache = localStartNode;
-                }
-            }
-        }
-        return localStartNode;
+        final Supplier<Node> creator = () -> getChangeAtlas().node(startNodeIdentifier());
+        return ChangeEntity.getOrCreateCache(this.startNodeCache, this.startNodeCacheLock, creator);
     }
 
     public long startNodeIdentifier()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
@@ -58,7 +58,8 @@ public class ChangeEdge extends Edge // NOSONAR
     public Node end()
     {
         final Supplier<Node> creator = () -> getChangeAtlas().node(endNodeIdentifier());
-        return ChangeEntity.getOrCreateCache(this.endNodeCache, this.endNodeCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.endNodeCache, cache -> this.endNodeCache = cache,
+                this.endNodeCacheLock, creator);
     }
 
     public long endNodeIdentifier()
@@ -83,14 +84,16 @@ public class ChangeEdge extends Edge // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     @Override
     public Node start()
     {
         final Supplier<Node> creator = () -> getChangeAtlas().node(startNodeIdentifier());
-        return ChangeEntity.getOrCreateCache(this.startNodeCache, this.startNodeCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.startNodeCache,
+                cache -> this.startNodeCache = cache, this.startNodeCacheLock, creator);
     }
 
     public long startNodeIdentifier()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -105,7 +105,18 @@ public final class ChangeEntity
         return result;
     }
 
-    static <V> V getOrCreateCache(V fieldCache, final Object lock, final Supplier<V> supplier)
+    /**
+     * @param <V>
+     *            The cached value type
+     * @param fieldCache
+     *            The cache
+     * @param lock
+     *            The synchronization lock to access the cache
+     * @param creator
+     *            The original creator of the type if the cache does not contain it.
+     * @return Either the cached value or the freshly created one.
+     */
+    static <V> V getOrCreateCache(V fieldCache, final Object lock, final Supplier<V> creator)
     {
         V localRelationCache = fieldCache;
         if (localRelationCache == null)
@@ -115,7 +126,7 @@ public final class ChangeEntity
                 localRelationCache = fieldCache; // NOSONAR
                 if (localRelationCache == null) // NOSONAR
                 {
-                    fieldCache = supplier.get();
+                    fieldCache = creator.get();
                     localRelationCache = fieldCache;
                 }
             }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -102,6 +103,24 @@ public final class ChangeEntity
             throw new CoreException("Could not retrieve attribute from source nor backup!");
         }
         return result;
+    }
+
+    static <V> V getOrCreateCache(V fieldCache, final Object lock, final Supplier<V> supplier)
+    {
+        V localRelationCache = fieldCache;
+        if (localRelationCache == null)
+        {
+            synchronized (lock) // NOSONAR
+            {
+                localRelationCache = fieldCache; // NOSONAR
+                if (localRelationCache == null) // NOSONAR
+                {
+                    fieldCache = supplier.get();
+                    localRelationCache = fieldCache;
+                }
+            }
+        }
+        return localRelationCache;
     }
 
     private ChangeEntity()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -110,13 +111,16 @@ public final class ChangeEntity
      *            The cached value type
      * @param fieldCache
      *            The cache
+     * @param cacheSetter
+     *            A function that will set the cache not null in case it was null.
      * @param lock
      *            The synchronization lock to access the cache
      * @param creator
      *            The original creator of the type if the cache does not contain it.
      * @return Either the cached value or the freshly created one.
      */
-    static <V> V getOrCreateCache(V fieldCache, final Object lock, final Supplier<V> creator)
+    static <V> V getOrCreateCache(final V fieldCache, final Consumer<V> cacheSetter,
+            final Object lock, final Supplier<V> creator)
     {
         V localRelationCache = fieldCache;
         if (localRelationCache == null)
@@ -126,8 +130,8 @@ public final class ChangeEntity
                 localRelationCache = fieldCache; // NOSONAR
                 if (localRelationCache == null) // NOSONAR
                 {
-                    fieldCache = creator.get();
-                    localRelationCache = fieldCache;
+                    localRelationCache = creator.get();
+                    cacheSetter.accept(localRelationCache);
                 }
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
@@ -58,21 +58,9 @@ public class ChangeLine extends Line // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     private <T extends Object> T attribute(final Function<Line, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -58,9 +59,9 @@ public class ChangeLine extends Line // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
-                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                        getChangeAtlas()));
+        final Supplier<Set<Relation>> creator = () -> ChangeEntity
+                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Line, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
@@ -61,7 +61,8 @@ public class ChangeLine extends Line // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Line, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -82,7 +82,8 @@ public class ChangeNode extends Node // NOSONAR
                 .map(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier))
                 .collect(Collectors.toCollection(TreeSet::new));
 
-        return ChangeEntity.getOrCreateCache(this.inEdgesCache, this.inEdgesCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.inEdgesCache, cache -> this.inEdgesCache = cache,
+                this.inEdgesCacheLock, creator);
     }
 
     public SortedSet<Long> outEdgeIdentifiers()
@@ -99,7 +100,8 @@ public class ChangeNode extends Node // NOSONAR
                 .map(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier))
                 .collect(Collectors.toCollection(TreeSet::new));
 
-        return ChangeEntity.getOrCreateCache(this.outEdgesCache, this.outEdgesCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.outEdgesCache,
+                cache -> this.outEdgesCache = cache, this.outEdgesCacheLock, creator);
     }
 
     @Override
@@ -107,7 +109,8 @@ public class ChangeNode extends Node // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Node, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -77,6 +77,7 @@ public class ChangeNode extends Node // NOSONAR
     @Override
     public SortedSet<Edge> inEdges()
     {
+        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
         SortedSet<Edge> localInEdges = this.inEdgesCache;
         if (localInEdges == null)
         {
@@ -105,6 +106,7 @@ public class ChangeNode extends Node // NOSONAR
     @Override
     public SortedSet<Edge> outEdges()
     {
+        return ChangeEntity.getOrCreateCache(fieldCache, lock, supplier);
         SortedSet<Edge> localOutEdges = this.outEdgesCache;
         if (localOutEdges == null)
         {
@@ -126,21 +128,9 @@ public class ChangeNode extends Node // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     private <T extends Object> T attribute(final Function<Node, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
@@ -60,7 +60,8 @@ public class ChangePoint extends Point // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Point, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
@@ -57,21 +57,9 @@ public class ChangePoint extends Point // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     private <T extends Object> T attribute(final Function<Point, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -57,9 +58,9 @@ public class ChangePoint extends Point // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
-                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                        getChangeAtlas()));
+        final Supplier<Set<Relation>> creator = () -> ChangeEntity
+                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> T attribute(final Function<Point, T> memberExtractor)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -115,21 +115,9 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        Set<Relation> localRelations = this.relationsCache;
-        if (localRelations == null)
-        {
-            synchronized (this.relationsCacheLock)
-            {
-                localRelations = this.relationsCache;
-                if (localRelations == null)
-                {
-                    localRelations = ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                            getChangeAtlas());
-                    this.relationsCache = localRelations;
-                }
-            }
-        }
-        return localRelations;
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
+                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
+                        getChangeAtlas()));
     }
 
     private <T extends Object> List<T> allAvailableAttributes(

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -118,7 +118,8 @@ public class ChangeRelation extends Relation // NOSONAR
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
                 .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
+        return ChangeEntity.getOrCreateCache(this.relationsCache,
+                cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> List<T> allAvailableAttributes(

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
@@ -115,9 +116,9 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public Set<Relation> relations()
     {
-        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock,
-                () -> ChangeEntity.filterRelations(attribute(AtlasEntity::relations),
-                        getChangeAtlas()));
+        final Supplier<Set<Relation>> creator = () -> ChangeEntity
+                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+        return ChangeEntity.getOrCreateCache(this.relationsCache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> List<T> allAvailableAttributes(

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -75,7 +75,7 @@ public class ChangeRelation extends Relation // NOSONAR
     }
 
     @Override
-    public synchronized RelationMemberList members()
+    public RelationMemberList members()
     {
         RelationMemberList localMembers = this.membersCache;
         if (localMembers == null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -29,7 +29,6 @@ import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.geography.atlas.validators.FeatureChangeUsefulnessValidator;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 
 /**
@@ -193,10 +192,6 @@ public class FeatureChange implements Located, Serializable
         }
 
         this.validateNotShallow();
-        if (this.beforeView != null)
-        {
-            new FeatureChangeUsefulnessValidator(this).validate();
-        }
     }
 
     /**
@@ -211,7 +206,6 @@ public class FeatureChange implements Located, Serializable
     FeatureChange withAtlasContext(final Atlas atlas)
     {
         computeBeforeViewUsingAtlasContext(atlas, this.changeType);
-        new FeatureChangeUsefulnessValidator(this).validate();
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -29,6 +29,7 @@ import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.validators.FeatureChangeUsefulnessValidator;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 
 /**
@@ -192,6 +193,10 @@ public class FeatureChange implements Located, Serializable
         }
 
         this.validateNotShallow();
+        if (this.beforeView != null)
+        {
+            new FeatureChangeUsefulnessValidator(this).validate();
+        }
     }
 
     /**
@@ -206,6 +211,7 @@ public class FeatureChange implements Located, Serializable
     FeatureChange withAtlasContext(final Atlas atlas)
     {
         computeBeforeViewUsingAtlasContext(atlas, this.changeType);
+        new FeatureChangeUsefulnessValidator(this).validate();
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -326,7 +326,7 @@ public class FeatureChange implements Located, Serializable
 
     public ItemType getItemType()
     {
-        return ItemType.forEntity(getAfterView());
+        return getAfterView().getType();
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidator.java
@@ -31,8 +31,7 @@ public class AtlasValidator
         final Time start = Time.now();
         logger.trace("Starting relation validation of Atlas {}", this.atlas.getName());
         final Time startRelations = Time.now();
-        validateRelationsPresent();
-        validateRelationsLinked();
+        validateRelationsPresentAndLinked();
         logger.trace("Finished relation validation of Atlas {} in {}", this.atlas.getName(),
                 startRelations.elapsedSince());
         logger.trace("Starting tags validation of Atlas {}", this.atlas.getName());
@@ -48,24 +47,7 @@ public class AtlasValidator
                 start.elapsedSince());
     }
 
-    protected void validateRelationsLinked()
-    {
-        for (final AtlasEntity entity : this.atlas.entities())
-        {
-            for (final Relation relation : entity.relations())
-            {
-                if (!relation.members().asBean()
-                        .getItemFor(entity.getIdentifier(), entity.getType()).isPresent())
-                {
-                    throw new CoreException(
-                            "Entity {} {} lists parent relation {} which does not have it as a member.",
-                            entity.getType(), entity.getIdentifier(), relation.getIdentifier());
-                }
-            }
-        }
-    }
-
-    protected void validateRelationsPresent()
+    protected void validateRelationsPresentAndLinked()
     {
         for (final AtlasEntity entity : this.atlas.entities())
         {
@@ -80,6 +62,13 @@ public class AtlasValidator
                                     .map(parent -> parent == null ? "null"
                                             : String.valueOf(parent.getIdentifier()))
                                     .collect(Collectors.toSet()));
+                }
+                if (!relation.members().asBean()
+                        .getItemFor(entity.getIdentifier(), entity.getType()).isPresent())
+                {
+                    throw new CoreException(
+                            "Entity {} {} lists parent relation {} which does not have it as a member.",
+                            entity.getType(), entity.getIdentifier(), relation.getIdentifier());
                 }
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
@@ -10,9 +10,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.utilities.time.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Validate that a {@link FeatureChange} actually introduces changes. This will throw an exception
@@ -23,9 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class FeatureChangeUsefulnessValidator
 {
-    private static final Logger logger = LoggerFactory
-            .getLogger(FeatureChangeUsefulnessValidator.class);
-
     private final FeatureChange featureChange;
 
     public FeatureChangeUsefulnessValidator(final FeatureChange featureChange)
@@ -35,17 +29,7 @@ public class FeatureChangeUsefulnessValidator
 
     public void validate()
     {
-        if (logger.isTraceEnabled())
-        {
-            logger.trace("Starting validation of FeatureChange {}", this.featureChange);
-        }
-        final Time start = Time.now();
         validateFeatureChange();
-        if (logger.isTraceEnabled())
-        {
-            logger.trace("Finished validation of FeatureChange {} in {}", this.featureChange,
-                    start.elapsedSince());
-        }
     }
 
     private void validateFeatureChange()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/validators/FeatureChangeUsefulnessValidator.java
@@ -35,11 +35,17 @@ public class FeatureChangeUsefulnessValidator
 
     public void validate()
     {
-        logger.info("Starting validation of FeatureChange {}", this.featureChange);
+        if (logger.isTraceEnabled())
+        {
+            logger.trace("Starting validation of FeatureChange {}", this.featureChange);
+        }
         final Time start = Time.now();
         validateFeatureChange();
-        logger.info("Finished validation of FeatureChange {} in {}", this.featureChange,
-                start.elapsedSince());
+        if (logger.isTraceEnabled())
+        {
+            logger.trace("Finished validation of FeatureChange {} in {}", this.featureChange,
+                    start.elapsedSince());
+        }
     }
 
     private void validateFeatureChange()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -21,6 +21,8 @@ import org.openstreetmap.atlas.utilities.collections.Sets;
  */
 public class AtlasChangeGeneratorTest
 {
+    public static final String HIGHWAY = "highway";
+
     @Rule
     public final AtlasChangeGeneratorTestRule rule = new AtlasChangeGeneratorTestRule();
 
@@ -49,9 +51,9 @@ public class AtlasChangeGeneratorTest
         // bonus!
         result.add(FeatureChange.add(new CompleteEdge(123L, PolyLine.wkt(
                 "LINESTRING (4.2194855 38.8231656, 4.2202479 38.8233871, 4.2200000 38.8235147)"),
-                Maps.hashMap("highway", "primary"), 177633000000L, 456L, Sets.hashSet())));
+                Maps.hashMap(HIGHWAY, "primary"), 177633000000L, 456L, Sets.hashSet())));
         result.add(FeatureChange.add(new CompleteNode(456L,
-                Location.forWkt("POINT (4.2200000 38.8235147)"), Maps.hashMap("highway", "primary"),
+                Location.forWkt("POINT (4.2200000 38.8235147)"), Maps.hashMap(HIGHWAY, "primary"),
                 Sets.treeSet(), Sets.treeSet(123L), Sets.hashSet())));
         final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
         for (final FeatureChange featureChange : changes)
@@ -70,9 +72,8 @@ public class AtlasChangeGeneratorTest
     public void testValidBeforeView()
     {
         final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
-        final AtlasChangeGenerator generator = atlas -> Sets
-                .hashSet(FeatureChange.add(CompleteNode.shallowFrom(source.node(177628000000L))
-                        .withAddedTag("highway", "traffic_signals")));
+        final AtlasChangeGenerator generator = atlas -> Sets.hashSet(FeatureChange.add(CompleteNode
+                .shallowFrom(source.node(177628000000L)).withAddedTag(HIGHWAY, "traffic_signals")));
         Assert.assertNotNull(generator.apply(source).iterator().next().getBeforeView());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/validators/AtlasValidatorTest.java
@@ -50,7 +50,7 @@ public class AtlasValidatorTest
         this.expectedException.expect(CoreException.class);
         this.expectedException.expectMessage("lists some parent relation that is not present");
 
-        new AtlasValidator(atlas).validateRelationsPresent();
+        new AtlasValidator(atlas).validateRelationsPresentAndLinked();
     }
 
     @Test


### PR DESCRIPTION
### Description:

> Below, "forgiveness" means the action `ChangeAtlas` takes to infer potentially missing `FeatureChange` object. For example, if one point is removed, but the relation it belongs to is not updated, `ChangeAtlas` will automatically update the relation member list to get rid of the point.

- `ChangeAtlas` caches its relations, which are very expensive to compute (due to forgiveness).
- `ChangeRelation` caches its member list, which is very expensive to compute (due to forgiveness).
- `ChangeEdge` caches its start/end nodes, which are very expensive to compute (due to forgiveness).
- `ChangeNode` caches its in/out edges, which are very expensive to compute (due to forgiveness).
- All ChangeItems cache their parent relations, which are very expensive to compute (due to forgiveness).
- `AtlasChangeGenerator`'s `expandNodeBounds` retooled with an index to avoid the nested for loops.
  - Added a `// NOSONAR` here to avoid breaking that method in a lot of other static methods within the interface.

### Potential Impact:

A nice speedup in ChangeAtlas validation (quadratic to linear)

### Unit Test Approach:

Updated existing tests.

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)