### PR TITLE
Fixed MultiAtlas load with filter, and added tests

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -32,15 +32,24 @@ public class Location
 {
     private static final long serialVersionUID = 3770424147251047128L;
 
+    public static final String TEST_1_COORDINATES = "37.335310,-122.009566";
+    public static final String TEST_2_COORDINATES = "37.321628,-122.028464";
+    public static final String TEST_3_COORDINATES = "37.317585,-122.052138";
+    public static final String TEST_4_COORDINATES = "37.332451,-122.028932";
+    public static final String TEST_5_COORDINATES = "37.390535,-122.031007";
+    public static final String TEST_6_COORDINATES = "37.325440,-122.033948";
+    public static final String TEST_7_COORDINATES = "37.3314171,-122.0304871";
+    public static final String TEST_8_COORDINATES = "37.3214159,-122.0303831";
+
     // Quick-access locations, mostly used for testing.
-    public static final Location TEST_1 = Location.forString("37.335310,-122.009566");
-    public static final Location TEST_2 = Location.forString("37.321628,-122.028464");
-    public static final Location TEST_3 = Location.forString("37.317585,-122.052138");
-    public static final Location TEST_4 = Location.forString("37.332451,-122.028932");
-    public static final Location TEST_5 = Location.forString("37.390535,-122.031007");
-    public static final Location TEST_6 = Location.forString("37.325440,-122.033948");
-    public static final Location TEST_7 = Location.forString("37.3314171,-122.0304871");
-    public static final Location TEST_8 = Location.forString("37.3214159,-122.0303831");
+    public static final Location TEST_1 = Location.forString(TEST_1_COORDINATES);
+    public static final Location TEST_2 = Location.forString(TEST_2_COORDINATES);
+    public static final Location TEST_3 = Location.forString(TEST_3_COORDINATES);
+    public static final Location TEST_4 = Location.forString(TEST_4_COORDINATES);
+    public static final Location TEST_5 = Location.forString(TEST_5_COORDINATES);
+    public static final Location TEST_6 = Location.forString(TEST_6_COORDINATES);
+    public static final Location TEST_7 = Location.forString(TEST_7_COORDINATES);
+    public static final Location TEST_8 = Location.forString(TEST_8_COORDINATES);
     public static final Location STEVENS_CREEK = Location.forString("37.324233,-122.003467");
     public static final Location CROSSING_85_280 = Location.forString("37.332439,-122.055760");
     public static final Location CROSSING_85_17 = Location.forString("37.255731,-121.955918");
@@ -164,12 +173,6 @@ public class Location
         result <<= INT_SIZE;
         result |= this.longitude.asDm7() & INT_FULL_MASK_AS_LONG;
         return result;
-    }
-
-    @Override
-    public boolean within(final GeometricSurface surface)
-    {
-        return surface.fullyGeometricallyEncloses(this);
     }
 
     @Override
@@ -578,6 +581,12 @@ public class Location
     public String toWkt()
     {
         return new WktLocationConverter().convert(this);
+    }
+
+    @Override
+    public boolean within(final GeometricSurface surface)
+    {
+        return surface.fullyGeometricallyEncloses(this);
     }
 
     protected Point2D asAwtPoint()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
@@ -197,7 +197,7 @@ public class MultiAtlas extends AbstractAtlas
                         .stream(Iterables.translate(resources,
                                 resource -> PackedAtlas.load(resource).subAtlas(filter,
                                         AtlasCutType.SOFT_CUT)))
-                        .filter(optional -> optional.isPresent()), optional -> optional.get());
+                        .filter(Optional::isPresent), Optional::get);
         return new MultiAtlas(validAtlases, lotsOfOverlap);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
@@ -192,12 +192,13 @@ public class MultiAtlas extends AbstractAtlas
         {
             throw new CoreException("Can't create an atlas from zero resources");
         }
-        return new MultiAtlas(
-                Iterables
-                        .translate(resources,
-                                resource -> PackedAtlas.load(resource)
-                                        .subAtlas(filter, AtlasCutType.SOFT_CUT).get()),
-                lotsOfOverlap);
+        final Iterable<Atlas> validAtlases = Iterables
+                .translate(Iterables
+                        .stream(Iterables.translate(resources,
+                                resource -> PackedAtlas.load(resource).subAtlas(filter,
+                                        AtlasCutType.SOFT_CUT)))
+                        .filter(optional -> optional.isPresent()), optional -> optional.get());
+        return new MultiAtlas(validAtlases, lotsOfOverlap);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlas.java
@@ -192,12 +192,12 @@ public class MultiAtlas extends AbstractAtlas
         {
             throw new CoreException("Can't create an atlas from zero resources");
         }
-        final Iterable<Atlas> validAtlases = Iterables
-                .translate(Iterables
-                        .stream(Iterables.translate(resources,
-                                resource -> PackedAtlas.load(resource).subAtlas(filter,
-                                        AtlasCutType.SOFT_CUT)))
-                        .filter(Optional::isPresent), Optional::get);
+        final Iterable<Atlas> validAtlases = Iterables.translate(
+                Iterables.stream(Iterables.translate(resources,
+                        resource -> PackedAtlas.load(resource).subAtlas(filter,
+                                AtlasCutType.SOFT_CUT)))
+                        .filter(Optional::isPresent),
+                Optional::get);
         return new MultiAtlas(validAtlases, lotsOfOverlap);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlas.java
