### PR TITLE
Conflicting beforeView forgiveness for Nodes

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -15,5 +15,7 @@
     <suppress checks="ParameterName" files="src/main/java/org/openstreetmap/atlas/utilities/function/TernaryOperator.java" />
     <suppress checks="ParameterName" files="src/main/java/org/openstreetmap/atlas/utilities/function/QuaternaryFunction.java" />
     <suppress checks="ParameterName" files="src/main/java/org/openstreetmap/atlas/utilities/function/QuaternaryOperator.java" />
+    <suppress checks="ParameterName" files="src/main/java/org/openstreetmap/atlas/utilities/function/SenaryFunction.java" />
+    <suppress checks="ParameterName" files="src/main/java/org/openstreetmap/atlas/utilities/function/SenaryOperator.java" />
     <suppress checks="." files="src/generated/*" />
 </suppressions>

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -72,13 +72,6 @@ public class ChangeNode extends Node // NOSONAR
 
     public SortedSet<Long> inEdgeIdentifiers()
     {
-        return attribute(Node::inEdges, "in edges").stream().map(Edge::getIdentifier)
-                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
-                .collect(Collectors.toCollection(TreeSet::new));
-    }
-
-    public SortedSet<Long> inEdgeIdentifiers2()
-    {
         final List<SortedSet<Edge>> inEdgeSetList = allAvailableAttributes(Node::inEdges,
                 "in edges");
         Set<Long> mergedIdentifiers = inEdgeSetList.stream().flatMap(Set::stream)
@@ -118,13 +111,6 @@ public class ChangeNode extends Node // NOSONAR
     }
 
     public SortedSet<Long> outEdgeIdentifiers()
-    {
-        return attribute(Node::outEdges, "out edges").stream().map(Edge::getIdentifier)
-                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
-                .collect(Collectors.toCollection(TreeSet::new));
-    }
-
-    public SortedSet<Long> outEdgeIdentifiers2()
     {
         final List<SortedSet<Edge>> outEdgeSetList = allAvailableAttributes(Node::outEdges,
                 "out edges");

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -15,6 +15,8 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link Node} that references a {@link ChangeAtlas}. That {@link Node} makes sure that all the
@@ -29,20 +31,21 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
 public class ChangeNode extends Node // NOSONAR
 {
     private static final long serialVersionUID = 4353679260691518275L;
+    private static final Logger logger = LoggerFactory.getLogger(ChangeNode.class);
 
     private final Node source;
     private final Node override;
-
     // Computing Parent Relations is very expensive, so we cache it here.
     private transient Set<Relation> relationsCache;
-    private transient Object relationsCacheLock = new Object();
 
+    private transient Object relationsCacheLock = new Object();
     // Computing In Edges is very expensive, so we cache it here.
     private transient SortedSet<Edge> inEdgesCache;
-    private transient Object inEdgesCacheLock = new Object();
 
+    private transient Object inEdgesCacheLock = new Object();
     // Computing Out Edges is very expensive, so we cache it here.
     private transient SortedSet<Edge> outEdgesCache;
+
     private transient Object outEdgesCacheLock = new Object();
 
     protected ChangeNode(final ChangeAtlas atlas, final Node source, final Node override)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -9,6 +10,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
@@ -75,6 +77,35 @@ public class ChangeNode extends Node // NOSONAR
                 .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    public SortedSet<Long> inEdgeIdentifiers2()
+    {
+        final List<SortedSet<Edge>> inEdgeSetList = allAvailableAttributes(Node::inEdges,
+                "in edges");
+        Set<Long> mergedIdentifiers = inEdgeSetList.stream().flatMap(Set::stream)
+                .map(Edge::getIdentifier)
+                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
+                .collect(Collectors.toSet());
+
+        if (this.override != null)
+        {
+            /*
+             * We need to filter any identifiers that were marked as explicitly excluded in the
+             * override. It is possible that the atlas view used to generate a FeatureChange context
+             * will differ from the atlas on which the FeatureChange will be applied. In that case,
+             * we must distinguish between two kinds of missing edge identifiers: 1) those that are
+             * missing because on shard simply couldn't see them and 2) those that are missing
+             * because a FeatureChange explicitly removed them.
+             */
+            final CompleteNode completeNodeOverride = (CompleteNode) this.override;
+            mergedIdentifiers = mergedIdentifiers.stream()
+                    .filter(edgeIdentifier -> !completeNodeOverride
+                            .explicitlyExcludedInEdgeIdentifiers().contains(edgeIdentifier))
+                    .collect(Collectors.toSet());
+        }
+
+        return new TreeSet<>(mergedIdentifiers);
+    }
+
     @Override
     public SortedSet<Edge> inEdges()
     {
@@ -91,6 +122,35 @@ public class ChangeNode extends Node // NOSONAR
         return attribute(Node::outEdges, "out edges").stream().map(Edge::getIdentifier)
                 .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
                 .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    public SortedSet<Long> outEdgeIdentifiers2()
+    {
+        final List<SortedSet<Edge>> outEdgeSetList = allAvailableAttributes(Node::outEdges,
+                "out edges");
+        Set<Long> mergedIdentifiers = outEdgeSetList.stream().flatMap(Set::stream)
+                .map(Edge::getIdentifier)
+                .filter(edgeIdentifier -> getChangeAtlas().edge(edgeIdentifier) != null)
+                .collect(Collectors.toSet());
+
+        if (this.override != null)
+        {
+            /*
+             * We need to filter any identifiers that were marked as explicitly excluded in the
+             * override. It is possible that the atlas view used to generate a FeatureChange context
+             * will differ from the atlas on which the FeatureChange will be applied. In that case,
+             * we must distinguish between two kinds of missing edge identifiers: 1) those that are
+             * missing because on shard simply couldn't see them and 2) those that are missing
+             * because a FeatureChange explicitly removed them.
+             */
+            final CompleteNode completeNodeOverride = (CompleteNode) this.override;
+            mergedIdentifiers = mergedIdentifiers.stream()
+                    .filter(edgeIdentifier -> !completeNodeOverride
+                            .explicitlyExcludedOutEdgeIdentifiers().contains(edgeIdentifier))
+                    .collect(Collectors.toSet());
+        }
+
+        return new TreeSet<>(mergedIdentifiers);
     }
 
     @Override
@@ -111,6 +171,13 @@ public class ChangeNode extends Node // NOSONAR
                 .filterRelations(attribute(AtlasEntity::relations, "relations"), getChangeAtlas());
         return ChangeEntity.getOrCreateCache(this.relationsCache,
                 cache -> this.relationsCache = cache, this.relationsCacheLock, creator);
+    }
+
+    private <T extends Object> List<T> allAvailableAttributes(
+            final Function<Node, T> memberExtractor, final String name)
+    {
+        return ChangeEntity.getAttributeAndOptionallyBackup(this.source, this.override,
+                memberExtractor, name);
     }
 
     private <T extends Object> T attribute(final Function<Node, T> memberExtractor,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -35,17 +35,17 @@ public class ChangeNode extends Node // NOSONAR
 
     private final Node source;
     private final Node override;
+
     // Computing Parent Relations is very expensive, so we cache it here.
     private transient Set<Relation> relationsCache;
-
     private transient Object relationsCacheLock = new Object();
+
     // Computing In Edges is very expensive, so we cache it here.
     private transient SortedSet<Edge> inEdgesCache;
-
     private transient Object inEdgesCacheLock = new Object();
+
     // Computing Out Edges is very expensive, so we cache it here.
     private transient SortedSet<Edge> outEdgesCache;
-
     private transient Object outEdgesCacheLock = new Object();
 
     protected ChangeNode(final ChangeAtlas atlas, final Node source, final Node override)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/ChangeNode.java
@@ -86,7 +86,7 @@ public class ChangeNode extends Node // NOSONAR
              * override. It is possible that the atlas view used to generate a FeatureChange context
              * will differ from the atlas on which the FeatureChange will be applied. In that case,
              * we must distinguish between two kinds of missing edge identifiers: 1) those that are
-             * missing because on shard simply couldn't see them and 2) those that are missing
+             * missing because a shard simply couldn't see them and 2) those that are missing
              * because a FeatureChange explicitly removed them.
              */
             final CompleteNode completeNodeOverride = (CompleteNode) this.override;
@@ -126,7 +126,7 @@ public class ChangeNode extends Node // NOSONAR
              * override. It is possible that the atlas view used to generate a FeatureChange context
              * will differ from the atlas on which the FeatureChange will be applied. In that case,
              * we must distinguish between two kinds of missing edge identifiers: 1) those that are
