### PR TITLE
Update Validators.isOfSameType() to operate on type T

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -425,7 +425,7 @@ public class Validators
      * @return true if the tag exists in firstTaggable AND secondTaggable, AND the value of
      *         firstTaggable is equal to the value of secondTaggable.
      */
-    public static <T extends Enum<T>> boolean isOfSameType(final Taggable firstTaggable,
+    public static <T> boolean isOfSameType(final Taggable firstTaggable,
             final Taggable secondTaggable, final Class<T> type)
     {
         final String key = findTagNameIn(type);

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.LastEditTimeTag;
 import org.openstreetmap.atlas.tags.NaturalTag;
 import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.WaterTag;
@@ -133,5 +134,26 @@ public class ValidatorsHasValuesForTestCase
     {
         Assert.assertFalse(Validators.isOfSameType(new TestTaggable(WaterwayTag.CANAL),
                 new TestTaggable(WaterwayTag.CANAL), WaterTag.class));
+    }
+
+    @Test
+    public void twoNonEnumeratedTagsSameKeySameValue()
+    {
+        Assert.assertTrue(Validators.isOfSameType(new TestTaggable(LastEditTimeTag.KEY, "06June19"),
+                new TestTaggable(LastEditTimeTag.KEY, "06June19"), LastEditTimeTag.class));
+    }
+
+    @Test
+    public void twoNonEnumeratedTagsSameKeyDifferentValues()
+    {
+        Assert.assertFalse(Validators.isOfSameType(new TestTaggable(LastEditTimeTag.KEY, "01Apr19"),
+                new TestTaggable(LastEditTimeTag.KEY, "06June19"), LastEditTimeTag.class));
+    }
+
+    @Test
+    public void oneEnumeratedTagOneNonEnumeratedTag()
+    {
+        Assert.assertFalse(Validators.isOfSameType(new TestTaggable(WaterwayTag.CANAL),
+                new TestTaggable(LastEditTimeTag.KEY, "invalid"), WaterTag.class));
     }
 }


### PR DESCRIPTION
### Description:

Update Validators.isOfSameType() to operate on more general type \<T\> instead of \<T extends Enum \<T\>\>.

### Potential Impact:

No impact, since \<T\> is more general. Due to this the change allows for a wider range of use cases.

### Unit Test Approach:

Test cases verify the use of interface tags as arguments to Validators.isOfSameType() and can all be found in ValidatorsHasValuesForTestCase.java:

twoNonEnumeratedTagsSameKeySameValue()
twoNonEnumeratedTagsSameKeyDifferentValues()
oneEnumeratedTagOneNonEnumeratedTag()

### Test Results:

All tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)