@@ -224,6 +224,8 @@ public @interface TestAtlas
 
         Member[] members() default {};
 
+        String osmId() default DEFAULT_OSM_ID;
+
         /**
          * Tags we want on the Relation
          *
@@ -266,6 +268,8 @@ public @interface TestAtlas
 
     // This is for identifiers: by default they will be auto-generated
     String AUTO_GENERATED = "<auto>";
+
+    String DEFAULT_OSM_ID = "<default>";
 
     // This is for the atlas metadata: we only add the ISO country code if it is something besides
     // unknown

--- a/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/testing/TestAtlasHandler.java
@@ -379,7 +379,10 @@ public class TestAtlasHandler implements FieldHandler
                         Enum.valueOf(ItemType.class, member.type().toUpperCase()));
             }
             final long identifier = relationIDGenerator.nextId(relation.id());
-            builder.addRelation(identifier, identifier, bean, parseTags(relation.tags()));
+            final long osmIdentifier = relation.osmId().equals(TestAtlas.DEFAULT_OSM_ID)
+                    ? identifier
+                    : relationIDGenerator.nextId(relation.osmId());
+            builder.addRelation(identifier, osmIdentifier, bean, parseTags(relation.tags()));
         }
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RouteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RouteTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasTest;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 /**
@@ -24,7 +23,7 @@ public class RouteTest
     @Before
     public void init()
     {
-        this.atlas = new PackedAtlasTest().getAtlas();
+        this.atlas = this.rule.getPackedAtlas();
         final Edge edge1 = this.atlas.edge(98);
         final Edge edge2 = this.atlas.edge(987);
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RouteTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/RouteTestRule.java
@@ -1,11 +1,17 @@
 package org.openstreetmap.atlas.geography.atlas.items;
 
+import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
  * {@link RouteTest} test data.
@@ -19,7 +25,6 @@ public class RouteTestRule extends CoreTestRule
     private static final String THREE = "39.9976118, 116.2836054";
     private static final String FOUR = "40.0007062, 116.2829521";
     private static final String FIVE = "40.0082021, 116.2824999";
-
     @TestAtlas(
 
             nodes = {
@@ -41,7 +46,6 @@ public class RouteTestRule extends CoreTestRule
                     @Edge(id = "138620888", coordinates = { @Loc(value = THREE),
                             @Loc(value = FIVE) }, tags = { "highway=tertiary", "oneway=yes" }) })
     private Atlas atlas;
-
     @TestAtlas(
 
             nodes = {
@@ -66,7 +70,6 @@ public class RouteTestRule extends CoreTestRule
                     @Edge(id = "-138620888", coordinates = { @Loc(value = FOUR),
                             @Loc(value = THREE) }, tags = { "highway=tertiary", }) })
     private Atlas biDirectionalEdgeAtlas;
-
     @TestAtlas(
 
             nodes = {
@@ -89,7 +92,6 @@ public class RouteTestRule extends CoreTestRule
                     @Edge(id = "-138620888", coordinates = { @Loc(value = FOUR),
                             @Loc(value = THREE) }, tags = { "highway=tertiary", }) })
     private Atlas uniDirectionalEdgeAtlas;
-
     @TestAtlas(
 
             nodes = {
@@ -109,7 +111,6 @@ public class RouteTestRule extends CoreTestRule
                     @Edge(id = "-206786592000007", coordinates = { @Loc(value = ONE),
                             @Loc(value = THREE) }, tags = { "highway=tertiary_link" }) })
     private Atlas routeHashCodeAtlas;
-
     @TestAtlas(
 
             nodes = {
@@ -143,6 +144,86 @@ public class RouteTestRule extends CoreTestRule
 
     private Atlas uTurnAtlas;
 
+    @TestAtlas(points = {
+            @Point(id = "1", coordinates = @Loc(value = Location.TEST_3_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "2", coordinates = @Loc(value = Location.TEST_2_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "3", coordinates = @Loc(value = Location.TEST_6_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "4", coordinates = @Loc(value = Location.TEST_7_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "5", coordinates = @Loc(value = Location.TEST_4_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "6", coordinates = @Loc(value = Location.TEST_1_COORDINATES), tags = {
+                    "addr:city=Cupertino" }),
+            @Point(id = "7", coordinates = @Loc(value = Location.TEST_5_COORDINATES), tags = {
+                    "addr:city=Cupertino" }), },
+
+            nodes = {
+                    @Node(id = "123", coordinates = @Loc(value = Location.TEST_6_COORDINATES), tags = {
+                            "highway=turning_circle" }),
+                    @Node(id = "1234", coordinates = @Loc(value = Location.TEST_5_COORDINATES), tags = {
+                            "highway=turning_circle" }),
+                    @Node(id = "12345", coordinates = @Loc(value = Location.TEST_2_COORDINATES), tags = {
+                            "highway=turning_circle" }), },
+
+            lines = {
+                    @Line(id = "32", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
+                            @Loc(value = Location.TEST_1_COORDINATES) }, tags = { "power=line" }),
+                    @Line(id = "23", coordinates = { @Loc(value = Location.TEST_3_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES),
+                            @Loc(value = Location.TEST_4_COORDINATES) }, tags = {
+                                    "aeroway=runway" }),
+                    @Line(id = "24", coordinates = { @Loc(value = Location.TEST_7_COORDINATES),
+                            @Loc(value = Location.TEST_4_COORDINATES),
+                            @Loc(value = Location.TEST_6_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
+                                    "natural=coastline", "waterway=canal" }) },
+
+            edges = {
+                    @Edge(id = "9", coordinates = { @Loc(value = Location.TEST_6_COORDINATES),
+                            @Loc(value = Location.TEST_5_COORDINATES) }, tags = { "highway=primary",
+                                    "name=edge9", "surface=concrete", "lanes=3" }),
+                    @Edge(id = "-9", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
+                            @Loc(value = Location.TEST_6_COORDINATES) }, tags = { "highway=primary",
+                                    "name=edge_9", "surface=fine_gravel" }),
+                    @Edge(id = "98", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
+                                    "highway=secondary", "name=edge98", "bridge=movable",
+                                    "maxspeed=100" }),
+                    @Edge(id = "987", coordinates = { @Loc(value = Location.TEST_2_COORDINATES),
+                            @Loc(value = Location.TEST_6_COORDINATES) }, tags = {
+                                    "highway=residential", "name=edge987", "tunnel=culvert",
+                                    "maxspeed=50 knots" }) },
+
+            areas = {
+                    @Area(id = "45", coordinates = { @Loc(value = Location.TEST_6_COORDINATES),
+                            @Loc(value = Location.TEST_3_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
+                                    "leisure=golf_course", "natural=grassland" }),
+                    @Area(id = "54", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
+                            @Loc(value = Location.TEST_1_COORDINATES),
+                            @Loc(value = Location.TEST_4_COORDINATES),
+                            @Loc(value = Location.TEST_6_COORDINATES) }, tags = {
+                                    "leisure=swimming_pool", "sport=swimming" }),
+                    @Area(id = "4554", coordinates = { @Loc(value = Location.TEST_1_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES),
+                            @Loc(value = Location.TEST_3_COORDINATES) }, tags = {
+                                    "hello=world" }) },
+
+            relations = {
+                    @Relation(id = "1", members = { @Member(id = "9", role = "in", type = "edge"),
+                            @Member(id = "1234", role = "node", type = "node"),
+                            @Member(id = "-9", role = "out", type = "edge") }, tags = {}),
+                    @Relation(id = "2", members = {
+                            @Member(id = "45", role = "area", type = "area"),
+                            @Member(id = "32", role = "line", type = "line"),
+                            @Member(id = "5", role = "pt", type = "point"),
+                            @Member(id = "1", role = "rel", type = "relation"),
+                            @Member(id = "1234", role = "node", type = "node") }, tags = {}) })
+    private Atlas packedAtlas;
+
     public Atlas getAtlas()
     {
         return this.atlas;
@@ -151,6 +232,11 @@ public class RouteTestRule extends CoreTestRule
     public Atlas getBiDirectionalEdgeAtlas()
     {
         return this.biDirectionalEdgeAtlas;
+    }
+
+    public Atlas getPackedAtlas()
+    {
+        return this.packedAtlas;
     }
 
     public Atlas getRouteHashCodeAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Route;
 import org.openstreetmap.atlas.geography.atlas.routing.AStarRouter;
 import org.openstreetmap.atlas.geography.atlas.routing.Router;
@@ -43,6 +44,42 @@ public class MultiAtlasOverlappingNodesFixerTest extends Command
     public static void main(final String[] args)
     {
         new MultiAtlasOverlappingNodesFixerTest().run(args);
+    }
+
+    @Test
+    public void testOrderOverlappingNode()
+    {
+        final Atlas subAtlas1 = this.setup.overlappingSubAtlas1();
+        final Atlas subAtlas2 = this.setup.overlappingSubAtlas2();
+        final MultiAtlas multiAtlasOrder1 = new MultiAtlas(subAtlas1, subAtlas2);
+        final MultiAtlas multiAtlasOrder2 = new MultiAtlas(subAtlas2, subAtlas1);
+        multiAtlasOrder1.edges().forEach(edge ->
+        {
+            final Edge otherOrderEdge = multiAtlasOrder2.edge(edge.getIdentifier());
+            Assert.assertEquals(edge.start().getIdentifier(),
+                    otherOrderEdge.start().getIdentifier());
+            Assert.assertEquals(edge.end().getIdentifier(), otherOrderEdge.end().getIdentifier());
+            Assert.assertEquals(edge.getTags(), otherOrderEdge.getTags());
+            Assert.assertEquals(edge.asPolyLine(), otherOrderEdge.asPolyLine());
+        });
+    }
+
+    @Test
+    public void testOrderOverlappingNodesCrossingEdges()
+    {
+        final Atlas subAtlas1 = this.setup.overlappingAndCrossingSubAtlas1();
+        final Atlas subAtlas2 = this.setup.overlappingAndCrossingSubAtlas2();
+        final MultiAtlas multiAtlasOrder1 = new MultiAtlas(subAtlas1, subAtlas2);
+        final MultiAtlas multiAtlasOrder2 = new MultiAtlas(subAtlas2, subAtlas1);
+        multiAtlasOrder1.edges().forEach(edge ->
+        {
+            final Edge otherOrderEdge = multiAtlasOrder2.edge(edge.getIdentifier());
+            Assert.assertEquals(edge.start().getIdentifier(),
+                    otherOrderEdge.start().getIdentifier());
+            Assert.assertEquals(edge.end().getIdentifier(), otherOrderEdge.end().getIdentifier());
+            Assert.assertEquals(edge.getTags(), otherOrderEdge.getTags());
+            Assert.assertEquals(edge.asPolyLine(), otherOrderEdge.asPolyLine());
+        });
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasTest.java
@@ -1,24 +1,21 @@
 package org.openstreetmap.atlas.geography.atlas.multi;
 
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
-import org.openstreetmap.atlas.geography.Segment;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.builder.AtlasSize;
-import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
-import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
-import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasTest;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas.AtlasSerializationFormat;
+import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 import org.slf4j.Logger;
@@ -32,8 +29,11 @@ import org.slf4j.LoggerFactory;
 public class MultiAtlasTest
 {
     private static final Logger logger = LoggerFactory.getLogger(MultiAtlasTest.class);
+    @Rule
+    public MultiAtlasTestRule setup = new MultiAtlasTestRule();
 
-    private final Atlas base = new PackedAtlasTest().getAtlas();
+    private Atlas base;
+
     private Atlas other;
 
     private MultiAtlas multi;
@@ -64,48 +64,8 @@ public class MultiAtlasTest
     @Before
     public void setup()
     {
-        final PackedAtlasBuilder builder = new PackedAtlasBuilder()
-                .withSizeEstimates(new AtlasSize(2, 3, 0, 0, 0, 1));
-        final Map<String, String> edge5Tags = new HashMap<>();
-        edge5Tags.put("highway", "primary");
-        edge5Tags.put("name", "edge5");
-        edge5Tags.put("surface", "concrete");
-        edge5Tags.put("lanes", "3");
-
-        final Map<String, String> edge6Tags = new HashMap<>();
-        edge6Tags.put("highway", "secondary");
-        edge6Tags.put("name", "edge98");
-        edge6Tags.put("bridge", "cantilever");
-        edge6Tags.put("maxspeed", "100");
-
-        final Map<String, String> nodeTags = new HashMap<>();
-        nodeTags.put("highway", "traffic_signal");
-        // shared
-        builder.addNode(123, Location.TEST_6, nodeTags);
-        // shared
-        builder.addNode(12345, Location.TEST_2, nodeTags);
-        // private
-        builder.addNode(4, Location.TEST_1, nodeTags);
-        builder.addEdge(5, new Segment(Location.TEST_6, Location.TEST_1), edge5Tags);
-        builder.addEdge(6, new Segment(Location.TEST_1, Location.TEST_2), edge6Tags);
-
-        // Relation structure and tags
-        // This one is already in the base atlas
-        final RelationBean structure1 = new RelationBean();
-        // structure1.addItem(null, "in", ItemType.EDGE);
-        // structure1.addItem(null, "node", ItemType.NODE);
-        // structure1.addItem(null, "out", ItemType.EDGE);
-        structure1.addItem(4L, "notThere", ItemType.NODE);
-        final RelationBean structure3 = new RelationBean();
-        structure3.addItem(5L, "in", ItemType.EDGE);
-        structure3.addItem(12345L, "node", ItemType.NODE);
-        structure3.addItem(6L, "out", ItemType.EDGE);
-        // Add relations
-        builder.addRelation(1, 1, structure1, this.base.relation(1L).getTags());
-        builder.addRelation(3, 2, structure3, this.base.relation(2L).getTags());
-
-        this.other = builder.get();
-
+        this.other = this.setup.getAtlas1();
+        this.base = this.setup.getAtlas2();
         this.multi = new MultiAtlas(this.base, this.other);
     }
 
@@ -114,12 +74,37 @@ public class MultiAtlasTest
     {
         final Rectangle ac2Box = Location.TEST_1.boxAround(Distance.ONE_METER);
         Assert.assertEquals(1, Iterables.size(this.multi.nodesWithin(ac2Box)));
-        Assert.assertEquals(4L, this.multi.nodesWithin(ac2Box).iterator().next().getIdentifier());
+        Assert.assertEquals(4, this.multi.nodesWithin(ac2Box).iterator().next().getIdentifier());
         Assert.assertEquals(2, Iterables.size(this.multi.edgesIntersecting(ac2Box)));
         final Iterator<Edge> edgeIterator = this.multi.edgesIntersecting(ac2Box).iterator();
         Assert.assertEquals(6, edgeIterator.next().getIdentifier());
         Assert.assertEquals(5, edgeIterator.next().getIdentifier());
         Assert.assertFalse(edgeIterator.hasNext());
+    }
+
+    @Test
+    public void testFilter()
+    {
+        final WritableResource baseResource = new ByteArrayResource();
+        final WritableResource otherResource = new ByteArrayResource();
+        final PackedAtlas packedBase = this.base.cloneToPackedAtlas();
+        packedBase.setSaveSerializationFormat(AtlasSerializationFormat.JAVA);
+        packedBase.save(baseResource);
+        final PackedAtlas otherBase = this.other.cloneToPackedAtlas();
+        otherBase.setSaveSerializationFormat(AtlasSerializationFormat.JAVA);
+        otherBase.save(otherResource);
+
+        // filter out all resources from one atlas, make sure load still works
+        final Atlas multiFiltered = MultiAtlas
+                .loadFromPackedAtlas(Iterables.from(baseResource, otherResource), false, entity ->
+                {
+                    final boolean test = entity.getIdentifier() != 123L
+                            && entity.getIdentifier() != 12345L && entity.getIdentifier() != 4L
+                            && entity.getIdentifier() != 5L && entity.getIdentifier() != 6L
+                            && entity.getIdentifier() != 1L && entity.getIdentifier() != 3L;
+                    return test;
+                });
+
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasTestRule.java
@@ -1,4 +1,4 @@
-package org.openstreetmap.atlas.geography.atlas.statistics;
+package org.openstreetmap.atlas.geography.atlas.multi;
 
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -14,12 +14,37 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
- * Test rule for {@link AtlasStatisticsTest}
- *
- * @author matthieun
+ * @author samg
  */