-             * missing because on shard simply couldn't see them and 2) those that are missing
+             * missing because a shard simply couldn't see them and 2) those that are missing
              * because a FeatureChange explicitly removed them.
              */
             final CompleteNode completeNodeOverride = (CompleteNode) this.override;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -681,8 +681,9 @@ public final class FeatureChangeMergingHelpers
                 .withMemberName("allKnownOsmMembers").withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
-                .withMemberExtractor(entity -> ((Relation) entity).allKnownOsmMembers() == null
-                        ? null : ((Relation) entity).allKnownOsmMembers().asBean())
+                .withMemberExtractor(
+                        entity -> ((Relation) entity).allKnownOsmMembers() == null ? null
+                                : ((Relation) entity).allKnownOsmMembers().asBean())
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleRelationBeanMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedRelationBeanMerger)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -646,8 +646,9 @@ public final class FeatureChangeMergingHelpers
                 .withMemberName("allKnownOsmMembers").withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
-                .withMemberExtractor(entity -> ((Relation) entity).allKnownOsmMembers() == null
-                        ? null : ((Relation) entity).allKnownOsmMembers().asBean())
+                .withMemberExtractor(
+                        entity -> ((Relation) entity).allKnownOsmMembers() == null ? null
+                                : ((Relation) entity).allKnownOsmMembers().asBean())
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleRelationBeanMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedRelationBeanMerger)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -488,7 +487,6 @@ public final class FeatureChangeMergingHelpers
         final CompleteNode afterNodeLeft = (CompleteNode) left.getAfterView();
         final CompleteNode afterNodeRight = (CompleteNode) right.getAfterView();
 
-        final Set<Long> explicitlyExcludedInEdgesOverride = new HashSet<>();
         final MergedMemberBean<SortedSet<Long>> mergedInEdgeIdentifiersBean = new MemberMerger.Builder<SortedSet<Long>>()
                 .withMemberName(IN_EDGE_IDENTIFIERS_FIELD).withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
