### PR TITLE
ChangeAtlas: have member extraction names for better debugging

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeArea.java
@@ -41,33 +41,34 @@ public class ChangeArea extends Area // NOSONAR
     @Override
     public Polygon asPolygon()
     {
-        return attribute(Area::asPolygon);
+        return attribute(Area::asPolygon, "polygon");
     }
 
     @Override
     public long getIdentifier()
     {
-        return attribute(Area::getIdentifier);
+        return attribute(Area::getIdentifier, "identifier");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Area::getTags);
+        return attribute(Area::getTags, "tags");
     }
 
     @Override
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
-    private <T extends Object> T attribute(final Function<Area, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Area, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEdge.java
@@ -51,7 +51,7 @@ public class ChangeEdge extends Edge // NOSONAR
     @Override
     public PolyLine asPolyLine()
     {
-        return attribute(Edge::asPolyLine);
+        return attribute(Edge::asPolyLine, "polyLine");
     }
 
     @Override
@@ -64,26 +64,26 @@ public class ChangeEdge extends Edge // NOSONAR
 
     public long endNodeIdentifier()
     {
-        return attribute(Edge::end).getIdentifier();
+        return attribute(Edge::end, "end node").getIdentifier();
     }
 
     @Override
     public long getIdentifier()
     {
-        return attribute(Edge::getIdentifier);
+        return attribute(Edge::getIdentifier, "identifier");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Edge::getTags);
+        return attribute(Edge::getTags, "tags");
     }
 
     @Override
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
@@ -98,12 +98,13 @@ public class ChangeEdge extends Edge // NOSONAR
 
     public long startNodeIdentifier()
     {
-        return attribute(Edge::start).getIdentifier();
+        return attribute(Edge::start, "start node").getIdentifier();
     }
 
-    private <T extends Object> T attribute(final Function<Edge, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Edge, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -74,7 +74,7 @@ public final class ChangeEntity
         if (result.isEmpty())
         {
             throw new CoreException(
-                    "Could not retrieve attribute {} from override nor source!\noverride: {}\nsource:{}",
+                    "Could not retrieve attribute \"{}\" from override nor source!\noverride: {}\nsource:{}",
                     name, override, source);
         }
         return result;
@@ -109,7 +109,7 @@ public final class ChangeEntity
         if (result == null)
         {
             throw new CoreException(
-                    "Could not retrieve attribute {} from override nor source!\noverride: {}\nsource:{}",
+                    "Could not retrieve attribute \"{}\" from override nor source!\noverride: {}\nsource:{}",
                     name, override, source);
         }
         return result;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeEntity.java
@@ -39,6 +39,8 @@ public final class ChangeEntity
      * Get all the available attributes asked from the change entity (override), and/or from the
      * backup entity.
      *
+     * @param name
+     *            The name of the extraction operation
      * @param source
      *            The source entity
      * @param override
@@ -48,7 +50,8 @@ public final class ChangeEntity
      * @return The corresponding attribute list. Will not be empty.
      */
     static <T extends Object, M extends AtlasEntity> List<T> getAttributeAndOptionallyBackup(
-            final M source, final M override, final Function<M, T> memberExtractor)
+            final M source, final M override, final Function<M, T> memberExtractor,
+            final String name)
     {
         final List<T> result = new ArrayList<>();
         if (override != null)
@@ -70,7 +73,9 @@ public final class ChangeEntity
         }
         if (result.isEmpty())
         {
-            throw new CoreException("Could not retrieve attribute from source nor backup!");
+            throw new CoreException(
+                    "Could not retrieve attribute {} from override nor source!\noverride: {}\nsource:{}",
+                    name, override, source);
         }
         return result;
     }
@@ -79,6 +84,8 @@ public final class ChangeEntity
      * Get either the attribute asked from the change entity (override), or from the backup entity
      * if unavailable.
      *
+     * @param name
+     *            The name of the extraction operation
      * @param source
      *            The source entity
      * @param override
@@ -88,7 +95,7 @@ public final class ChangeEntity
      * @return The corresponding attribute
      */
     static <T extends Object, M extends AtlasEntity> T getAttributeOrBackup(final M source,
-            final M override, final Function<M, T> memberExtractor)
+            final M override, final Function<M, T> memberExtractor, final String name)
     {
         T result = null;
         if (override != null)
@@ -101,7 +108,9 @@ public final class ChangeEntity
         }
         if (result == null)
         {
-            throw new CoreException("Could not retrieve attribute from source nor backup!");
+            throw new CoreException(
+                    "Could not retrieve attribute {} from override nor source!\noverride: {}\nsource:{}",
+                    name, override, source);
         }
         return result;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeLine.java