-public class AtlasStatisticsTestRule extends CoreTestRule
+
+public class MultiAtlasTestRule extends CoreTestRule
 {
+    @TestAtlas(nodes = {
+            @Node(id = "123", coordinates = @Loc(value = Location.TEST_6_COORDINATES), tags = {
+                    "highway=traffic_signal" }),
+            @Node(id = "12345", coordinates = @Loc(value = Location.TEST_2_COORDINATES), tags = {
+                    "highway=traffic_signal" }),
+            @Node(id = "4", coordinates = @Loc(value = Location.TEST_1_COORDINATES), tags = {
+                    "highway=traffic_signal" }), },
+
+            edges = {
+                    @Edge(id = "5", coordinates = { @Loc(value = Location.TEST_6_COORDINATES),
+                            @Loc(value = Location.TEST_1_COORDINATES) }, tags = { "highway=primary",
+                                    "name=edge5", "surface=concrete", "lanes=3" }),
+                    @Edge(id = "6", coordinates = { @Loc(value = Location.TEST_1_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
+                                    "highway=secondary", "name=edge98", "bridge=cantilever",
+                                    "maxspeed=100" }) },
+
+            relations = {
+                    @Relation(id = "1", members = {
+                            @Member(id = "4", role = "notThere", type = "node") }),
+                    @Relation(id = "3", osmId = "2", members = {
+                            @Member(id = "5", role = "in", type = "edge"),
+                            @Member(id = "12345", role = "node", type = "node"),
+                            @Member(id = "6", role = "out", type = "edge") }), })
+    private Atlas atlas1;
+
     @TestAtlas(points = {
             @Point(id = "1", coordinates = @Loc(value = Location.TEST_3_COORDINATES), tags = {
                     "addr:city=Cupertino" }),
@@ -63,7 +88,7 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                                     "name=edge9", "surface=concrete", "lanes=3" }),
                     @Edge(id = "-9", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_6_COORDINATES) }, tags = { "highway=primary",
-                                    "name=edge_9", "surface=gravel" }),
+                                    "name=edge_9", "surface=fine_gravel" }),
                     @Edge(id = "98", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
                                     "highway=secondary", "name=edge98", "bridge=movable",
@@ -98,42 +123,16 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                             @Member(id = "5", role = "pt", type = "point"),
                             @Member(id = "1", role = "rel", type = "relation"),
                             @Member(id = "1234", role = "node", type = "node") }, tags = {}) })