@@ -502,11 +500,9 @@ public final class FeatureChangeMergingHelpers
                 .withBeforeViewMerger(
                         MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
-                        (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight,
-                        explicitlyExcludedInEdgesOverride)
+                        (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
                 .build().mergeMember();
 
-        final Set<Long> explicitlyExcludedOutEdgesOverride = new HashSet<>();
         final MergedMemberBean<SortedSet<Long>> mergedOutEdgeIdentifiersBean = new MemberMerger.Builder<SortedSet<Long>>()
                 .withMemberName(OUT_EDGE_IDENTIFIERS_FIELD).withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
@@ -520,8 +516,7 @@ public final class FeatureChangeMergingHelpers
                 .withBeforeViewMerger(
                         MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
-                        (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight,
-                        explicitlyExcludedOutEdgesOverride)
+                        (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
                 .build().mergeMember();
 
         final CompleteNode mergedAfterNode = new CompleteNode(left.getIdentifier(),
@@ -532,35 +527,15 @@ public final class FeatureChangeMergingHelpers
         mergedAfterNode.withBoundsExtendedBy(afterEntityLeft.bounds());
         mergedAfterNode.withBoundsExtendedBy(afterEntityRight.bounds());
 
-        /*
-         * The explicitlyExcludedOverride sets will be populated in the case when the hack
-         * mergeConflict resolution strategy is applied. Otherwise, we need to merge the left and
-         * right side sets from the given CompleteNodes.
-         */
-        if (!explicitlyExcludedInEdgesOverride.isEmpty())
-        {
-            mergedAfterNode
-                    .setExplicitlyExcludedInEdgeIdentifiers(explicitlyExcludedInEdgesOverride);
-        }
-        else
-        {
-            mergedAfterNode.setExplicitlyExcludedInEdgeIdentifiers(
-                    MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
-                            afterNodeLeft.explicitlyExcludedInEdgeIdentifiers(),
-                            afterNodeRight.explicitlyExcludedInEdgeIdentifiers()));
-        }
-        if (!explicitlyExcludedOutEdgesOverride.isEmpty())
-        {
-            mergedAfterNode
-                    .setExplicitlyExcludedOutEdgeIdentifiers(explicitlyExcludedOutEdgesOverride);
-        }
-        else
-        {
-            mergedAfterNode.setExplicitlyExcludedOutEdgeIdentifiers(
-                    MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
-                            afterNodeLeft.explicitlyExcludedOutEdgeIdentifiers(),
-                            afterNodeRight.explicitlyExcludedOutEdgeIdentifiers()));
-        }
+        mergedAfterNode.setExplicitlyExcludedInEdgeIdentifiers(
+                MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
+                        afterNodeLeft.explicitlyExcludedInEdgeIdentifiers(),
+                        afterNodeRight.explicitlyExcludedInEdgeIdentifiers()));
+
+        mergedAfterNode.setExplicitlyExcludedOutEdgeIdentifiers(
+                MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
+                        afterNodeLeft.explicitlyExcludedOutEdgeIdentifiers(),
+                        afterNodeRight.explicitlyExcludedOutEdgeIdentifiers()));
 
         final CompleteNode mergedBeforeNode;
         /*

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -484,9 +484,6 @@ public final class FeatureChangeMergingHelpers
             throw new CoreException(AFTER_ENTITY_RIGHT_WAS_NULL);
         }
 
-        final CompleteNode afterNodeLeft = (CompleteNode) left.getAfterView();
-        final CompleteNode afterNodeRight = (CompleteNode) right.getAfterView();
-
         final MergedMemberBean<SortedSet<Long>> mergedInEdgeIdentifiersBean = new MemberMerger.Builder<SortedSet<Long>>()
                 .withMemberName(IN_EDGE_IDENTIFIERS_FIELD).withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
@@ -526,16 +523,19 @@ public final class FeatureChangeMergingHelpers
                 mergedParentRelationsBean.getMergedAfterMember());
         mergedAfterNode.withBoundsExtendedBy(afterEntityLeft.bounds());
         mergedAfterNode.withBoundsExtendedBy(afterEntityRight.bounds());
-
+        /*
+         * We need to merge the explicitlyExcluded sets from the left and right CompleteNodes. This
+         * simple merge will always succeed, since the sets are key only.
+         */
         mergedAfterNode.setExplicitlyExcludedInEdgeIdentifiers(
                 MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
-                        afterNodeLeft.explicitlyExcludedInEdgeIdentifiers(),
-                        afterNodeRight.explicitlyExcludedInEdgeIdentifiers()));
+                        ((CompleteNode) afterEntityLeft).explicitlyExcludedInEdgeIdentifiers(),
+                        ((CompleteNode) afterEntityRight).explicitlyExcludedInEdgeIdentifiers()));
 
         mergedAfterNode.setExplicitlyExcludedOutEdgeIdentifiers(
                 MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
-                        afterNodeLeft.explicitlyExcludedOutEdgeIdentifiers(),
-                        afterNodeRight.explicitlyExcludedOutEdgeIdentifiers()));
+                        ((CompleteNode) afterEntityLeft).explicitlyExcludedOutEdgeIdentifiers(),
+                        ((CompleteNode) afterEntityRight).explicitlyExcludedOutEdgeIdentifiers()));
 
         final CompleteNode mergedBeforeNode;
         /*

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -378,10 +378,11 @@ public final class MemberMergeStrategies
     static final BinaryOperator<RelationBean> beforeViewRelationBeanMerger = RelationBean::mergeBeans;
 
     /**
-     * A merger for cases when two {@link Set}s have conflicting beforeViews. This can happen
-     * occasionally, since different shards may have slightly inconsistent Node views. While this
-     * merger uses explicitlyExcluded state to properly compute the merge, it does not handle
-     * merging the explicitlyExcluded state itself. This responsibility lies with the caller.
+     * A merger for cases when two {@link Set}s have conflicting beforeViews. This is useful for
+     * merging {@link Node} in/out {@link Edge} sets, since different shards may occasionally have
+     * inconsistent views of a {@link Node}'s connected {@link Edge}s. While this merger uses
+     * explicitlyExcluded state to properly compute the merge, it does not handle merging the
+     * explicitlyExcluded state itself. This responsibility lies with the caller.
      */
     static final SenaryFunction<SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>> conflictingBeforeViewSetMerger = (
             beforeLeftSet, afterLeftSet, explicitlyExcludedLeftSet, beforeRightSet, afterRightSet,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -379,7 +379,9 @@ public final class MemberMergeStrategies
 
     /**
      * A merger for cases when two {@link Set}s have conflicting beforeViews. This can happen
-     * occasionally, since different shards may have slightly inconsistent Node views.
+     * occasionally, since different shards may have slightly inconsistent Node views. While this
+     * merger uses explicitlyExcluded state to properly compute the merge, it does not handle
+     * merging the explicitlyExcluded state itself. This responsibility lies with the caller.
      */
     static final SenaryFunction<SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>> conflictingBeforeViewSetMerger = (
             beforeLeftSet, afterLeftSet, explicitlyExcludedLeftSet, beforeRightSet, afterRightSet,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -24,7 +24,6 @@ import org.openstreetmap.atlas.utilities.collections.Sets;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
 import org.openstreetmap.atlas.utilities.function.SenaryFunction;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
-import org.openstreetmap.atlas.utilities.tuples.Tuple;
 
 /**
  * A utility class to store the various merge strategies utilized by the {@link FeatureChange} merge
@@ -382,7 +381,7 @@ public final class MemberMergeStrategies
      * A merger for cases when two {@link Set}s have conflicting beforeViews. This can happen
      * occasionally, since different shards may have slightly inconsistent Node views.
      */
-    static final SenaryFunction<SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>, SortedSet<Long>, Set<Long>, Tuple<SortedSet<Long>, Set<Long>>> conflictingBeforeViewSetMerger = (
+    static final SenaryFunction<SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>> conflictingBeforeViewSetMerger = (
             beforeLeftSet, afterLeftSet, explicitlyExcludedLeftSet, beforeRightSet, afterRightSet,
             explicitlyExcludedRightSet) ->
     {
@@ -434,12 +433,9 @@ public final class MemberMergeStrategies
         mergedBeforeView.addAll(addedMerged);
 
         final SortedSet<Long> resultSet = new TreeSet<>();
-        final Set<Long> explicitlyExcludedResultSet = new HashSet<>();
         mergedBeforeView.forEach(resultSet::add);
-        Stream.concat(explicitlyExcludedLeftSet.stream(), explicitlyExcludedRightSet.stream())
-                .forEach(explicitlyExcludedResultSet::add);
 
-        return new Tuple<>(resultSet, explicitlyExcludedResultSet);
+        return resultSet;
     };
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -22,6 +22,7 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedRelation;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
+import org.openstreetmap.atlas.utilities.function.SenaryOperator;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
 
 /**
@@ -71,8 +72,9 @@ public final class MemberMergeStrategies
         final Map<RelationBeanItem, Integer> afterLeftBeanMap = afterLeftBean.asMap();
         final Map<RelationBeanItem, Integer> afterRightBeanMap = afterRightBean.asMap();
 
-        verifyExplicitlyExcludedSetsArePopulatedProperly(beforeBean, afterLeftBean, beforeBean,
-                afterRightBean);
+        verifyExplicitlyExcludedSets(beforeBean.asSet(), afterLeftBean.asSet(),
+                afterLeftBean.getExplicitlyExcluded(), beforeBean.asSet(), afterRightBean.asSet(),
+                afterRightBean.getExplicitlyExcluded());
 
         /*
          * Compute the difference set between the beforeView and the afterViews (which is equivalent
@@ -376,6 +378,18 @@ public final class MemberMergeStrategies
     static final BinaryOperator<RelationBean> beforeViewRelationBeanMerger = RelationBean::mergeBeans;
 
     /**
+     * A merger for cases when two {@link Set}s have conflicting beforeViews. This can happen
+     * occasionally, since different shards may have slightly inconsistent Node views.
+     */
+    static final SenaryOperator<Set<Long>> conflictingBeforeViewSetMerger = (beforeLeftSet,
+            afterLeftSet, explicitlyExcludedLeftSet, beforeRightSet, afterRightSet,
+            explicitlyExcludedRightSet) ->
+    {
+        // TODO implement
+        return null;
+    };
+
+    /**
      * A merger for cases when two {@link RelationBean}s have conflicting beforeViews. This can
      * happen occasionally, since different shards may have slightly inconsistent relation views.
      * <p>
@@ -388,8 +402,9 @@ public final class MemberMergeStrategies
     static final QuaternaryOperator<RelationBean> conflictingBeforeViewRelationBeanMerger = (
             beforeLeftBean, afterLeftBean, beforeRightBean, afterRightBean) ->
     {
-        verifyExplicitlyExcludedSetsArePopulatedProperly(beforeLeftBean, afterLeftBean,
-                beforeRightBean, afterRightBean);
+        verifyExplicitlyExcludedSets(beforeLeftBean.asSet(), afterLeftBean.asSet(),
+                afterLeftBean.getExplicitlyExcluded(), beforeRightBean.asSet(),
+                afterRightBean.asSet(), afterRightBean.getExplicitlyExcluded());
 
         /*
          * Merge the removed sets. This should just work, since we are doing a key-only merge and
@@ -523,47 +538,39 @@ public final class MemberMergeStrategies
         };
     }
 
-    private static void verifyExplicitlyExcludedSetsArePopulatedProperly(
-            final RelationBean beforeLeftBean, final RelationBean afterLeftBean,
-            final RelationBean beforeRightBean, final RelationBean afterRightBean)
+    private static <T> void verifyExplicitlyExcludedSets(final Set<T> beforeLeft,
+            final Set<T> afterLeft, final Set<T> explicitlyExcludedLeft, final Set<T> beforeRight,
+            final Set<T> afterRight, final Set<T> explicitlyExcludedRight)
     {
         /*
-         * The explicitly computed removed sets. These come straight from the explicitlyExcluded
-         * sets of RelationBeans on each side of the merge. explicitlyExcluded is populated by
-         * calling CompleteRelation#withMembersAndSource.
-         */
-        final Set<RelationBeanItem> removedFromLeft = afterLeftBean.getExplicitlyExcluded();
-        final Set<RelationBeanItem> removedFromRight = afterRightBean.getExplicitlyExcluded();
-
-        /*
          * The implicitly computed removed sets. These are computed by comparing the before and
-         * after views of the given RelationBeans on each side of the merge.
+         * after views of the given set-based entities on each side of the merge.
          */
-        final Set<RelationBeanItem> implicitlyRemovedFromLeft = com.google.common.collect.Sets
-                .difference(beforeLeftBean.asSet(), afterLeftBean.asSet());
-        final Set<RelationBeanItem> implicitlyRemovedFromRight = com.google.common.collect.Sets
-                .difference(beforeRightBean.asSet(), afterRightBean.asSet());
+        final Set<T> implicitlyRemovedFromLeft = com.google.common.collect.Sets
+                .difference(beforeLeft, afterLeft);
+        final Set<T> implicitlyRemovedFromRight = com.google.common.collect.Sets
+                .difference(beforeRight, afterRight);
 
         /*
          * It must be the case that the explicitly and implicitly computed removed sets match for a
-         * given RelationBean from one side of the merge. If they don't, that means the user likely
-         * removed some relation members without using the withMembersAndSource API, which means the
-         * explicitlyExcluded sets are not properly populated. This will lead to corrupt and
-         * unexpected results.
+         * given set-based entity from one side of the merge. If they don't, that means the user
+         * likely removed some elements without using the contextual API (withMembersAndSource for
+         * Relations, withXEdgeIdentifiersAndSource for Edges), which means the explicitlyExcluded
+         * sets are not properly populated. This will lead to corrupt and unexpected results.
          */
-        if (!removedFromLeft.equals(implicitlyRemovedFromLeft))
+        if (!explicitlyExcludedLeft.equals(implicitlyRemovedFromLeft))
         {
             throw new CoreException(
-                    "Explicit removedFromLeft set did not match the implicitly computed removedFromLeft set: {} vs {}\n"
-                            + "This is likely because members were removed without using the withMembersAndSource method",
-                    removedFromLeft, implicitlyRemovedFromLeft);
+                    "explicitlyExcludedLeft set did not match the implicitly computed removedFromLeft set: {} vs {}\n"
+                            + "This is likely because members were removed without using the correct withXAndSource API",
+                    explicitlyExcludedLeft, implicitlyRemovedFromLeft);
         }
-        if (!removedFromRight.equals(implicitlyRemovedFromRight))
+        if (!explicitlyExcludedRight.equals(implicitlyRemovedFromRight))
         {
             throw new CoreException(
-                    "Explicit removedFromRight set did not match the implicitly computed removedFromRight set: {} vs {}\n"
-                            + "This is likely because members were removed without using the withMembersAndSource method",
-                    removedFromRight, implicitlyRemovedFromRight);
+                    "explicitlyExcludedRight set did not match the implicitly computed removedFromRight set: {} vs {}\n"
+                            + "This is likely because members were removed without using the correct withXAndSource API",
+                    explicitlyExcludedRight, implicitlyRemovedFromRight);
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -382,7 +382,7 @@ public final class MemberMergeStrategies
      * A merger for cases when two {@link Set}s have conflicting beforeViews. This can happen
      * occasionally, since different shards may have slightly inconsistent Node views.
      */
-    static final SenaryFunction<Set<Long>, Set<Long>, Set<Long>, Set<Long>, Set<Long>, Set<Long>, Tuple<Set<Long>, Set<Long>>> conflictingBeforeViewSetMerger = (
+    static final SenaryFunction<SortedSet<Long>, SortedSet<Long>, Set<Long>, SortedSet<Long>, SortedSet<Long>, Set<Long>, Tuple<SortedSet<Long>, Set<Long>>> conflictingBeforeViewSetMerger = (
             beforeLeftSet, afterLeftSet, explicitlyExcludedLeftSet, beforeRightSet, afterRightSet,
             explicitlyExcludedRightSet) ->
     {
@@ -433,7 +433,7 @@ public final class MemberMergeStrategies
         mergedBeforeView.removeAll(removedMerged);
         mergedBeforeView.addAll(addedMerged);
 
-        final Set<Long> resultSet = new HashSet<>();
+        final SortedSet<Long> resultSet = new TreeSet<>();
         final Set<Long> explicitlyExcludedResultSet = new HashSet<>();
         mergedBeforeView.forEach(resultSet::add);
         Stream.concat(explicitlyExcludedLeftSet.stream(), explicitlyExcludedRightSet.stream())

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -397,8 +397,8 @@ public final class MemberMerger<M>
 
         /*
          * Here we hardcode the application of the SenaryOperator node connected edge set merger. We
-         * can cast back and forth between M and Set<Long> here, since we know that M is of type
-         * Set<Long> based on the constraints imposed when calling this function.
+         * can cast back and forth between M and SortedSet<Long> here, since we know that M is of
+         * type SortedSet<Long> based on the constraints imposed when calling this function.
          */
         try
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -1,10 +1,13 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
@@ -34,10 +37,14 @@ public final class MemberMerger<M>
         private AtlasEntity beforeEntityRight;
         private AtlasEntity afterEntityRight;
         private Function<AtlasEntity, M> memberExtractor;
-        private BinaryOperator<M> afterViewNoBeforeMerger;
-        private TernaryOperator<M> afterViewConsistentBeforeMerger;
-        private QuaternaryOperator<M> afterViewConflictingBeforeMerger;
+        private BinaryOperator<M> afterViewNoBeforeViewMerger;
+        private TernaryOperator<M> afterViewConsistentBeforeViewMerger;
+        private QuaternaryOperator<M> afterViewConflictingBeforeViewMerger;
         private BinaryOperator<M> beforeViewMerger;
+        private boolean useHackForMergingConflictingConnectedEdgeSetBeforeViews;
+
+        private Optional<CompleteNode> leftNode;
+        private Optional<CompleteNode> rightNode;
 
         public MemberMerger<M> build()
         {
@@ -50,12 +57,24 @@ public final class MemberMerger<M>
             merger.beforeEntityRight = this.beforeEntityRight;
             merger.afterEntityRight = this.afterEntityRight;
             merger.memberExtractor = this.memberExtractor;
-            merger.afterViewNoBeforeMerger = this.afterViewNoBeforeMerger;
-            merger.afterViewConsistentBeforeMerger = this.afterViewConsistentBeforeMerger;
-            merger.afterViewConflictingBeforeMerger = this.afterViewConflictingBeforeMerger;
+            merger.afterViewNoBeforeViewMerger = this.afterViewNoBeforeViewMerger;
+            merger.afterViewConsistentBeforeViewMerger = this.afterViewConsistentBeforeViewMerger;
+            merger.afterViewConflictingBeforeViewMerger = this.afterViewConflictingBeforeViewMerger;
             merger.beforeViewMerger = this.beforeViewMerger;
+            merger.useHackForMergingConflictingConnectedEdgeSetBeforeViews = this.useHackForMergingConflictingConnectedEdgeSetBeforeViews;
+            merger.leftNode = this.leftNode;
+            merger.rightNode = this.rightNode;
 
             return merger;
+        }
+
+        public Builder<M> useHackForMergingConflictingConnectedEdgeSetBeforeViews(
+                final boolean useHack, final CompleteNode left, final CompleteNode right)
+        {
+            this.useHackForMergingConflictingConnectedEdgeSetBeforeViews = useHack;
+            this.leftNode = Optional.ofNullable(left);
+            this.rightNode = Optional.ofNullable(right);
+            return this;
         }
 
         public Builder<M> withAfterEntityLeft(final AtlasEntity afterEntityLeft)
@@ -70,24 +89,24 @@ public final class MemberMerger<M>
             return this;
         }
 
-        public Builder<M> withAfterViewConflictingBeforeMerger(
-                final QuaternaryOperator<M> afterViewConflictingBeforeMerger)
+        public Builder<M> withAfterViewConflictingBeforeViewMerger(
+                final QuaternaryOperator<M> afterViewConflictingBeforeViewMerger)
         {
-            this.afterViewConflictingBeforeMerger = afterViewConflictingBeforeMerger;
+            this.afterViewConflictingBeforeViewMerger = afterViewConflictingBeforeViewMerger;
             return this;
         }
 
-        public Builder<M> withAfterViewConsistentBeforeMerger(
-                final TernaryOperator<M> afterViewConsistentBeforeMerger)
+        public Builder<M> withAfterViewConsistentBeforeViewMerger(
+                final TernaryOperator<M> afterViewConsistentBeforeViewMerger)
         {
-            this.afterViewConsistentBeforeMerger = afterViewConsistentBeforeMerger;
+            this.afterViewConsistentBeforeViewMerger = afterViewConsistentBeforeViewMerger;
             return this;
         }
 
         public Builder<M> withAfterViewNoBeforeMerger(
                 final BinaryOperator<M> afterViewNoBeforeMerger)
         {
-            this.afterViewNoBeforeMerger = afterViewNoBeforeMerger;
+            this.afterViewNoBeforeViewMerger = afterViewNoBeforeMerger;
             return this;
         }
 
@@ -183,10 +202,14 @@ public final class MemberMerger<M>
     private AtlasEntity beforeEntityRight;
     private AtlasEntity afterEntityRight;
     private Function<AtlasEntity, M> memberExtractor;
-    private BinaryOperator<M> afterViewNoBeforeMerger;
-    private TernaryOperator<M> afterViewConsistentBeforeMerger;
-    private QuaternaryOperator<M> afterViewConflictingBeforeMerger;
+    private BinaryOperator<M> afterViewNoBeforeViewMerger;
+    private TernaryOperator<M> afterViewConsistentBeforeViewMerger;
+    private QuaternaryOperator<M> afterViewConflictingBeforeViewMerger;
     private BinaryOperator<M> beforeViewMerger;
+    private boolean useHackForMergingConflictingConnectedEdgeSetBeforeViews;
+
+    private Optional<CompleteNode> leftNode;
+    private Optional<CompleteNode> rightNode;
 
     private MemberMerger()
     {
@@ -221,6 +244,18 @@ public final class MemberMerger<M>
         if (beforeMemberLeft != null && beforeMemberRight != null
                 && !beforeMemberLeft.equals(beforeMemberRight))
         {
+            /*
+             * In the case that we are merging the inEdges or outEdges members of Node, we perform a
+             * different merge logic. The in/outEdge sets have a possibility of beforeView
+             * conflicts, and since we are unable to attach additional explicitlyExcluded state
+             * directly to a set, we cannot use the same logic utilized for merging other members
+             * with conflicting beforeViews.
+             */
+            if (this.useHackForMergingConflictingConnectedEdgeSetBeforeViews)
+            {
+                return mergeMemberHackForConflictingConnectedEdgeSetBeforeViews(beforeMemberLeft,
+                        afterMemberLeft, beforeMemberRight, afterMemberRight);
+            }
             return mergeMemberWithConflictingBeforeViews(beforeMemberLeft, afterMemberLeft,
                     beforeMemberRight, afterMemberRight);
         }
@@ -297,6 +332,89 @@ public final class MemberMerger<M>
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private MergedMemberBean<M> mergeMemberHackForConflictingConnectedEdgeSetBeforeViews(
+            final M beforeMemberLeft, final M afterMemberLeft, final M beforeMemberRight,
+            final M afterMemberRight)
+    {
+        final M beforeMemberResult;
+        final M afterMemberResult;
+
+        final Set<Long> explicitlyExcludedLeft;
+        final Set<Long> explicitlyExcludedRight;
+
+        if (!this.leftNode.isPresent())
+        {
+            throw new CoreException(
+                    "Attempted merge failed for {}: tried to use hackForConflictingConnectedEdgeSet but was missing leftNode",
+                    this.memberName);
+        }
+        if (!this.rightNode.isPresent())
+        {
+            throw new CoreException(
+                    "Attempted merge failed for {}: tried to use hackForConflictingConnectedEdgeSet but was missing rightNode",
+                    this.memberName);
+        }
+
+        if (FeatureChangeMergingHelpers.IN_EDGE_IDENTIFIERS_FIELD.equals(this.memberName))
+        {
+            explicitlyExcludedLeft = this.leftNode.get().explicitlyExcludedInEdgeIdentifiers();
+            explicitlyExcludedRight = this.rightNode.get().explicitlyExcludedInEdgeIdentifiers();
+        }
+        else if (FeatureChangeMergingHelpers.OUT_EDGE_IDENTIFIERS_FIELD.equals(this.memberName))
+        {
+            explicitlyExcludedLeft = this.leftNode.get().explicitlyExcludedOutEdgeIdentifiers();
+            explicitlyExcludedRight = this.rightNode.get().explicitlyExcludedOutEdgeIdentifiers();
+        }
+        else
+        {
+            throw new CoreException(
+                    "Attempted merge failed for {}: hackForConflictingConnectedEdgeSet is not a valid strategy for {}",
+                    this.memberName, this.memberName);
+        }
+
+        if (this.beforeViewMerger == null)
+        {
+            throw new CoreException(
+                    "Conflicting beforeMembers {} and no beforeView merge strategy was provided; beforeView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight);
+        }
+
+        try
+        {
+            beforeMemberResult = this.beforeViewMerger.apply(beforeMemberLeft, beforeMemberRight);
+        }
+        catch (final Exception exception)
+        {
+            throw new CoreException(
+                    "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, exception);
+        }
+
+        /*
+         * Here we hardcode the application of the SenaryOperator node connected edge set merger. We
+         * can cast back and forth between M and Set<Long> here, since we know that M is of type
+         * Set<Long> based on the constraints imposed when calling this function.
+         */
+        try
+        {
+            afterMemberResult = (M) MemberMergeStrategies.conflictingBeforeViewSetMerger.apply(
+                    (Set<Long>) beforeMemberLeft, (Set<Long>) afterMemberLeft,
+                    explicitlyExcludedLeft, (Set<Long>) beforeMemberRight,
+                    (Set<Long>) afterMemberRight, explicitlyExcludedRight);
+        }
+        catch (final Exception exception)
+        {
+            throw new CoreException(
+                    "Tried merge strategy for hackForConflictingConnectedEdgeSet, but it failed for {}"
+                            + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
+                    afterMemberRight, exception);
+        }
+
+        return new MergedMemberBean<>(beforeMemberResult, afterMemberResult);
+    }
+
     /**
      * Merge a member that has consistent (possibly null) beforeViews.
      *
@@ -327,12 +445,12 @@ public final class MemberMerger<M>
          * If both beforeMembers are present (we have already asserted their equivalence so we just
          * arbitrarily use beforeMemberLeft), we use the diffBased strategy if present.
          */
-        if (beforeMemberResult != null && this.afterViewConsistentBeforeMerger != null)
+        if (beforeMemberResult != null && this.afterViewConsistentBeforeViewMerger != null)
         {
             try
             {
-                afterMemberResult = this.afterViewConsistentBeforeMerger.apply(beforeMemberResult,
-                        afterMemberLeft, afterMemberRight);
+                afterMemberResult = this.afterViewConsistentBeforeViewMerger
+                        .apply(beforeMemberResult, afterMemberLeft, afterMemberRight);
             }
             catch (final Exception exception)
             {
@@ -346,11 +464,11 @@ public final class MemberMerger<M>
          * If the beforeMember is not present, or we don't have a diffBased strategy, we try the
          * simple strategy.
          */
-        else if (this.afterViewNoBeforeMerger != null)
+        else if (this.afterViewNoBeforeViewMerger != null)
         {
             try
             {
-                afterMemberResult = this.afterViewNoBeforeMerger.apply(afterMemberLeft,
+                afterMemberResult = this.afterViewNoBeforeViewMerger.apply(afterMemberLeft,
                         afterMemberRight);
             }
             catch (final CoreException exception)
@@ -395,7 +513,7 @@ public final class MemberMerger<M>
         final M beforeMemberResult;
         final M afterMemberResult;
 
-        if (this.afterViewConflictingBeforeMerger == null)
+        if (this.afterViewConflictingBeforeViewMerger == null)
         {
             throw new CoreException(
                     "Conflicting beforeMembers {} and no afterView merge strategy capable of handling"
@@ -423,7 +541,7 @@ public final class MemberMerger<M>
 
         try
         {
-            afterMemberResult = this.afterViewConflictingBeforeMerger.apply(beforeMemberLeft,
+            afterMemberResult = this.afterViewConflictingBeforeViewMerger.apply(beforeMemberLeft,
                     afterMemberLeft, beforeMemberRight, afterMemberRight);
         }
         catch (final Exception exception)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
@@ -12,6 +13,8 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
 import org.openstreetmap.atlas.utilities.tuples.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class encapsulates the logic and configuration for {@link CompleteEntity} member merging in
@@ -201,6 +204,7 @@ public final class MemberMerger<M>
         }
     }
 
+    private static final Logger logger = LoggerFactory.getLogger(MemberMerger.class);
     private String memberName;
     private AtlasEntity beforeEntityLeft;
     private AtlasEntity afterEntityLeft;
@@ -211,10 +215,11 @@ public final class MemberMerger<M>
     private TernaryOperator<M> afterViewConsistentBeforeViewMerger;
     private QuaternaryOperator<M> afterViewConflictingBeforeViewMerger;
     private BinaryOperator<M> beforeViewMerger;
-    private boolean useHackForMergingConflictingConnectedEdgeSetBeforeViews;
 
+    private boolean useHackForMergingConflictingConnectedEdgeSetBeforeViews;
     private Optional<CompleteNode> leftNode;
     private Optional<CompleteNode> rightNode;
+
     private Optional<Set<Long>> newExplicitlyExcludedSet;
 
     private MemberMerger()
@@ -411,10 +416,10 @@ public final class MemberMerger<M>
          */
         try
         {
-            final Tuple<Set<Long>, Set<Long>> tupleResult = MemberMergeStrategies.conflictingBeforeViewSetMerger
-                    .apply((Set<Long>) beforeMemberLeft, (Set<Long>) afterMemberLeft,
-                            explicitlyExcludedLeft, (Set<Long>) beforeMemberRight,
-                            (Set<Long>) afterMemberRight, explicitlyExcludedRight);
+            final Tuple<SortedSet<Long>, Set<Long>> tupleResult = MemberMergeStrategies.conflictingBeforeViewSetMerger
+                    .apply((SortedSet<Long>) beforeMemberLeft, (SortedSet<Long>) afterMemberLeft,
+                            explicitlyExcludedLeft, (SortedSet<Long>) beforeMemberRight,
+                            (SortedSet<Long>) afterMemberRight, explicitlyExcludedRight);
             afterMemberResult = (M) tupleResult.getFirst();
 
             /*

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffHelper.java
@@ -25,6 +25,8 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A helper class for {@link AtlasDiff}. Contains lots of static utilities.
@@ -33,6 +35,8 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
  */
 public final class AtlasDiffHelper
 {
+    private static final Logger logger = LoggerFactory.getLogger(AtlasDiffHelper.class);
+
     public static Optional<FeatureChange> getAreaChangeIfNecessary(final Area beforeArea,
             final Area afterArea, final Atlas beforeViewAtlas)
     {
@@ -141,8 +145,9 @@ public final class AtlasDiffHelper
             }
             if (differentEdgeSet(beforeNode.inEdges(), afterNode.inEdges()))
             {
-                completeNode.withInEdgeIdentifiers(new TreeSet<>(afterNode.inEdges().stream()
-                        .map(Edge::getIdentifier).collect(Collectors.toSet())));
+                completeNode.withInEdgeIdentifiersAndSource(new TreeSet<>(afterNode.inEdges()
+                        .stream().map(Edge::getIdentifier).collect(Collectors.toSet())),
+                        beforeNode);
                 if (saveAllGeometries)
                 {
                     completeNode.withLocation(afterNode.getLocation());
@@ -151,8 +156,9 @@ public final class AtlasDiffHelper
             }
             if (differentEdgeSet(beforeNode.outEdges(), afterNode.outEdges()))
             {
-                completeNode.withOutEdgeIdentifiers(new TreeSet<>(afterNode.outEdges().stream()
-                        .map(Edge::getIdentifier).collect(Collectors.toSet())));
+                completeNode.withOutEdgeIdentifiersAndSource(new TreeSet<>(afterNode.outEdges()
+                        .stream().map(Edge::getIdentifier).collect(Collectors.toSet())),
+                        beforeNode);
                 if (saveAllGeometries)
                 {
                     completeNode.withLocation(afterNode.getLocation());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -36,8 +36,8 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     private Map<String, String> tags;
     private SortedSet<Long> inEdgeIdentifiers;
     private SortedSet<Long> outEdgeIdentifiers;
-    private final Set<Long> explicitlyExcludedInEdgeIdentifiers;
-    private final Set<Long> explicitlyExcludedOutEdgeIdentifiers;
+    private Set<Long> explicitlyExcludedInEdgeIdentifiers;
+    private Set<Long> explicitlyExcludedOutEdgeIdentifiers;
     private Set<Long> relationIdentifiers;
 
     /**
@@ -201,6 +201,16 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
          */
         return this.relationIdentifiers == null ? null : this.relationIdentifiers.stream()
                 .map(CompleteRelation::new).collect(Collectors.toSet());
+    }
+
+    public void setExplicitlyExcludedInEdgeIdentifiers(final Set<Long> edges)
+    {
+        this.explicitlyExcludedInEdgeIdentifiers = edges;
+    }
+
+    public void setExplicitlyExcludedOutEdgeIdentifiers(final Set<Long> edges)
+    {
+        this.explicitlyExcludedOutEdgeIdentifiers = edges;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -282,6 +282,7 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
                 .collect(Collectors.toSet());
         final Set<Long> excludedBasedOnSource = com.google.common.collect.Sets
                 .difference(sourceIdentifiers, inEdgeIdentifiers);
+        this.inEdgeIdentifiers = inEdgeIdentifiers;
         this.explicitlyExcludedInEdgeIdentifiers.addAll(excludedBasedOnSource);
         return this;
     }
@@ -334,6 +335,7 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
                 .collect(Collectors.toSet());
         final Set<Long> excludedBasedOnSource = com.google.common.collect.Sets
                 .difference(sourceIdentifiers, outEdgeIdentifiers);
+        this.outEdgeIdentifiers = outEdgeIdentifiers;
         this.explicitlyExcludedOutEdgeIdentifiers.addAll(excludedBasedOnSource);
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -169,8 +169,9 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
          * Note that the Edges returned by this method will technically break the Located contract,
          * since they have null bounds.
          */
-        return this.inEdgeIdentifiers == null ? null : this.inEdgeIdentifiers.stream()
-                .map(CompleteEdge::new).collect(Collectors.toCollection(TreeSet::new));
+        return this.inEdgeIdentifiers == null ? null
+                : this.inEdgeIdentifiers.stream().map(CompleteEdge::new)
+                        .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
@@ -188,8 +189,9 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
          * Note that the Edges returned by this method will technically break the Located contract,
          * since they have null bounds.
          */
-        return this.outEdgeIdentifiers == null ? null : this.outEdgeIdentifiers.stream()
-                .map(CompleteEdge::new).collect(Collectors.toCollection(TreeSet::new));
+        return this.outEdgeIdentifiers == null ? null
+                : this.outEdgeIdentifiers.stream().map(CompleteEdge::new)
+                        .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
@@ -199,8 +201,9 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
          * Note that the Relations returned by this method will technically break the Located
          * contract, since they have null bounds.
          */
-        return this.relationIdentifiers == null ? null : this.relationIdentifiers.stream()
-                .map(CompleteRelation::new).collect(Collectors.toSet());
+        return this.relationIdentifiers == null ? null
+                : this.relationIdentifiers.stream().map(CompleteRelation::new)
+                        .collect(Collectors.toSet());
     }
 
     public void setExplicitlyExcludedInEdgeIdentifiers(final Set<Long> edges)

--- a/src/main/java/org/openstreetmap/atlas/utilities/function/SenaryFunction.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/function/SenaryFunction.java
@@ -1,0 +1,69 @@
+package org.openstreetmap.atlas.utilities.function;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts six arguments and produces a result. This is the six-arity
+ * specialization of {@link Function}.
+ *
+ * @param <P>
+ *            the type of the first argument to the function
+ * @param <Q>
+ *            the type of the second argument to the function
+ * @param <S>
+ *            the type of the third argument to the function
+ * @param <T>
+ *            the type of the fourth argument to the function
+ * @param <U>
+ *            the type of the fifth argument to the function
+ * @param <V>
+ *            the type of the sixth argument to the function
+ * @param <R>
+ *            the type of the result of the function
+ * @author lcram
+ */
+@FunctionalInterface
+public interface SenaryFunction<P, Q, S, T, U, V, R>
+{
+    /**
+     * Returns a composed function that first applies this function to its input, and then applies
+     * the {@code after} function to the result. If evaluation of either function throws an
+     * exception, it is relayed to the caller of the composed function.
+     *
+     * @param <W>
+     *            the type of output of the {@code after} function, and of the composed function
+     * @param after
+     *            the function to apply after this function is applied
+     * @return a composed function that first applies this function and then applies the
+     *         {@code after} function
+     * @throws NullPointerException
+     *             if after is null
+     */
+    default <W> SenaryFunction<P, Q, S, T, U, V, W> andThen(
+            final Function<? super R, ? extends W> after)
+    {
+        Objects.requireNonNull(after);
+        return (final P p, final Q q, final S s, final T t, final U u, final V v) -> after
+                .apply(apply(p, q, s, t, u, v));
+    }
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param p
+     *            the first function argument
+     * @param q
+     *            the second function argument
+     * @param s
+     *            the third function argument
+     * @param t
+     *            the fourth function argument
+     * @param u
+     *            the fifth function argument
+     * @param v
+     *            the sixth function argument
+     * @return the function result
+     */
+    R apply(P p, Q q, S s, T t, U u, V v);
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/function/SenaryOperator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/function/SenaryOperator.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.utilities.function;
+
+/**
+ * Represents an operation upon six operands of the same type, producing a result of the same type
+ * as the operands. This is a specialization of {@link SenaryFunction} for the case where the
+ * operands and the result are all of the same type.
+ *
+ * @param <T>
+ *            the type of the operands and result of the operator
+ * @author lcram
+ */
+@FunctionalInterface
+public interface SenaryOperator<T> extends SenaryFunction<T, T, T, T, T, T, T>
+{
+
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTestRule.java
@@ -3,17 +3,99 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 /**
  * @author matthieun
  */
 public class ChangeAtlasTestRule extends CoreTestRule
 {
+    private static final String ONE = "15.420563,-61.336198";
+    private static final String TWO = "15.429499,-61.332850";
+    private static final String THREE = "15.4855,-61.3041";
+    private static final String FOUR = "15.4809,-61.3366";
+    private static final String FIVE = "15.4852,-61.3816";
+    private static final String SIX = "15.4781,-61.3949";
+    private static final String SEVEN = "15.4145,-61.3826";
+    private static final String EIGHT = "15.4073,-61.3749";
+    private static final String NINE = "15.4075,-61.3746";
+    private static final String TEN = "15.4081,-61.3741";
+    private static final String ELEVEN = "15.4111,-62.3741";
+
     @TestAtlas(loadFromJosmOsmResource = "ChangeAtlasTest.josm.osm")
     private Atlas atlas;
 
     @TestAtlas(loadFromJosmOsmResource = "ChangeAtlasTestEdge.josm.osm")
     private Atlas atlasEdge;
+
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "1", coordinates = @Loc(value = ONE), tags = { "tag1=value1" }),
+                    @Node(id = "2", coordinates = @Loc(value = TWO), tags = { "tag1=value1" }),
+                    @Node(id = "3", coordinates = @Loc(value = THREE), tags = { "tag1=value1" }),
+                    @Node(id = "4", coordinates = @Loc(value = FOUR), tags = { "tag1=value1" })
+
+            },
+
+            edges = {
+
+                    @Edge(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }, tags = {
+                            "highway=secondary" }),
+                    @Edge(id = "-1", coordinates = { @Loc(value = TWO),
+                            @Loc(value = ONE) }, tags = { "highway=secondary" }),
+                    @Edge(id = "2", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=secondary" }),
+                    @Edge(id = "-2", coordinates = { @Loc(value = THREE),
+                            @Loc(value = TWO) }, tags = { "highway=secondary" }),
+                    @Edge(id = "3", coordinates = { @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "highway=secondary" }),
+                    @Edge(id = "-3", coordinates = { @Loc(value = FOUR),
+                            @Loc(value = THREE) }, tags = { "highway=secondary" })
+
+            }
+
+    )
+    private Atlas differentNodeAndEdgeProperties1;
+
+    @TestAtlas(
+
+            nodes = {
+
+                    @Node(id = "2", coordinates = @Loc(value = TWO), tags = { "tag1=value1" }),
+                    @Node(id = "3", coordinates = @Loc(value = THREE), tags = { "tag1=value1" }),
+                    @Node(id = "4", coordinates = @Loc(value = FOUR), tags = { "tag1=value1" })
+
+            },
+
+            edges = {
+
+                    @Edge(id = "2", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=secondary" }),
+                    @Edge(id = "-2", coordinates = { @Loc(value = THREE),
+                            @Loc(value = TWO) }, tags = { "highway=secondary" }),
+                    @Edge(id = "3", coordinates = { @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "highway=secondary" }),
+                    @Edge(id = "-3", coordinates = { @Loc(value = FOUR),
+                            @Loc(value = THREE) }, tags = { "highway=secondary" })
+
+            }
+
+    )
+    private Atlas differentNodeAndEdgeProperties2;
+
+    public Atlas differentNodeAndEdgeProperties1()
+    {
+        return this.differentNodeAndEdgeProperties1;
+    }
+
+    public Atlas differentNodeAndEdgeProperties2()
+    {
+        return this.differentNodeAndEdgeProperties2;
+    }
 
     public Atlas getAtlas()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -401,7 +401,8 @@ public class FeatureChangeMergerTest
         afterNode1.withOutEdgeIdentifierLess(13L);
 
         final CompleteNode afterNode2 = new CompleteNode(123L, Location.COLOSSEUM, null,
-                Sets.treeSet(2L, 3L, 4L), Sets.treeSet(11L), null);
+                Sets.treeSet(2L, 3L), Sets.treeSet(11L), null);
+        afterNode2.withInEdgeIdentifierLess(4L);
         afterNode2.withInEdgeIdentifierExtra(100L);
 
         final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, afterNode1,
@@ -410,14 +411,20 @@ public class FeatureChangeMergerTest
                 beforeNode2);
 
         final FeatureChange merged = featureChange1.merge(featureChange2);
-        final Set<Long> goldenInEdgeSet = Sets.hashSet(2L, 3L, 4L, 100L);
+        final Set<Long> goldenInEdgeSet = Sets.hashSet(2L, 3L, 100L);
         final Set<Long> goldenOutEdgeSet = Sets.hashSet(10L, 11L);
+        final Set<Long> goldenExplicitlyExcludedInEdgeSet = Sets.hashSet(1L, 4L);
+        final Set<Long> goldenExplicitlyExcludedOutEdgeSet = Sets.hashSet(12L, 13L);
 
-        final Node mergedAfterNode = (Node) merged.getAfterView();
+        final CompleteNode mergedAfterNode = (CompleteNode) merged.getAfterView();
         Assert.assertEquals(goldenInEdgeSet, mergedAfterNode.inEdges().stream()
                 .map(Edge::getIdentifier).collect(Collectors.toSet()));
         Assert.assertEquals(goldenOutEdgeSet, mergedAfterNode.outEdges().stream()
                 .map(Edge::getIdentifier).collect(Collectors.toSet()));
+        Assert.assertEquals(goldenExplicitlyExcludedInEdgeSet,
+                mergedAfterNode.explicitlyExcludedInEdgeIdentifiers());
+        Assert.assertEquals(goldenExplicitlyExcludedOutEdgeSet,
+                mergedAfterNode.explicitlyExcludedOutEdgeIdentifiers());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -380,6 +381,43 @@ public class FeatureChangeMergerTest
                 .stream().map(edge -> edge.getIdentifier()).collect(Collectors.toSet()));
 
         Assert.assertEquals(Location.EIFFEL_TOWER, ((Node) merged.getAfterView()).getLocation());
+    }
+
+    @Test
+    public void testMergeNodesWithConflictingBeforeViews()
+    {
+        final CompleteNode beforeNode1 = new CompleteNode(123L, Location.COLOSSEUM,
+                Maps.hashMap("a", "1", "b", "2"), Sets.treeSet(1L, 2L),
+                Sets.treeSet(10L, 11L, 12L, 13L), Sets.hashSet(1L));
+
+        final CompleteNode beforeNode2 = new CompleteNode(123L, Location.COLOSSEUM,
+                Maps.hashMap("a", "1", "b", "2"), Sets.treeSet(2L, 3L, 4L), Sets.treeSet(11L),
+                Sets.hashSet(1L));
+
+        final CompleteNode afterNode1 = new CompleteNode(123L, Location.COLOSSEUM, null,
+                Sets.treeSet(1L, 2L), Sets.treeSet(10L, 11L, 12L, 13L), null);
+        afterNode1.withInEdgeIdentifierLess(1L);
+        afterNode1.withOutEdgeIdentifierLess(12L);
+        afterNode1.withOutEdgeIdentifierLess(13L);
+
+        final CompleteNode afterNode2 = new CompleteNode(123L, Location.COLOSSEUM, null,
+                Sets.treeSet(2L, 3L, 4L), Sets.treeSet(11L), null);
+        afterNode2.withInEdgeIdentifierExtra(100L);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, afterNode1,
+                beforeNode1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, afterNode2,
+                beforeNode2);
+
+        final FeatureChange merged = featureChange1.merge(featureChange2);
+        final Set<Long> goldenInEdgeSet = Sets.hashSet(2L, 3L, 4L, 100L);
+        final Set<Long> goldenOutEdgeSet = Sets.hashSet(10L, 11L);
+
+        final Node mergedAfterNode = (Node) merged.getAfterView();
+        Assert.assertEquals(goldenInEdgeSet, mergedAfterNode.inEdges().stream()
+                .map(Edge::getIdentifier).collect(Collectors.toSet()));
+        Assert.assertEquals(goldenOutEdgeSet, mergedAfterNode.outEdges().stream()
+                .map(Edge::getIdentifier).collect(Collectors.toSet()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
@@ -97,7 +97,7 @@ public class MemberMergeStrategiesTest
          */
         this.expectedException.expect(CoreException.class);
         this.expectedException.expectMessage(
-                "Explicit removedFromRight set did not match the implicitly computed removedFromRight set");
+                "explicitlyExcludedRight set did not match the implicitly computed removedFromRight set");
         MemberMergeStrategies.conflictingBeforeViewRelationBeanMerger.apply(beforeBean1, afterBean1,
                 beforeBean2, afterBean2);
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBean
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
 
 /**
  * @author lcram
@@ -175,6 +176,85 @@ public class MemberMergeStrategiesTest
         Assert.assertTrue(goldenImage1.equalsIncludingExplicitlyExcluded(
                 MemberMergeStrategies.conflictingBeforeViewRelationBeanMerger.apply(beforeBean1,
                         afterBean1, beforeBean2, afterBean2)));
+    }
+
+    @Test
+    public void testConflictingBeforeViewSetMergerADDREMOVEConflictFail()
+    {
+        final SortedSet<Long> beforeSet1 = Sets.treeSet(1L, 2L, 3L, 4L, 5L);
+        final SortedSet<Long> afterSet1 = Sets.treeSet(1L, 2L, 3L, 4L, 5L, 6L);
+        final Set<Long> explicitlyExcludedSet1 = Sets.hashSet();
+
+        final SortedSet<Long> beforeSet2 = Sets.treeSet(3L, 4L, 5L, 6L);
+        final SortedSet<Long> afterSet2 = Sets.treeSet(3L, 4L, 5L);
+        final Set<Long> explicitlyExcludedSet2 = Sets.hashSet(6L);
+
+        /*
+         * This will fail because the left side added 6L, while the right side explicitly removed
+         * 6L.
+         */
+        this.expectedException.expect(CoreException.class);
+        this.expectedException
+                .expectMessage("conflictingBeforeViewSetMerger failed due to ADD/REMOVE");
+        MemberMergeStrategies.conflictingBeforeViewSetMerger.apply(beforeSet1, afterSet1,
+                explicitlyExcludedSet1, beforeSet2, afterSet2, explicitlyExcludedSet2);
+    }
+
+    @Test
+    public void testConflictingBeforeViewSetMergerInconsistentRemovalFail()
+    {
+        /*
+         * Left side we explicitly remove 5L.
+         */
+        final SortedSet<Long> beforeSet1 = Sets.treeSet(1L, 2L, 3L, 4L, 5L);
+        final SortedSet<Long> afterSet1 = Sets.treeSet(1L, 2L, 3L, 4L);
+        final Set<Long> explicitlyExcludedSet1 = Sets.hashSet(5L);
+
+        /*
+         * Right side we explicitly remove 3L and add 6L. We also implicitly remove 5L, which will
+         * cause problems when we try to merge.
+         */
+        final SortedSet<Long> beforeSet2 = Sets.treeSet(3L, 4L, 5L);
+        final SortedSet<Long> afterSet2 = Sets.treeSet(4L, 6L);
+        final Set<Long> explicitlyExcludedSet2 = Sets.hashSet(3L);
+
+        /*
+         * This will fail because the right side implicitly removes 5L without declaring it in its
+         * explicitlyExcluded elements.
+         */
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage(
+                "explicitlyExcludedRight set did not match the implicitly computed removedFromRight set");
+        MemberMergeStrategies.conflictingBeforeViewSetMerger.apply(beforeSet1, afterSet1,
+                explicitlyExcludedSet1, beforeSet2, afterSet2, explicitlyExcludedSet2);
+    }
+
+    @Test
+    public void testConflictingBeforeViewSetMergerSuccess()
+    {
+        /*
+         * Left side we explicitly remove 5L.
+         */
+        final SortedSet<Long> beforeSet1 = Sets.treeSet(1L, 2L, 3L, 4L, 5L);
+        final SortedSet<Long> afterSet1 = Sets.treeSet(1L, 2L, 3L, 4L);
+        final Set<Long> explicitlyExcludedSet1 = Sets.hashSet(5L);
+
+        /*
+         * Right side we explicitly remove 3L, 5L and add 6L.
+         */
+        final SortedSet<Long> beforeSet2 = Sets.treeSet(3L, 4L, 5L);
+        final SortedSet<Long> afterSet2 = Sets.treeSet(4L, 6L);
+        final Set<Long> explicitlyExcludedSet2 = Sets.hashSet(3L, 5L);
+
+        final SortedSet<Long> goldenAfterSet = Sets.treeSet(1L, 2L, 4L, 6L);
+        final Set<Long> goldenExplicitlyExcludedSet = Sets.hashSet(3L, 5L);
+
+        final Tuple<SortedSet<Long>, Set<Long>> mergeResult = MemberMergeStrategies.conflictingBeforeViewSetMerger
+                .apply(beforeSet1, afterSet1, explicitlyExcludedSet1, beforeSet2, afterSet2,
+                        explicitlyExcludedSet2);
+
+        Assert.assertEquals(goldenAfterSet, mergeResult.getFirst());
+        Assert.assertEquals(goldenExplicitlyExcludedSet, mergeResult.getSecond());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
@@ -17,7 +17,6 @@ import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBean
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
-import org.openstreetmap.atlas.utilities.tuples.Tuple;
 
 /**
  * @author lcram
@@ -247,14 +246,12 @@ public class MemberMergeStrategiesTest
         final Set<Long> explicitlyExcludedSet2 = Sets.hashSet(3L, 5L);
 
         final SortedSet<Long> goldenAfterSet = Sets.treeSet(1L, 2L, 4L, 6L);
-        final Set<Long> goldenExplicitlyExcludedSet = Sets.hashSet(3L, 5L);
 
-        final Tuple<SortedSet<Long>, Set<Long>> mergeResult = MemberMergeStrategies.conflictingBeforeViewSetMerger
+        final SortedSet<Long> mergeResult = MemberMergeStrategies.conflictingBeforeViewSetMerger
                 .apply(beforeSet1, afterSet1, explicitlyExcludedSet1, beforeSet2, afterSet2,
                         explicitlyExcludedSet2);
 
-        Assert.assertEquals(goldenAfterSet, mergeResult.getFirst());
-        Assert.assertEquals(goldenExplicitlyExcludedSet, mergeResult.getSecond());
+        Assert.assertEquals(goldenAfterSet, mergeResult);
     }
 
     @Test


### PR DESCRIPTION
### Description:

This is a follow up PR for #418.

Since `Node` views may differ across shards, we need some way to forgive inconsistent `inEdge` and `outEdge` beforeViews when merging relevant FeatureChanges. This PR provides that functionality, as well as additional tests (which are not yet implemented, hence the DNM).

### Potential Impact:

Code that previously failed with merge conflicts may now pass.

### Unit Test Approach:

Added additional unit tests to demonstrate correct forgiveness conditions.

### Test Results:

All tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)