### PR TITLE
Improve zip reading performance

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
@@ -104,10 +104,10 @@ public class ZipResource
                             }
 
                             @Override
-                            public int read(final byte[] b, final int off, final int len)
+                            public int read(final byte[] bYte, final int offset, final int length)
                                     throws IOException
                             {
-                                return ZipIterator.this.input.read(b, off, len);
+                                return ZipIterator.this.input.read(bYte, offset, length);
                             }
                         };
                     }

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
@@ -5,6 +5,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -101,6 +102,13 @@ public class ZipResource
                             {
                                 return ZipIterator.this.input.read();
                             }
+
+                            @Override
+                            public int read(final byte[] b, final int off, final int len)
+                                    throws IOException
+                            {
+                                return ZipIterator.this.input.read(b, off, len);
+                            }
                         };
                     }
                 };
@@ -109,7 +117,7 @@ public class ZipResource
             }
             else
             {
-                return null;
+                throw new NoSuchElementException();
             }
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/zip/ZipResource.java
@@ -104,10 +104,10 @@ public class ZipResource
                             }
 
                             @Override
-                            public int read(final byte[] bYte, final int offset, final int length)
+                            public int read(final byte[] buffer, final int offset, final int length)
                                     throws IOException
                             {
-                                return ZipIterator.this.input.read(bYte, offset, length);
+                                return ZipIterator.this.input.read(buffer, offset, length);
                             }
                         };
                     }


### PR DESCRIPTION
### Description:

A method was missing in `ZipResource`. The iterator over each resource was only implementing the `int read()` method, forcing any buffered reader to fall back to that slow method. This PR adds `int read(final byte[] b, final int off, final int len)` to allow for faster buffer reading.

- Also squashed one sonar issue related to the `NoSuchElementException`

### Potential Impact:

Dramatic speed improvement in reading zip resources (including proto-serialized Atlas files): ~15x (tested with a profiler).

### Unit Test Approach:

Use existing unit tests.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)