### PR TITLE
Update atlas-area.json

### DIFF
--- a/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
+++ b/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
@@ -1,6 +1,6 @@
 {
     "filters": [
-        "highway->!|highway->platform,bus_stop",
+        "highway->!|highway->platform,bus_stop,rest_area",
         "railway->!|railway->platform,traverser,station",
         "route->!ferry",
         "man_made->!pier"


### PR DESCRIPTION
### Description:
Minor update to area filter tags to allow highway->rest_area to be included as Areas by default.

### Potential Impact:

Limited, closed lines tagged as highway->rest_area will now be represented as Areas.

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)