@@ -41,33 +41,34 @@ public class ChangeLine extends Line // NOSONAR
     @Override
     public PolyLine asPolyLine()
     {
-        return attribute(Line::asPolyLine);
+        return attribute(Line::asPolyLine, "polyLine");
     }
 
     @Override
     public long getIdentifier()
     {
-        return attribute(Line::getIdentifier);
+        return attribute(Line::getIdentifier, "identifier");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Line::getTags);
+        return attribute(Line::getTags, "tags");
     }
 
     @Override
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
-    private <T extends Object> T attribute(final Function<Line, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Line, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -53,24 +53,24 @@ public class ChangeNode extends Node // NOSONAR
     @Override
     public long getIdentifier()
     {
-        return attribute(Node::getIdentifier);
+        return attribute(Node::getIdentifier, "identifier");
     }
 
     @Override
     public Location getLocation()
     {
-        return attribute(Node::getLocation);
+        return attribute(Node::getLocation, "location");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Node::getTags);
+        return attribute(Node::getTags, "tags");
     }
 
     public SortedSet<Long> inEdgeIdentifiers()
     {
-        return attribute(Node::inEdges).stream().map(Edge::getIdentifier)
+        return attribute(Node::inEdges, "in edges").stream().map(Edge::getIdentifier)
                 .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
                 .collect(Collectors.toCollection(TreeSet::new));
     }
@@ -88,7 +88,7 @@ public class ChangeNode extends Node // NOSONAR
 
     public SortedSet<Long> outEdgeIdentifiers()
     {
-        return attribute(Node::outEdges).stream().map(Edge::getIdentifier)
+        return attribute(Node::outEdges, "out edges").stream().map(Edge::getIdentifier)
                 .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
                 .collect(Collectors.toCollection(TreeSet::new));
     }
@@ -108,14 +108,15 @@ public class ChangeNode extends Node // NOSONAR
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
-    private <T extends Object> T attribute(final Function<Node, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Node, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangePoint.java
@@ -40,33 +40,34 @@ public class ChangePoint extends Point // NOSONAR
     @Override
     public long getIdentifier()
     {
-        return attribute(Point::getIdentifier);
+        return attribute(Point::getIdentifier, "identifier");
     }
 
     @Override
     public Location getLocation()
     {
-        return attribute(Point::getLocation);
+        return attribute(Point::getLocation, "location");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Point::getTags);
+        return attribute(Point::getTags, "tags");
     }
 
     @Override
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
-    private <T extends Object> T attribute(final Function<Point, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Point, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeRelation.java
@@ -51,27 +51,29 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public RelationMemberList allKnownOsmMembers()
     {
-        return membersFor(attribute(Relation::allKnownOsmMembers).asBean());
+        return membersFor(
+                attribute(Relation::allKnownOsmMembers, "all known osm members").asBean());
     }
 
     @Override
     public List<Relation> allRelationsWithSameOsmIdentifier()
     {
-        return attribute(Relation::allRelationsWithSameOsmIdentifier).stream()
-                .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
-                .collect(Collectors.toList());
+        return attribute(Relation::allRelationsWithSameOsmIdentifier,
+                "all relations with same osm identifier").stream()
+                        .map(relation -> getChangeAtlas().relation(relation.getIdentifier()))
+                        .collect(Collectors.toList());
     }
 
     @Override
     public long getIdentifier()
     {
-        return attribute(Relation::getIdentifier);
+        return attribute(Relation::getIdentifier, "identifier");
     }
 
     @Override
     public Map<String, String> getTags()
     {
-        return attribute(Relation::getTags);
+        return attribute(Relation::getTags, "tags");
     }
 
     @Override
@@ -80,7 +82,7 @@ public class ChangeRelation extends Relation // NOSONAR
         final Supplier<RelationMemberList> creator = () ->
         {
             final List<RelationMemberList> availableMemberLists = allAvailableAttributes(
-                    Relation::members);
+                    Relation::members, "members");
             final RelationBean mergedMembersBean = availableMemberLists.stream()
                     .map(RelationMemberList::asBean)
                     .reduce(new RelationBean(), RelationBean::merge);
@@ -103,28 +105,29 @@ public class ChangeRelation extends Relation // NOSONAR
     @Override
     public Long osmRelationIdentifier()
     {
-        return attribute(Relation::osmRelationIdentifier);
+        return attribute(Relation::osmRelationIdentifier, "osm relation identifier");
     }
 
     @Override
     public Set<Relation> relations()
     {
         final Supplier<Set<Relation>> creator = () -> ChangeEntity
-                .filterRelations(attribute(AtlasEntity::relations), getChangeAtlas());
+                .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
     }
 
     private <T extends Object> List<T> allAvailableAttributes(
-            final Function<Relation, T> memberExtractor)
+            final Function<Relation, T> memberExtractor, final String name)
     {
         return ChangeEntity.getAttributeAndOptionallyBackup(this.source, this.override,
-                memberExtractor);
+                memberExtractor, name);
     }
 
-    private <T extends Object> T attribute(final Function<Relation, T> memberExtractor)
+    private <T extends Object> T attribute(final Function<Relation, T> memberExtractor,
+            final String name)
     {
-        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor);
+        return ChangeEntity.getAttributeOrBackup(this.source, this.override, memberExtractor, name);
     }
 
     private ChangeAtlas getChangeAtlas()


### PR DESCRIPTION
### Description:

This adds better debugging information when a specific ChangeEntity cannot resolve one of its members.

### Potential Impact:

A better error message

### Unit Test Approach:

Using existing unit tests

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
