### PR TITLE
Declarative access to start or end Node of an Edge

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEdgeType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEdgeType.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
  *
  * @author Yazad Khambata
  */
-public enum ConnectedEdgeType
+public enum ConnectedEdgeType implements ConnectedEntityType<Node, SortedSet<Edge>>
 {
     IN("inEdges", Node::inEdges),
 
@@ -26,11 +26,13 @@ public enum ConnectedEdgeType
         this.accessFunction = accessFunction;
     }
 
+    @Override
     public String getPropertyName()
     {
         return this.propertyName;
     }
 
+    @Override
     public Function<Node, SortedSet<Edge>> getAccessFunction()
     {
         return this.accessFunction;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
@@ -5,15 +5,15 @@ import java.util.function.Function;
 /**
  * An interface that generalizes enum based declarative connectivity information.
  *
- * @param <ME>
+ * @param <M>
  *            - The current entity.
- * @param <CONNECTED>
+ * @param <C>
  *            - The connected entity.
  * @author Yazad Khambata
  */
-public interface ConnectedEntityType<ME extends AtlasEntity, CONNECTED>
+public interface ConnectedEntityType<M extends AtlasEntity, C>
 {
     String getPropertyName();
 
-    Function<ME, CONNECTED> getAccessFunction();
+    Function<M, C> getAccessFunction();
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
@@ -3,11 +3,16 @@ package org.openstreetmap.atlas.geography.atlas.items;
 import java.util.function.Function;
 
 /**
+ * An interface that generalizes enum based declarative connectivity information.
+ *
+ * @param <ME> - The current entity.
+ * @param <CONNECTED> - The connected entity.
+ *
  * @author Yazad Khambata
  */
-public interface ConnectedEntityType<ME extends AtlasEntity, RELATED>
+public interface ConnectedEntityType<ME extends AtlasEntity, CONNECTED>
 {
     String getPropertyName();
 
-    Function<ME, RELATED> getAccessFunction();
+    Function<ME, CONNECTED> getAccessFunction();
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
@@ -1,0 +1,13 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import java.util.function.Function;
+
+/**
+ * @author Yazad Khambata
+ */
+public interface ConnectedEntityType<ME extends AtlasEntity, RELATED>
+{
+    String getPropertyName();
+
+    Function<ME, RELATED> getAccessFunction();
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedEntityType.java
@@ -5,9 +5,10 @@ import java.util.function.Function;
 /**
  * An interface that generalizes enum based declarative connectivity information.
  *
- * @param <ME> - The current entity.
- * @param <CONNECTED> - The connected entity.
- *
+ * @param <ME>
+ *            - The current entity.
+ * @param <CONNECTED>
+ *            - The connected entity.
  * @author Yazad Khambata
  */
 public interface ConnectedEntityType<ME extends AtlasEntity, CONNECTED>

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedNodeType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/ConnectedNodeType.java
@@ -1,0 +1,35 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import java.util.function.Function;
+
+/**
+ * @author Yazad Khambata
+ */
+public enum ConnectedNodeType implements ConnectedEntityType<Edge, Node>
+{
+    START("startNode", Edge::start),
+
+    END("endNode", Edge::end);
+
+    private String propertyName;
+
+    private Function<Edge, Node> accessFunction;
+
+    ConnectedNodeType(final String propertyName, final Function<Edge, Node> accessFunction)
+    {
+        this.propertyName = propertyName;
+        this.accessFunction = accessFunction;
+    }
+
+    @Override
+    public String getPropertyName()
+    {
+        return this.propertyName;
+    }
+
+    @Override
+    public Function<Edge, Node> getAccessFunction()
+    {
+        return this.accessFunction;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
@@ -97,6 +98,13 @@ public abstract class Edge extends LineItem implements Comparable<Edge>
         return result;
     }
 
+    public Node connectedNode(final ConnectedNodeType connectedNodeType)
+    {
+        Validate.notNull(connectedNodeType);
+        final Node connectedNode = connectedNodeType.getAccessFunction().apply(this);
+        return connectedNode;
+    }
+
     /**
      * @return The same {@link Edge} but with the tags interpreted with this {@link Edge}'s
      *         direction. For example, if this {@link Edge} is backwards from its OSM way, and the
@@ -118,8 +126,8 @@ public abstract class Edge extends LineItem implements Comparable<Edge>
     {
         final JsonObject properties = super.getGeoJsonProperties();
 
-        properties.addProperty("startNode", start().getIdentifier());
-        properties.addProperty("endNode", end().getIdentifier());
+        properties.addProperty(ConnectedNodeType.START.getPropertyName(), start().getIdentifier());
+        properties.addProperty(ConnectedNodeType.END.getPropertyName(), end().getIdentifier());
 
         return properties;
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/EdgeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/EdgeTest.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author matthieun
  * @author mgostintsev
+ * @author Yazad Khambata
  */
 public class EdgeTest
 {
@@ -18,6 +19,19 @@ public class EdgeTest
 
     @Rule
     public final EdgeTestRule rule = new EdgeTestRule();
+
+    @Test
+    public void testConnectedNodes()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final Edge edge6 = atlas.edge(6L).directionalized();
+        Assert.assertNotNull(edge6);
+        Assert.assertNotNull(edge6.start());
+        Assert.assertNotNull(edge6.end());
+        Assert.assertNotEquals(edge6.start(), edge6.end());
+        Assert.assertEquals(edge6.start(), edge6.connectedNode(ConnectedNodeType.START));
+        Assert.assertEquals(edge6.end(), edge6.connectedNode(ConnectedNodeType.END));
+    }
 
     @Test
     public void testDirectionalizedTags()


### PR DESCRIPTION
### Description:

Declarative access to start or end Node of an Edge. The newly added enum `ConnectedNodeType` is similar to `ConnectedEdgeType` in the reverse direction (from `Edge` to `Node`). The enums are generalized using interface `ConnectedEntityType`.

### Potential Impact:

None.

### Unit Test Approach:

Unit Test added for the `ConnectedNodeType` in `Edge` class.

### Test Results:

Test successful.