-    private Atlas packedAtlas;
+    private Atlas atlas2;
 
-    @TestAtlas(loadFromJosmOsmResource = "addressAtlas.josm.osm")
-    private Atlas addressAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "waterAtlas.josm.osm")
-    private Atlas waterAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "ferryAtlas.josm.osm")
-    private Atlas ferryAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "refsAtlas.josm.osm")
-    private Atlas refsAtlas;
-
-    public Atlas getAddressAtlas()
+    public Atlas getAtlas1()
     {
-        return this.addressAtlas;
+        return this.atlas1;
     }
 
-    public Atlas getFerryAtlas()
+    public Atlas getAtlas2()
     {
-        return this.ferryAtlas;
+        return this.atlas2;
     }
 
-    public Atlas getPackedAtlas()
-    {
-        return this.packedAtlas;
-    }
-
-    public Atlas getRefsAtlas()
-    {
-        return this.refsAtlas;
-    }
-
-    public Atlas getWaterAtlas()
-    {
-        return this.waterAtlas;
-    }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializerTest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Latitude;
@@ -154,6 +156,16 @@ public class PackedAtlasSerializerTest
 
     private static final Logger logger = LoggerFactory.getLogger(PackedAtlasSerializerTest.class);
 
+    @Rule
+    public final PackedAtlasTestRule rule = new PackedAtlasTestRule();
+    private PackedAtlas atlas;
+
+    @Before
+    public void setup()
+    {
+        this.atlas = this.rule.getAtlas().cloneToPackedAtlas();
+    }
+
     @Test
     public void testDeserializedIntegrity()
     {
@@ -193,11 +205,10 @@ public class PackedAtlasSerializerTest
     @Test
     public void testPartialLoad() throws NoSuchFieldException, SecurityException
     {
-        final PackedAtlas atlas = new PackedAtlasTest().getAtlas();
-        logger.info("{}", atlas);
+        logger.info("{}", this.atlas);
         final File file = File.temporary();
         logger.info("Saving atlas to {}", file);
-        atlas.save(file);
+        this.atlas.save(file);
         final Time start = Time.now();
         final PackedAtlas deserialized = PackedAtlas.load(file);
         logger.info("Deserialized Atlas File in {}", start.elapsedSince());
@@ -294,19 +305,17 @@ public class PackedAtlasSerializerTest
     @Test
     public void testSize()
     {
-        final PackedAtlas atlas = new PackedAtlasTest().getAtlas();
         final ByteArrayResource zipped = new ByteArrayResource(8192).withName("zippedByteArray");
         zipped.setCompressor(Compressor.GZIP);
-        atlas.save(zipped);
+        this.atlas.save(zipped);
         logger.info("Zipped Size: {}", zipped.length());
     }
 
     private Atlas deserialized()
     {
-        final Atlas atlas = new PackedAtlasTest().getAtlas();
         final ByteArrayResource resource = new ByteArrayResource(524288)
                 .withName("testSerializationByteArray");
-        atlas.save(resource);
+        this.atlas.save(resource);
         return PackedAtlas.load(resource);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
@@ -1,19 +1,15 @@
 package org.openstreetmap.atlas.geography.atlas.packed;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
-import org.openstreetmap.atlas.geography.Segment;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.builder.AtlasSize;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
@@ -39,7 +35,6 @@ import org.openstreetmap.atlas.tags.WaterTag;
 import org.openstreetmap.atlas.tags.WaterwayTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.Maps;
-import org.openstreetmap.atlas.utilities.random.RandomTagsSupplier;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 import org.openstreetmap.atlas.utilities.scalars.Speed;
 import org.slf4j.Logger;
@@ -56,132 +51,13 @@ public class PackedAtlasTest
 
     private PackedAtlas atlas;
 
-    public PackedAtlas getAtlas()
-    {
-        if (this.atlas == null)
-        {
-            setup();
-        }
-        return this.atlas;
-    }
+    @Rule
+    public PackedAtlasTestRule setup = new PackedAtlasTestRule();
 
     @Before
     public void setup()
     {
-        final PackedAtlasBuilder builder = new PackedAtlasBuilder()
-                .withSizeEstimates(new AtlasSize(4, 3, 2, 3, 7, 2));
-        // Node tags
-        final Map<String, String> nodeTags = new HashMap<>();
-        nodeTags.put("highway", "turning_circle");
-
-        // Edge tags
-        final Map<String, String> edge9Tags = new HashMap<>();
-        edge9Tags.put("highway", "primary");
-        edge9Tags.put("name", "edge9");
-        edge9Tags.put("surface", "concrete");
-        edge9Tags.put("lanes", "3");
-
-        final Map<String, String> edgeMinus9Tags = new HashMap<>();
-        edgeMinus9Tags.put("highway", "primary");
-        edgeMinus9Tags.put("name", "edge_9");
-        edgeMinus9Tags.put("surface", "fine_gravel");
-
-        final Map<String, String> edge98Tags = new HashMap<>();
-        edge98Tags.put("highway", "secondary");
-        edge98Tags.put("name", "edge98");
-        edge98Tags.put("bridge", "movable");
-        edge98Tags.put("maxspeed", "100");
-
-        final Map<String, String> edge987Tags = new HashMap<>();
-        edge987Tags.put("highway", "residential");
-        edge987Tags.put("name", "edge987");
-        edge987Tags.put("tunnel", "culvert");
-        edge987Tags.put("maxspeed", "50 knots");
-
-        // Area tags
-        final Map<String, String> area1Tags = new HashMap<>();
-        area1Tags.put("leisure", "golf_course");
-        area1Tags.put("natural", "grassland");
-
-        final Map<String, String> area2Tags = new HashMap<>();
-        area2Tags.put("leisure", "swimming_pool");
-        area2Tags.put("sport", "swimming");
-
-        final Map<String, String> area3Tags = new HashMap<>();
-        area2Tags.put("hello", "world");
-
-        // Line tags
-        final Map<String, String> line1Tags = new HashMap<>();
-        line1Tags.put("power", "line");
-
-        final Map<String, String> line2Tags = new HashMap<>();
-        line2Tags.put("aeroway", "runway");
-
-        final Map<String, String> line3Tags = new HashMap<>();
-        line3Tags.put("natural", "coastline");
-        line3Tags.put("waterway", "canal");
-
-        // Point tags
-        final Map<String, String> pointTags = new HashMap<>();
-        pointTags.put("addr:city", "Cupertino");
-
-        // Relation structure and tags
-        final Map<String, String> relationTags = RandomTagsSupplier.randomTags(5);
-        final RelationBean structure1 = new RelationBean();
-        structure1.addItem(9L, "in", ItemType.EDGE);
-        structure1.addItem(1234L, "node", ItemType.NODE);
-        structure1.addItem(-9L, "out", ItemType.EDGE);
-        // structure1.addItem(null, "notThere", ItemType.NODE);
-        final RelationBean structure2 = new RelationBean();
-        structure2.addItem(45L, "area", ItemType.AREA);
-        structure2.addItem(32L, "line", ItemType.LINE);
-        structure2.addItem(5L, "pt", ItemType.POINT);
-        structure2.addItem(1L, "rel", ItemType.RELATION);
-        structure2.addItem(1234L, "node", ItemType.NODE);
-
-        // Add nodes
-        builder.addNode(123, Location.TEST_6, nodeTags);
-        builder.addNode(1234, Location.TEST_5, nodeTags);
-        builder.addNode(12345, Location.TEST_2, nodeTags);
-
-        // Add edges
-        builder.addEdge(9, new Segment(Location.TEST_6, Location.TEST_5), edge9Tags);
-        builder.addEdge(-9, new Segment(Location.TEST_5, Location.TEST_6), edgeMinus9Tags);
-        builder.addEdge(98, new Segment(Location.TEST_5, Location.TEST_2), edge98Tags);
-        builder.addEdge(987, new Segment(Location.TEST_2, Location.TEST_6), edge987Tags);
-
-        // Add Areas
-        builder.addArea(45, new Polygon(Location.TEST_6, Location.TEST_3, Location.TEST_2),
-                area1Tags);
-        builder.addArea(54,
-                new Polygon(Location.TEST_5, Location.TEST_1, Location.TEST_4, Location.TEST_6),
-                area2Tags);
-        builder.addArea(4554, new Polygon(Location.TEST_1, Location.TEST_2, Location.TEST_3),
-                area3Tags);
-
-        // Add Lines
-        builder.addLine(32, new Segment(Location.TEST_5, Location.TEST_1), line1Tags);
-        builder.addLine(23, new PolyLine(Location.TEST_3, Location.TEST_2, Location.TEST_4),
-                line2Tags);
-        builder.addLine(24,
-                new PolyLine(Location.TEST_7, Location.TEST_4, Location.TEST_6, Location.TEST_2),
-                line3Tags);
-
-        // Add points
-        builder.addPoint(1, Location.TEST_3, pointTags);
-        builder.addPoint(2, Location.TEST_2, pointTags);
-        builder.addPoint(3, Location.TEST_6, pointTags);
-        builder.addPoint(4, Location.TEST_7, pointTags);
-        builder.addPoint(5, Location.TEST_4, pointTags);
-        builder.addPoint(6, Location.TEST_1, pointTags);
-        builder.addPoint(7, Location.TEST_5, pointTags);
-
-        // Add relations
-        builder.addRelation(1, 1, structure1, relationTags);
-        builder.addRelation(2, 2, structure2, relationTags);
-
-        // Final call
-        this.atlas = (PackedAtlas) builder.get();
+        this.atlas = this.setup.getAtlas().cloneToPackedAtlas();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTestRule.java
@@ -1,4 +1,4 @@
-package org.openstreetmap.atlas.geography.atlas.statistics;
+package org.openstreetmap.atlas.geography.atlas.packed;
 
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -14,11 +14,9 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
- * Test rule for {@link AtlasStatisticsTest}
- *
- * @author matthieun
+ * @author samg
  */
-public class AtlasStatisticsTestRule extends CoreTestRule
+public class PackedAtlasTestRule extends CoreTestRule
 {
     @TestAtlas(points = {
             @Point(id = "1", coordinates = @Loc(value = Location.TEST_3_COORDINATES), tags = {
@@ -63,7 +61,7 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                                     "name=edge9", "surface=concrete", "lanes=3" }),
                     @Edge(id = "-9", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_6_COORDINATES) }, tags = { "highway=primary",
-                                    "name=edge_9", "surface=gravel" }),
+                                    "name=edge_9", "surface=fine_gravel" }),
                     @Edge(id = "98", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
                                     "highway=secondary", "name=edge98", "bridge=movable",
@@ -98,42 +96,10 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                             @Member(id = "5", role = "pt", type = "point"),
                             @Member(id = "1", role = "rel", type = "relation"),
                             @Member(id = "1234", role = "node", type = "node") }, tags = {}) })
