### PR TITLE
Save FeatureChanges as ldgeojson by default

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -519,12 +519,17 @@ public class FeatureChange implements Located, Serializable
      */
     public void save(final WritableResource resource)
     {
-        new FeatureChangeGeoJsonSerializer().accept(this, resource);
+        new FeatureChangeGeoJsonSerializer(true).accept(this, resource);
     }
 
     public String toGeoJson()
     {
-        return new FeatureChangeGeoJsonSerializer().convert(this);
+        return new FeatureChangeGeoJsonSerializer(false).convert(this);
+    }
+    
+    public String toPrettyGeoJson()
+    {
+        return new FeatureChangeGeoJsonSerializer(true).convert(this);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -200,21 +200,6 @@ public class FeatureChange implements Located, Serializable
     }
 
     /**
-     * Specify the Atlas on which this {@link FeatureChange} is based. {@link FeatureChange} objects
-     * with a contextual Atlas are able to calculate their before view, and so are able to leverage
-     * richer and more robust merging mechanics.
-     *
-     * @param atlas
-     *            the contextual atlas
-     * @return the updated {@link FeatureChange}
-     */
-    FeatureChange withAtlasContext(final Atlas atlas)
-    {
-        computeBeforeViewUsingAtlasContext(atlas, this.changeType);
-        return this;
-    }
-
-    /**
      * Check if this {@link FeatureChange}'s afterView is full. A full afterView is a
      * {@link CompleteEntity} that has all its fields set to non-null values.
      *
@@ -526,7 +511,7 @@ public class FeatureChange implements Located, Serializable
     {
         return new FeatureChangeGeoJsonSerializer(false).convert(this);
     }
-    
+
     public String toPrettyGeoJson()
     {
         return new FeatureChangeGeoJsonSerializer(true).convert(this);
@@ -538,6 +523,21 @@ public class FeatureChange implements Located, Serializable
         return "FeatureChange [changeType=" + this.changeType + ", reference={"
                 + this.afterView.getType() + "," + this.afterView.getIdentifier() + "}, tags="
                 + getTags() + ", bounds=" + bounds() + "]";
+    }
+
+    /**
+     * Specify the Atlas on which this {@link FeatureChange} is based. {@link FeatureChange} objects
+     * with a contextual Atlas are able to calculate their before view, and so are able to leverage
+     * richer and more robust merging mechanics.
+     *
+     * @param atlas
+     *            the contextual atlas
+     * @return the updated {@link FeatureChange}
+     */
+    FeatureChange withAtlasContext(final Atlas atlas)
+    {
+        computeBeforeViewUsingAtlasContext(atlas, this.changeType);
+        return this;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializer.java
@@ -177,16 +177,7 @@ public class FeatureChangeGeoJsonSerializer
     }
 
     private static final String NULL = "null";
-    private static final Gson jsonSerializer;
-    static
-    {
-        final GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.setPrettyPrinting();
-        gsonBuilder.disableHtmlEscaping();
-        gsonBuilder.registerTypeHierarchyAdapter(FeatureChange.class,
-                new FeatureChangeTypeHierarchyAdapter());
-        jsonSerializer = gsonBuilder.create();
-    }
+    private final Gson jsonSerializer;
 
     private static <T> void add(final JsonObject result, final String name, final T property,
             final Function<T, JsonElement> writer)
@@ -207,12 +198,25 @@ public class FeatureChangeGeoJsonSerializer
         result.addProperty(name, property == null ? NULL : writer.apply(property).toString());
     }
 
+    public FeatureChangeGeoJsonSerializer(final boolean prettyPrint)
+    {
+        final GsonBuilder gsonBuilder = new GsonBuilder();
+        if (prettyPrint)
+        {
+            gsonBuilder.setPrettyPrinting();
+        }
+        gsonBuilder.disableHtmlEscaping();
+        gsonBuilder.registerTypeHierarchyAdapter(FeatureChange.class,
+                new FeatureChangeTypeHierarchyAdapter());
+        this.jsonSerializer = gsonBuilder.create();
+    }
+
     @Override
     public void accept(final FeatureChange featureChange, final WritableResource resource)
     {
         try (Writer writer = resource.writer())
         {
-            jsonSerializer.toJson(featureChange, writer);
+            this.jsonSerializer.toJson(featureChange, writer);
         }
         catch (final IOException e)
         {
@@ -224,6 +228,6 @@ public class FeatureChangeGeoJsonSerializer
     @Override
     public String convert(final FeatureChange featureChange)
     {
-        return jsonSerializer.toJson(featureChange);
+        return this.jsonSerializer.toJson(featureChange);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializerTest.java
@@ -204,7 +204,9 @@ public class FeatureChangeGeoJsonSerializerTest
     {
         final String expected = new InputStreamResource(
                 () -> FeatureChangeGeoJsonSerializerTest.class.getResourceAsStream(fileName)).all();
-        Assert.assertEquals(expected, featureChange.toGeoJson());
+        Assert.assertEquals(expected, featureChange.toPrettyGeoJson());
+        Assert.assertEquals(expected.replaceAll(System.lineSeparator() + " *", "")
+                .replaceAll("(?<!Member): *", ":"), featureChange.toGeoJson());
         final File temporary = File.temporary();
         try
         {


### PR DESCRIPTION
### Description:

Ecah `FeatureChange` is single-line geojson when using the `toGeoJson()` method. This enables groups of `FeatureChange`s to be packaged as ldgeojson files.

### Potential Impact:

Default `FeatureChange` geojson printing will change.

### Unit Test Approach:

Augmented the existing unit tests to compare the results of the new method too.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)