### PR TITLE
Atlas diff cascade test

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasEntityKey.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasEntityKey.java
@@ -1,0 +1,44 @@
+package org.openstreetmap.atlas.geography.atlas.change;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteItemType;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/**
+ * Caters to use cases where {@link AtlasEntity}-ies need to be grouped by the {@link AtlasEntity#getIdentifier()}.
+ * {@link AtlasEntity#getIdentifier()} could repeat across different entity types, and hence combined with
+ * {@link ItemType}. This class extends {@link Tuple} and adds some functionality to reduce code verbosity.
+ *
+ * @author Yazad Khambata
+ */
+public class AtlasEntityKey extends Tuple<ItemType, Long> {
+    protected AtlasEntityKey(final ItemType itemType, final Long identifier) {
+        super(itemType, identifier);
+    }
+
+    public static AtlasEntityKey from(final ItemType itemType, final Long identifier) {
+        return new AtlasEntityKey(itemType, identifier);
+    }
+
+    public static AtlasEntityKey from(final FeatureChange featureChange) {
+        return from(featureChange.getItemType(), featureChange.getIdentifier());
+    }
+
+    public ItemType getItemType() {
+        return getFirst();
+    }
+
+    public Long getIdentifier() {
+        return getSecond();
+    }
+
+    public CompleteItemType getCompleteItemType() {
+        return CompleteItemType.from(getItemType());
+    }
+
+    public AtlasEntity getAtlasEntity(final Atlas atlas) {
+        return getItemType().entityForIdentifier(atlas, getIdentifier());
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasEntityKey.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasEntityKey.java
@@ -7,38 +7,47 @@ import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.utilities.tuples.Tuple;
 
 /**
- * Caters to use cases where {@link AtlasEntity}-ies need to be grouped by the {@link AtlasEntity#getIdentifier()}.
- * {@link AtlasEntity#getIdentifier()} could repeat across different entity types, and hence combined with
- * {@link ItemType}. This class extends {@link Tuple} and adds some functionality to reduce code verbosity.
+ * Caters to use cases where {@link AtlasEntity}-ies need to be grouped by the
+ * {@link AtlasEntity#getIdentifier()}. {@link AtlasEntity#getIdentifier()} could repeat across
+ * different entity types, and hence combined with {@link ItemType}. This class extends
+ * {@link Tuple} and adds some functionality to reduce code verbosity.
  *
  * @author Yazad Khambata
  */
-public class AtlasEntityKey extends Tuple<ItemType, Long> {
-    protected AtlasEntityKey(final ItemType itemType, final Long identifier) {
+public class AtlasEntityKey extends Tuple<ItemType, Long>
+{
+    protected AtlasEntityKey(final ItemType itemType, final Long identifier)
+    {
         super(itemType, identifier);
     }
 
-    public static AtlasEntityKey from(final ItemType itemType, final Long identifier) {
+    public static AtlasEntityKey from(final ItemType itemType, final Long identifier)
+    {
         return new AtlasEntityKey(itemType, identifier);
     }
 
-    public static AtlasEntityKey from(final FeatureChange featureChange) {
+    public static AtlasEntityKey from(final FeatureChange featureChange)
+    {
         return from(featureChange.getItemType(), featureChange.getIdentifier());
     }
 
-    public ItemType getItemType() {
+    public ItemType getItemType()
+    {
         return getFirst();
     }
 
-    public Long getIdentifier() {
+    public Long getIdentifier()
+    {
         return getSecond();
     }
 
-    public CompleteItemType getCompleteItemType() {
+    public CompleteItemType getCompleteItemType()
+    {
         return CompleteItemType.from(getItemType());
     }
 
-    public AtlasEntity getAtlasEntity(final Atlas atlas) {
+    public AtlasEntity getAtlasEntity(final Atlas atlas)
+    {
         return getItemType().entityForIdentifier(atlas, getIdentifier());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * It contains a collection of {@link FeatureChange} objects, which describe the changes.
  *
  * @author matthieun
+ * @author Yazad Khambata
  */
 public class Change implements Located, Serializable
 {
@@ -38,7 +39,7 @@ public class Change implements Located, Serializable
     private static final AtomicInteger CHANGE_IDENTIFIER_FACTORY = new AtomicInteger();
 
     private final List<FeatureChange> featureChanges;
-    private final Map<Tuple<ItemType, Long>, Integer> identifierToIndex;
+    private final Map<AtlasEntityKey, Integer> identifierToIndex;
     private final int identifier;
     private Rectangle bounds;
     private String name;
@@ -94,7 +95,7 @@ public class Change implements Located, Serializable
 
     public Optional<FeatureChange> changeFor(final ItemType itemType, final Long identifier)
     {
-        final Tuple<ItemType, Long> key = new Tuple<>(itemType, identifier);
+        final AtlasEntityKey key = AtlasEntityKey.from(itemType, identifier);
         if (!this.identifierToIndex.containsKey(key))
         {
             return Optional.empty();
@@ -112,6 +113,12 @@ public class Change implements Located, Serializable
         return this.identifierToIndex.keySet().stream()
                 .filter(tuple -> tuple.getFirst() == itemType)
                 .map(tuple -> this.featureChanges.get(this.identifierToIndex.get(tuple)));
+    }
+
+    public Map<AtlasEntityKey, FeatureChange> allChangesMappedByAtlasEntityKey() {
+        return changes()
+                .map(featureChange -> Tuple.createTuple(AtlasEntityKey.from(featureChange), featureChange))
+                .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond));
     }
 
     /**
@@ -214,8 +221,8 @@ public class Change implements Located, Serializable
     protected Change add(final FeatureChange featureChange)
     {
         final int currentIndex = this.featureChanges.size();
-        final Tuple<ItemType, Long> key = new Tuple<>(featureChange.getItemType(),
-                featureChange.getIdentifier());
+        final AtlasEntityKey key = AtlasEntityKey.from(featureChange.getItemType(), featureChange.getIdentifier());
+
         FeatureChange chosen = featureChange;
         if (!this.identifierToIndex.containsKey(key))
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -115,9 +115,11 @@ public class Change implements Located, Serializable
                 .map(tuple -> this.featureChanges.get(this.identifierToIndex.get(tuple)));
     }
 
-    public Map<AtlasEntityKey, FeatureChange> allChangesMappedByAtlasEntityKey() {
+    public Map<AtlasEntityKey, FeatureChange> allChangesMappedByAtlasEntityKey()
+    {
         return changes()
-                .map(featureChange -> Tuple.createTuple(AtlasEntityKey.from(featureChange), featureChange))
+                .map(featureChange -> Tuple.createTuple(AtlasEntityKey.from(featureChange),
+                        featureChange))
                 .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond));
     }
 
@@ -221,7 +223,8 @@ public class Change implements Located, Serializable
     protected Change add(final FeatureChange featureChange)
     {
         final int currentIndex = this.featureChanges.size();
-        final AtlasEntityKey key = AtlasEntityKey.from(featureChange.getItemType(), featureChange.getIdentifier());
+        final AtlasEntityKey key = AtlasEntityKey.from(featureChange.getItemType(),
+                featureChange.getIdentifier());
 
         FeatureChange chosen = featureChange;
         if (!this.identifierToIndex.containsKey(key))

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
@@ -1,5 +1,9 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,10 +15,6 @@ import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * There are 2 edges AB and BC. Node B is common between the 2 edges.
@@ -53,13 +53,15 @@ public class MultiCascadeDeleteTest
         Assert.assertEquals(1, relation.membersOfType(ItemType.EDGE).size());
         Assert.assertEquals(1, relation.membersOfType(ItemType.NODE).size());
 
-        //Step-3 Verify AtlasDiff
-        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>() {
+        // Step-3 Verify AtlasDiff
+        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
+        {
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
                 put(AtlasEntityKey.from(ItemType.EDGE, MultiCascadeDeleteTestRule.edgeAB), true);
-                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX), false);
+                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX),
+                        false);
             }
         };
 
@@ -90,13 +92,15 @@ public class MultiCascadeDeleteTest
         Assert.assertEquals(1, relation.membersOfType(ItemType.EDGE).size());
         Assert.assertEquals(1, relation.membersOfType(ItemType.NODE).size());
 
-        //Step-3 Verify AtlasDiff
-        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>() {
+        // Step-3 Verify AtlasDiff
+        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
+        {
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), true);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
                 put(AtlasEntityKey.from(ItemType.EDGE, MultiCascadeDeleteTestRule.edgeAB), true);
-                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX), false);
+                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX),
+                        false);
             }
         };
 
@@ -125,15 +129,17 @@ public class MultiCascadeDeleteTest
         final Relation relation = changeAtlas.relation(MultiCascadeDeleteTestRule.relationX);
         Assert.assertNull(relation);
 
-        //Step-3 Verify AtlasDiff
-        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>() {
+        // Step-3 Verify AtlasDiff
+        final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
+        {
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), true);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeC), false);
                 put(AtlasEntityKey.from(ItemType.EDGE, MultiCascadeDeleteTestRule.edgeAB), true);
                 put(AtlasEntityKey.from(ItemType.EDGE, MultiCascadeDeleteTestRule.edgeBC), true);
-                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX), true);
+                put(AtlasEntityKey.from(ItemType.RELATION, MultiCascadeDeleteTestRule.relationX),
+                        true);
             }
         };
 
@@ -174,24 +180,31 @@ public class MultiCascadeDeleteTest
         return atlas;
     }
 
-    private void verifyAtlasDiff(final Atlas originalAtlas, final Atlas changeAtlas, final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted) {
+    private void verifyAtlasDiff(final Atlas originalAtlas, final Atlas changeAtlas,
+            final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted)
+    {
         final AtlasDiff atlasDiff = new AtlasDiff(originalAtlas, changeAtlas);
         final Optional<Change> optionalChangeFromDiff = atlasDiff.generateChange();
         Assert.assertTrue(optionalChangeFromDiff.isPresent());
         final Change changeFromDiff = optionalChangeFromDiff.get();
 
-        final Map<AtlasEntityKey, FeatureChange> atlasEntityKeyFeatureChangeMap = changeFromDiff.allChangesMappedByAtlasEntityKey();
+        final Map<AtlasEntityKey, FeatureChange> atlasEntityKeyFeatureChangeMap = changeFromDiff
+                .allChangesMappedByAtlasEntityKey();
 
-        atlasEntityKeyFeatureChangeMap.entrySet().stream().forEach(entry -> {
+        atlasEntityKeyFeatureChangeMap.entrySet().stream().forEach(entry ->
+        {
             log.info("{} : {}", entry.getKey(), entry.getValue());
         });
 
-        Assert.assertEquals(expectedChangedAndDeleted.size(), atlasEntityKeyFeatureChangeMap.size());
+        Assert.assertEquals(expectedChangedAndDeleted.size(),
+                atlasEntityKeyFeatureChangeMap.size());
 
-        expectedChangedAndDeleted.entrySet().stream().forEach(expectedEntry -> {
+        expectedChangedAndDeleted.entrySet().stream().forEach(expectedEntry ->
+        {
             Assert.assertNotNull(atlasEntityKeyFeatureChangeMap.get(expectedEntry.getKey()));
 
-            final AtlasEntity changedAtlasEntity = expectedEntry.getKey().getAtlasEntity(changeAtlas);
+            final AtlasEntity changedAtlasEntity = expectedEntry.getKey()
+                    .getAtlasEntity(changeAtlas);
             Assert.assertTrue((changedAtlasEntity == null) == expectedEntry.getValue());
         });
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTestRule.java
@@ -16,15 +16,16 @@ public class MultiCascadeDeleteTestRule extends CoreTestRule
     public static final String strNodeA = "1";
     public static final String strNodeB = "2";
     public static final String strNodeC = "3";
-    public static final String strEdgeA = "1";
-    public static final String strEdgeB = "2";
+    public static final String strEdgeAB = "1";
+    public static final String strEdgeBC = "2";
     public static final String strRelationX = "1";
 
     public static final Long nodeA = Long.valueOf(strNodeA);
     public static final Long nodeB = Long.valueOf(strNodeB);
     public static final Long nodeC = Long.valueOf(strNodeC);
 
-    public static final Long edgeA = Long.valueOf(strEdgeA);
+    public static final Long edgeAB = Long.valueOf(strEdgeAB);
+    public static final Long edgeBC = Long.valueOf(strEdgeBC);
 
     public static final Long relationX = Long.valueOf(strRelationX);
 
@@ -34,14 +35,14 @@ public class MultiCascadeDeleteTestRule extends CoreTestRule
             @TestAtlas.Node(id = strNodeC, coordinates = @TestAtlas.Loc(value = LOC_C)), },
 
             edges = {
-                    @TestAtlas.Edge(id = strEdgeA, coordinates = { @TestAtlas.Loc(value = LOC_A),
+                    @TestAtlas.Edge(id = strEdgeAB, coordinates = { @TestAtlas.Loc(value = LOC_A),
                             @TestAtlas.Loc(value = LOC_B) }),
-                    @TestAtlas.Edge(id = strEdgeB, coordinates = { @TestAtlas.Loc(value = LOC_B),
+                    @TestAtlas.Edge(id = strEdgeBC, coordinates = { @TestAtlas.Loc(value = LOC_B),
                             @TestAtlas.Loc(value = LOC_C) }), },
 
             relations = { @TestAtlas.Relation(id = strRelationX, members = {
-                    @TestAtlas.Relation.Member(id = strEdgeA, role = "x", type = "edge"),
-                    @TestAtlas.Relation.Member(id = strEdgeB, role = "y", type = "edge"),
+                    @TestAtlas.Relation.Member(id = strEdgeAB, role = "x", type = "edge"),
+                    @TestAtlas.Relation.Member(id = strEdgeBC, role = "y", type = "edge"),
                     @TestAtlas.Relation.Member(id = strNodeB, role = "y", type = "node"), }) })
     private Atlas atlas;
 


### PR DESCRIPTION
### Description:

Enhanced the Delete Multi Level Cascade to also verify against `AtlasDiff`. Also added `AtlasEntityKey` which extends Atlas `Tuple` class for the specific use case of unique keys representing `ItemType` and `AtlasEntity` `identifier`.

### Potential Impact:

None.

### Unit Test Approach:

Unit tested

### Test Results:

Test successful.
