### PR TITLE
Easier means to convert an AtlasEntity to the appropriate CompleteEntity (without the explicit entity type)

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -284,4 +284,6 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
     {
         return CompleteEntity.withTags((C) this, tags, false);
     }
+
+    ItemType getType();
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
@@ -65,8 +65,8 @@ public enum CompleteItemType
     {
         final ItemType itemType = reference.getType();
         final CompleteItemType completeItemType = CompleteItemType.from(itemType);
-        final C c = completeItemType.completeEntityShallowFrom(reference);
-        return c;
+        final C completeEntity = completeItemType.completeEntityShallowFrom(reference);
+        return completeEntity;
     }
 
     private void validate(final AtlasEntity reference)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
@@ -61,6 +61,14 @@ public enum CompleteItemType
         return (C) CompleteEntity.shallowFrom(reference);
     }
 
+    public static <C extends CompleteEntity> C shallowFrom(final AtlasEntity reference)
+    {
+        final ItemType itemType = reference.getType();
+        final CompleteItemType completeItemType = CompleteItemType.from(itemType);
+        final C c = completeItemType.completeEntityShallowFrom(reference);
+        return c;
+    }
+
     private void validate(final AtlasEntity reference)
     {
         Validate.isTrue(getItemType().getMemberClass().isAssignableFrom(reference.getClass()),

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
@@ -1,0 +1,50 @@
+package org.openstreetmap.atlas.geography.atlas.complete;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Yazad Khambata
+ */
+public class CompleteItemTypeTest {
+    @Rule
+    public CompleteItemTypeTestRule rule = new CompleteItemTypeTestRule();
+
+    @Test
+    public void shallowFrom() {
+        final Atlas atlas = rule.getAtlas();
+        final List<CompleteEntity> completeEntities = toCompleteEntities(atlas);
+        validate(completeEntities);
+    }
+
+    private List<CompleteEntity> toCompleteEntities(final Atlas atlas) {
+        return Arrays.stream(ItemType.values())
+                    .map(itemType -> itemType.entityForIdentifier(atlas, 1L))
+                    .map(atlasEntity -> {
+                        final CompleteEntity completeEntity = CompleteItemType.shallowFrom(atlasEntity);
+                        return completeEntity;
+                    })
+                    .collect(Collectors.toList());
+    }
+
+    private void validate(final List<CompleteEntity> completeEntities) {
+        Assert.assertNotNull(completeEntities);
+        Assert.assertFalse(completeEntities.isEmpty());
+        Assert.assertTrue(completeEntities.size() == ItemType.values().length);
+        final Set<ItemType> itemTypes = completeEntities.stream()
+                .filter(completeEntity -> completeEntity != null)
+                .map(CompleteEntity::getType)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(itemTypes, Arrays.stream(ItemType.values()).collect(Collectors.toSet()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
@@ -1,7 +1,5 @@
 package org.openstreetmap.atlas.geography.atlas.complete;
 
-import static org.junit.Assert.*;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
@@ -1,50 +1,53 @@
 package org.openstreetmap.atlas.geography.atlas.complete;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 
 /**
  * @author Yazad Khambata
  */
-public class CompleteItemTypeTest {
+public class CompleteItemTypeTest
+{
     @Rule
     public CompleteItemTypeTestRule rule = new CompleteItemTypeTestRule();
 
     @Test
-    public void shallowFrom() {
+    public void shallowFrom()
+    {
         final Atlas atlas = rule.getAtlas();
         final List<CompleteEntity> completeEntities = toCompleteEntities(atlas);
         validate(completeEntities);
     }
 
-    private List<CompleteEntity> toCompleteEntities(final Atlas atlas) {
+    private List<CompleteEntity> toCompleteEntities(final Atlas atlas)
+    {
         return Arrays.stream(ItemType.values())
-                    .map(itemType -> itemType.entityForIdentifier(atlas, 1L))
-                    .map(atlasEntity -> {
-                        final CompleteEntity completeEntity = CompleteItemType.shallowFrom(atlasEntity);
-                        return completeEntity;
-                    })
-                    .collect(Collectors.toList());
+                .map(itemType -> itemType.entityForIdentifier(atlas, 1L)).map(atlasEntity ->
+                {
+                    final CompleteEntity completeEntity = CompleteItemType.shallowFrom(atlasEntity);
+                    return completeEntity;
+                }).collect(Collectors.toList());
     }
 
-    private void validate(final List<CompleteEntity> completeEntities) {
+    private void validate(final List<CompleteEntity> completeEntities)
+    {
         Assert.assertNotNull(completeEntities);
         Assert.assertFalse(completeEntities.isEmpty());
         Assert.assertTrue(completeEntities.size() == ItemType.values().length);
         final Set<ItemType> itemTypes = completeEntities.stream()
-                .filter(completeEntity -> completeEntity != null)
-                .map(CompleteEntity::getType)
+                .filter(completeEntity -> completeEntity != null).map(CompleteEntity::getType)
                 .collect(Collectors.toSet());
-        Assert.assertEquals(itemTypes, Arrays.stream(ItemType.values()).collect(Collectors.toSet()));
+        Assert.assertEquals(itemTypes,
+                Arrays.stream(ItemType.values()).collect(Collectors.toSet()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTestRule.java
@@ -20,33 +20,20 @@ public class CompleteItemTypeTestRule extends CoreTestRule
     public static final String ONE = "35.3,-128.03";
     public static final String TWO = "37.4,-127.02";
 
-    @TestAtlas(
-            nodes = {
-                    @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO))
-            },
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)) },
 
-            edges = {
-                    @Edge(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
-            },
+            edges = { @Edge(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }) },
 
-            areas = {
-                    @Area(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
-            },
+            areas = { @Area(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }) },
 
-            lines = {
-                    @Line(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
-            },
+            lines = { @Line(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }) },
 
-            points = {
-                    @Point(id = "1", coordinates = @Loc(value = ONE))
-            },
+            points = { @Point(id = "1", coordinates = @Loc(value = ONE)) },
 
             relations = { @Relation(id = "1", members = {
                     @Member(id = "1", type = "node", role = "node-role"),
-                    @Member(id = "1", type = "edge", role = "edge-role")
-            })}
-    )
+                    @Member(id = "1", type = "edge", role = "edge-role") }) })
     private Atlas atlas;
 
     public Atlas getAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTestRule.java
@@ -1,0 +1,56 @@
+package org.openstreetmap.atlas.geography.atlas.complete;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * @author Yazad Khambata
+ */
+public class CompleteItemTypeTestRule extends CoreTestRule
+{
+    public static final String ONE = "35.3,-128.03";
+    public static final String TWO = "37.4,-127.02";
+
+    @TestAtlas(
+            nodes = {
+                    @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO))
+            },
+
+            edges = {
+                    @Edge(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
+            },
+
+            areas = {
+                    @Area(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
+            },
+
+            lines = {
+                    @Line(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO) })
+            },
+
+            points = {
+                    @Point(id = "1", coordinates = @Loc(value = ONE))
+            },
+
+            relations = { @Relation(id = "1", members = {
+                    @Member(id = "1", type = "node", role = "node-role"),
+                    @Member(id = "1", type = "edge", role = "edge-role")
+            })}
+    )
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}


### PR DESCRIPTION
### Description:

An easier means to convert an `AtlasEntity` to the appropriate `CompleteEntity` (without the explicit entity type)

### Potential Impact:

None.

### Unit Test Approach:

Unit tested for all entities.

### Test Results:

Test successful.