-    private Atlas packedAtlas;
+    private Atlas atlas;
 
-    @TestAtlas(loadFromJosmOsmResource = "addressAtlas.josm.osm")
-    private Atlas addressAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "waterAtlas.josm.osm")
-    private Atlas waterAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "ferryAtlas.josm.osm")
-    private Atlas ferryAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "refsAtlas.josm.osm")
-    private Atlas refsAtlas;
-
-    public Atlas getAddressAtlas()
+    public Atlas getAtlas()
     {
-        return this.addressAtlas;
-    }
-
-    public Atlas getFerryAtlas()
-    {
-        return this.ferryAtlas;
-    }
-
-    public Atlas getPackedAtlas()
-    {
-        return this.packedAtlas;
-    }
-
-    public Atlas getRefsAtlas()
-    {
-        return this.refsAtlas;
-    }
-
-    public Atlas getWaterAtlas()
-    {
-        return this.waterAtlas;
+        return this.atlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/routing/AStarRouterTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/routing/AStarRouterTestRule.java
@@ -1,4 +1,4 @@
-package org.openstreetmap.atlas.geography.atlas.statistics;
+package org.openstreetmap.atlas.geography.atlas.routing;
 
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -14,12 +14,34 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
- * Test rule for {@link AtlasStatisticsTest}
- *
- * @author matthieun
+ * @author samg
  */
-public class AtlasStatisticsTestRule extends CoreTestRule
+public class AStarRouterTestRule extends CoreTestRule
 {
+    @TestAtlas(nodes = {
+            @Node(id = "123", coordinates = @Loc(value = Location.TEST_6_COORDINATES), tags = {
+                    "highway=traffic_signal" }),
+            @Node(id = "12345", coordinates = @Loc(value = Location.TEST_2_COORDINATES), tags = {
+                    "highway=traffic_signal" }),
+            @Node(id = "4", coordinates = @Loc(value = Location.TEST_1_COORDINATES), tags = {
+                    "highway=traffic_signal" }), },
+
+            edges = {
+                    @Edge(id = "5", coordinates = { @Loc(value = Location.TEST_6_COORDINATES),
+                            @Loc(value = Location.TEST_1_COORDINATES) }, tags = { "highway=primary",
+                                    "name=edge5", "surface=concrete", "lanes=3" }),
+                    @Edge(id = "6", coordinates = { @Loc(value = Location.TEST_1_COORDINATES),
+                            @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
+                                    "highway=secondary", "name=edge98", "bridge=cantilever",
+                                    "maxspeed=100" }) }, relations = {
+                                            @Relation(id = "1", members = {
+                                                    @Member(id = "4", role = "notThere", type = "node") }),
+                                            @Relation(id = "3", osmId = "2", members = {
+                                                    @Member(id = "5", role = "in", type = "edge"),
+                                                    @Member(id = "12345", role = "node", type = "node"),
+                                                    @Member(id = "6", role = "out", type = "edge") }), })
+    private Atlas atlas1;
+
     @TestAtlas(points = {
             @Point(id = "1", coordinates = @Loc(value = Location.TEST_3_COORDINATES), tags = {
                     "addr:city=Cupertino" }),
@@ -63,7 +85,7 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                                     "name=edge9", "surface=concrete", "lanes=3" }),
                     @Edge(id = "-9", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_6_COORDINATES) }, tags = { "highway=primary",
-                                    "name=edge_9", "surface=gravel" }),
+                                    "name=edge_9", "surface=fine_gravel" }),
                     @Edge(id = "98", coordinates = { @Loc(value = Location.TEST_5_COORDINATES),
                             @Loc(value = Location.TEST_2_COORDINATES) }, tags = {
                                     "highway=secondary", "name=edge98", "bridge=movable",
@@ -98,42 +120,16 @@ public class AtlasStatisticsTestRule extends CoreTestRule
                             @Member(id = "5", role = "pt", type = "point"),
                             @Member(id = "1", role = "rel", type = "relation"),
                             @Member(id = "1234", role = "node", type = "node") }, tags = {}) })
