### PR TITLE
Reworked sectioning logic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -570,6 +570,7 @@ public class WaySectionProcessor
 
         StreamSupport.stream(this.rawAtlas.lines().spliterator(), true).forEach(line ->
         {
+            boolean kept = false;
             if (isAtlasEdge(line))
             {
                 final NodeOccurrenceCounter nodesForEdge = new NodeOccurrenceCounter();
@@ -640,17 +641,20 @@ public class WaySectionProcessor
 
                 // Record the edge and all its nodes
                 changeSet.createEdgeToNodeMapping(line.getIdentifier(), nodesForEdge);
+                kept = true;
             }
-            else if (isAtlasArea(line))
+            if (isAtlasArea(line))
             {
                 changeSet.recordArea(line);
+                kept = true;
             }
-            else if (isAtlasLine(line))
+            if (isAtlasLine(line))
             {
+                kept = true;
                 // No-op. Unless a line becomes an area, edge or is excluded from the Atlas, it will
                 // stay a line. It's easier to track of exclusions than lines that stay as lines
             }
-            else
+            if (!kept)
             {
                 changeSet.recordExcludedLine(line);
                 logger.debug(

--- a/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
+++ b/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
@@ -1,6 +1,6 @@
 {
     "filters": [
-        "highway->!|highway->platform,bus_stop,rest_area",
+        "highway->platform,bus_stop,rest_area|highway->pedestrian&area->yes|highway->!",
         "railway->!|railway->platform,traverser,station",
         "route->!ferry",
         "man_made->!pier"

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -256,6 +256,24 @@ public class WaySectionProcessorTest
     }
 
     @Test
+    public void testPedestrianRing()
+    {
+        // Based on https://www.openstreetmap.org/way/460257372
+        final Atlas slicedRawAtlas = this.setup.getPedestrianRingAtlas();
+        final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
+                AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
+
+        Assert.assertEquals("Two edges, the ring got sectioned in the middle", 2,
+                finalAtlas.numberOfEdges());
+        Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
+        finalAtlas.edges().forEach(
+                edge -> Assert.assertFalse("No edge has a reverse edge", edge.hasReverseEdge()));
+
+        Assert.assertEquals("One area from the same way used for the edges", 1,
+                finalAtlas.numberOfAreas());
+    }
+
+    @Test
     public void testRelationMemberLocationItemInclusion()
     {
         // Based on https://www.openstreetmap.org/relation/578254 - the Node in the Relation gets

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -71,6 +71,9 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "nodeAndPointAsRelationMember.atlas.txt")
     private Atlas nodeAndPointAsRelationMember;
 
+    @TestAtlas(loadFromTextResource = "pedestrianRing.atlas.txt")
+    private Atlas pedestrianRing;
+
     public Atlas getBidirectionalRingAtlas()
     {
         return this.bidirectioalRingAtlas;
@@ -134,6 +137,11 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     public Atlas getOneWaySimpleLineAtlas()
     {
         return this.oneWaySimpleLine;
+    }
+
+    public Atlas getPedestrianRingAtlas()
+    {
+        return this.pedestrianRing;
     }
 
     public Atlas getRawAtlasSpanningOutsideBoundary()

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/pedestrianRing.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/pedestrianRing.atlas.txt
@@ -1,0 +1,19 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+460257372000000 && 7.4056228,-7.544423:7.4054606,-7.5440298:7.4054581,-7.5439855:7.4054698,-7.5439414:7.4055053,-7.5438961:7.4055438,-7.5438649:7.4055868,-7.5438658:7.4056928,-7.5439353:7.4057793,-7.5440219:7.4057738,-7.5440787:7.4056629,-7.5442744:7.405644,-7.5443205:7.4056228,-7.544423 && last_edit_changeset -> 44482187 || access -> customers || surface -> asphalt || iso_country_code -> CIV || source -> Cnes / Spot Image || oneway -> yes || last_edit_user_name -> ulrichm || last_edit_time -> 1482025768000 || last_edit_user_id -> 192829 || service -> driveway || lanes -> 1 || incline -> up || highway -> pedestrian || area -> yes || last_edit_version -> 1
+# Points
+1253867987000000 && 7.4056228,-7.544423 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025782000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 4
+3847137297000000 && 7.4054606,-7.5440298 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137302000000 && 7.4054698,-7.5439414 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137303000000 && 7.4054581,-7.5439855 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137304000000 && 7.4055053,-7.5438961 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137305000000 && 7.4055868,-7.5438658 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137310000000 && 7.4057738,-7.5440787 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137311000000 && 7.4056928,-7.5439353 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137312000000 && 7.405644,-7.5443205 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+3847137314000000 && 7.4056629,-7.5442744 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025831000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 2
+4559344028000000 && 7.4055438,-7.5438649 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025736000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 1
+4559344273000000 && 7.4057793,-7.5440219 && last_edit_user_name -> ulrichm || last_edit_changeset -> 44482187 || last_edit_time -> 1482025735000 || last_edit_user_id -> 192829 || iso_country_code -> CIV || last_edit_version -> 1
+# Relations


### PR DESCRIPTION
### Description:

This PR changes the sectioning logic to allow entities that pass both area and edge filter to become both instead of just an edge. This is useful primarily for [pedestrian highways](https://wiki.openstreetmap.org/wiki/Key:area), which are tagged as both highway=pedestrian (thus typically qualifying as Edges) and area=yes (thus should be considered Areas as well).

### Potential Impact:
Limited impact, though now pedestrian areas will appear simultaneously as Edges and as Areas which is a change from previous behavior of only being Edges.

### Unit Test Approach:
Added unit test for expected behavior.

### Test Results:
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)