-    private Atlas packedAtlas;
+    private Atlas atlas2;
 
-    @TestAtlas(loadFromJosmOsmResource = "addressAtlas.josm.osm")
-    private Atlas addressAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "waterAtlas.josm.osm")
-    private Atlas waterAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "ferryAtlas.josm.osm")
-    private Atlas ferryAtlas;
-
-    @TestAtlas(loadFromJosmOsmResource = "refsAtlas.josm.osm")
-    private Atlas refsAtlas;
-
-    public Atlas getAddressAtlas()
+    public Atlas getAtlas1()
     {
-        return this.addressAtlas;
+        return this.atlas1;
     }
 
-    public Atlas getFerryAtlas()
+    public Atlas getAtlas2()
     {
-        return this.ferryAtlas;
+        return this.atlas2;
     }
 
-    public Atlas getPackedAtlas()
-    {
-        return this.packedAtlas;
-    }
-
-    public Atlas getRefsAtlas()
-    {
-        return this.refsAtlas;
-    }
-
-    public Atlas getWaterAtlas()
-    {
-        return this.waterAtlas;
-    }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/statistics/AtlasStatisticsTest.java
@@ -5,7 +5,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasTest;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics.StatisticKey;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics.StatisticValue;
 
@@ -22,7 +21,7 @@ public class AtlasStatisticsTest
     @Test
     public void testCounting()
     {
-        final Atlas atlas = new PackedAtlasTest().getAtlas();
+        final Atlas atlas = this.rule.getPackedAtlas();
         final Counter counter = new Counter();
         final AtlasStatistics statistics = counter.processAtlas(atlas);
         Assert.assertEquals(7.245,


### PR DESCRIPTION
### Description:

This PR includes a fix for MultiAtlas.loadFromPackedAtlas() for loading over an Iterable of Resources with a Predicate filter. In cases in which the Predicate filters out all entities from a valid Atlas Resource in the Iterable, the result is an empty Optional; the previous code simply invokes .get() without checking, causing an error. This fix filters out all empty Optionals from the filtered Atlas Resources before loading, removing this error. 

Additionally, a few new tests have been added around this behavior and other [recent MultiAtlas behavior changes](https://github.com/osmlab/atlas/pull/408). As part of that change, lots of tests that were depending on PackedAtlas.getAtlas() and other Atlases built directly through PackedAtlasBuilder in test methods have been updated to have their own Rules with TestAtlases defined. 

Lastly, TestAtlas.Relation was augmented to allow for an OSM identifier to be specified-- this allows a synthetically sliced relation to be easily defined in TestAtlas annotations. Without being specified, it will default to the same identifier as the Relation.

### Potential Impact:
None, as this is just one bug fix and some tests were changed.

### Unit Test Approach:
Two unit tests capturing behavior previously not tested for, additionally reworked and streamlined test definitions.

### Test Results:
Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)