### PR TITLE
Reworked antimeridian handling to allow for both -180 and 180

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -498,7 +498,6 @@ public class Location
             lambda *= -1;
         }
         return new Location(Latitude.radians(pheta), Longitude.radians(lambda));
-
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -492,8 +492,13 @@ public class Location
 
         // Normalize to -180/180
         lambda = (lambda + FACTOR_OF_3 * Math.PI) % (2 * Math.PI) - Math.PI;
-
+        if (this.getLongitude().equals(Longitude.MAXIMUM)
+                && that.getLongitude().equals(Longitude.MAXIMUM))
+        {
+            lambda *= -1;
+        }
         return new Location(Latitude.radians(pheta), Longitude.radians(lambda));
+
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
@@ -3,8 +3,7 @@ package org.openstreetmap.atlas.geography;
 import org.openstreetmap.atlas.utilities.scalars.Angle;
 
 /**
- * A Longitude between -180 degrees included and 180 degrees excluded. A Longitude of 180 degrees is
- * still accepted, but it would create the -180 degrees object.
+ * A Longitude between -180 degrees and 180 degrees included.
  *
  * @author matthieun
  * @author tony
@@ -15,12 +14,10 @@ public class Longitude extends Angle
 
     public static final Longitude MINIMUM = Longitude.dm7(MINIMUM_DM7);
     public static final Longitude ZERO = Longitude.dm7(0L);
-    public static final Longitude MAXIMUM = Longitude.dm7(MAXIMUM_DM7 - 1);
+    public static final Longitude MAXIMUM = Longitude.dm7(MAXIMUM_DM7);
     public static final Longitude ANTIMERIDIAN_WEST = Longitude.MINIMUM;
-    public static final Longitude ANTIMERIDIAN_EAST = Longitude.dm7(MAXIMUM_DM7);
+    public static final Longitude ANTIMERIDIAN_EAST = Longitude.MAXIMUM;
 
-    // This will be true when the Longitude is created with +180 degrees. The underlying angle is
-    // still -180, but any representation will return +180.
     private boolean isMaximumDm7 = false;
 
     /**
@@ -40,8 +37,6 @@ public class Longitude extends Angle
      */
     public static Longitude dm7(final long dm7)
     {
-        // Here we allow dm7 = MAXIMUM_DM7, even though Longitude stops short of that number. The
-        // value in that case will be picked up by the "assertDm7" function
         if (dm7 < MINIMUM_DM7 || dm7 > MAXIMUM_DM7)
         {
             throw new IllegalArgumentException("Cannot have a longitude of " + dm7 / DM7_PER_DEGREE
@@ -134,11 +129,10 @@ public class Longitude extends Angle
     @Override
     protected int assertDm7(final int dm7)
     {
-        if (dm7 == MAXIMUM_DM7)
+        if (dm7 < MINIMUM_DM7 || dm7 > MAXIMUM_DM7)
         {
-            // Make one exception for the antimeridian, and make it the proper allowed value.
-            return MINIMUM_DM7;
+            throw new IllegalArgumentException("Angle dm7 value " + dm7 + " is invalid.");
         }
-        return super.assertDm7(dm7);
+        return dm7;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
@@ -131,7 +131,7 @@ public class Longitude extends Angle
     {
         if (dm7 < MINIMUM_DM7 || dm7 > MAXIMUM_DM7)
         {
-            throw new IllegalArgumentException("Angle dm7 value " + dm7 + " is invalid.");
+            throw new IllegalArgumentException("Longitude dm7 value " + dm7 + " is invalid.");
         }
         return dm7;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Longitude.java
@@ -3,7 +3,7 @@ package org.openstreetmap.atlas.geography;
 import org.openstreetmap.atlas.utilities.scalars.Angle;
 
 /**
- * A Longitude between -180 degrees and 180 degrees included.
+ * A Longitude between -180 degrees and +180 degrees, inclusive.
  *
  * @author matthieun
  * @author tony

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixer.java
@@ -135,7 +135,8 @@ public class MultiAtlasOverlappingNodesFixer implements Serializable
         // Make sure that the AntiMeridian case is taken care of
         final Location masterLocation = master.getLocation();
         // This will be true for both the minimum antimeridian and the maximum
-        if (Longitude.ANTIMERIDIAN_WEST.equals(masterLocation.getLongitude()))
+        if (Longitude.ANTIMERIDIAN_WEST.equals(masterLocation.getLongitude())
+                || Longitude.ANTIMERIDIAN_EAST.equals(masterLocation.getLongitude()))
         {
             final Location antimeridianMinimum = new Location(masterLocation.getLatitude(),
                     Longitude.ANTIMERIDIAN_WEST);
@@ -152,6 +153,7 @@ public class MultiAtlasOverlappingNodesFixer implements Serializable
         for (final Rectangle bound : bounds)
         {
             others.addAll(Iterables.asSet(this.parent.nodesWithin(bound)));
+
         }
         if (others.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/multi/MultiAtlasOverlappingNodesFixer.java
@@ -153,7 +153,6 @@ public class MultiAtlasOverlappingNodesFixer implements Serializable
         for (final Rectangle bound : bounds)
         {
             others.addAll(Iterables.asSet(this.parent.nodesWithin(bound)));
-
         }
         if (others.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -13,7 +13,6 @@ import java.util.TreeSet;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.Longitude;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -41,7 +40,6 @@ import org.openstreetmap.atlas.utilities.arrays.LongArrayOfArrays;
 import org.openstreetmap.atlas.utilities.arrays.PolyLineArray;
 import org.openstreetmap.atlas.utilities.arrays.PolygonArray;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
-import org.openstreetmap.atlas.utilities.collections.MultiIterable;
 import org.openstreetmap.atlas.utilities.compression.IntegerDictionary;
 import org.openstreetmap.atlas.utilities.maps.LongToLongMap;
 import org.openstreetmap.atlas.utilities.maps.LongToLongMultiMap;
@@ -1274,24 +1272,7 @@ public final class PackedAtlas extends AbstractAtlas
 
         final Iterator<Node> nodes;
         final Rectangle bounds = location.bounds();
-
-        // Handle the anti-meridian case. +180 and -180 are identical in the Atlas, if this happens
-        // to be the Longitude of the passed in Location, make sure to also check the equivalent
-        // Location across the anti-meridian.
-        if (location.getLongitude().equals(Longitude.ANTIMERIDIAN_EAST)
-                || location.getLongitude().equals(Longitude.ANTIMERIDIAN_WEST))
-        {
-            final Location locationAcrossAntiMeridian = new Location(location.getLatitude(),
-                    Longitude.dm7(-location.getLongitude().asDm7()));
-            final Rectangle boundsAcrossAntiMeridian = locationAcrossAntiMeridian.bounds();
-
-            nodes = new MultiIterable<>(this.getNodeSpatialIndex().get(bounds),
-                    this.getNodeSpatialIndex().get(boundsAcrossAntiMeridian)).iterator();
-        }
-        else
-        {
-            nodes = this.getNodeSpatialIndex().get(bounds).iterator();
-        }
+        nodes = this.getNodeSpatialIndex().get(bounds).iterator();
 
         if (nodes.hasNext())
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -45,6 +45,20 @@ public class LocationTest extends Command
     }
 
     @Test
+    public void testAntiMeridianMidPoint()
+    {
+        final Location location1 = Location.forWkt("POINT(-180 25)");
+        final Location location2 = Location.forWkt("POINT(-180 -25)");
+        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location1.midPoint(location2));
+        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location2.midPoint(location1));
+
+        final Location location3 = Location.forWkt("POINT(180 25)");
+        final Location location4 = Location.forWkt("POINT(180 -25)");
+        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location3.midPoint(location4));
+        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location4.midPoint(location3));
+    }
+
+    @Test
     public void testCrossingAntimeridian()
     {
         final Location one = new Location(Latitude.degrees(37), Longitude.degrees(179.998));
@@ -151,20 +165,6 @@ public class LocationTest extends Command
         final Location calculatedLoxodromicMidPoint = location1.loxodromicMidPoint(location2);
         System.out.println("Calculated Loxodromic Duration: " + beginning3.elapsedSince());
         System.out.println(calculatedLoxodromicMidPoint.toString() + "\n");
-    }
-
-    @Test
-    public void testAntiMeridianMidPoint()
-    {
-        final Location location1 = Location.forWkt("POINT(-180 25)");
-        final Location location2 = Location.forWkt("POINT(-180 -25)");
-        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location1.midPoint(location2));
-        Assert.assertEquals(Location.forWkt("POINT(-180 0)"), location2.midPoint(location1));
-
-        final Location location3 = Location.forWkt("POINT(180 25)");
-        final Location location4 = Location.forWkt("POINT(180 -25)");
-        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location3.midPoint(location4));
-        Assert.assertEquals(Location.forWkt("POINT(180 0)"), location4.midPoint(location3));
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/LongitudeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LongitudeTest.java
@@ -20,23 +20,7 @@ public class LongitudeTest
         final Longitude minusOneEighty = Longitude.degrees(-180);
         Assert.assertEquals(-1_800_000_000, minusOneEighty.asDm7());
 
-        Assert.assertTrue(oneEighty.equals(minusOneEighty));
-    }
-
-    @Test
-    public void testCreation()
-    {
-        final Longitude one = Longitude.degrees(-122);
-        Assert.assertEquals(-1_220_000_000, one.asDm7());
-        try
-        {
-            Longitude.degrees(-122 - 100);
-            fail("Longitude should not have been created!");
-        }
-        catch (final Exception e)
-        {
-            return;
-        }
+        Assert.assertFalse(oneEighty.equals(minusOneEighty));
     }
 
     @Test
@@ -53,5 +37,21 @@ public class LongitudeTest
         Assert.assertTrue(oneEighty.isLessThanOrEqualTo(oneEighty));
         Assert.assertTrue(oneEighty.isGreaterThan(ninety));
         Assert.assertTrue(ninety.isLessThanOrEqualTo(oneEighty));
+    }
+
+    @Test
+    public void testCreation()
+    {
+        final Longitude one = Longitude.degrees(-122);
+        Assert.assertEquals(-1_220_000_000, one.asDm7());
+        try
+        {
+            Longitude.degrees(-122 - 100);
+            fail("Longitude should not have been created!");
+        }
+        catch (final Exception e)
+        {
+            return;
+        }
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/PolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolyLineTest.java
@@ -23,6 +23,21 @@ public class PolyLineTest
     private static final Logger logger = LoggerFactory.getLogger(PolyLineTest.class);
 
     @Test
+    public void testAntimeridianHandling()
+    {
+        final PolyLine antimeridianWest = new PolyLine(
+                new Location(Latitude.degrees(40), Longitude.ANTIMERIDIAN_WEST),
+                new Location(Latitude.degrees(41), Longitude.ANTIMERIDIAN_WEST));
+        final PolyLine antimeridianEast = new PolyLine(
+                new Location(Latitude.degrees(40), Longitude.ANTIMERIDIAN_EAST),
+                new Location(Latitude.degrees(41), Longitude.ANTIMERIDIAN_EAST));
+
+        Assert.assertTrue(antimeridianWest.intersections(antimeridianEast).isEmpty());
+        Assert.assertTrue(antimeridianEast.length().equals(antimeridianWest.length()));
+        Assert.assertTrue(antimeridianEast.length().isLessThan(Distance.miles(100)));
+    }
+
+    @Test
     public void testAppend()
     {
         final PolyLine line = new PolyLine(Location.CROSSING_85_280, Location.TEST_1);
@@ -30,6 +45,16 @@ public class PolyLineTest
         final PolyLine appended = line.append(line2);
         Assert.assertTrue(appended.equalsShape(
                 new PolyLine(Location.CROSSING_85_280, Location.TEST_1, Location.TEST_7)));
+    }
+
+    @Test
+    public void testAsGeoJsonGeometry()
+    {
+        final PolyLine polyLine = PolyLine.wkt(
+                "LINESTRING (-75.616330 40.194570, -75.616330 40.194570, -75.616330 40.194570, -75.616340 40.194580, -75.616340 40.194590)");
+        final String geoJson = "{\"type\":\"LineString\",\"coordinates\":[[-75.61633,40.19457],[-75.61633,40.19457],[-75.61633,40.19457],[-75.61634,40.19458],[-75.61634,40.19459]]}";
+        final JsonObject geometry = polyLine.asGeoJsonGeometry();
+        Assert.assertEquals(geoJson, geometry.toString());
     }
 
     @Test
@@ -311,16 +336,6 @@ public class PolyLineTest
                 polyLine3.withoutDuplicateConsecutiveShapePoints().toWkt());
         Assert.assertEquals(polyLine5.toWkt(),
                 polyLine4.withoutDuplicateConsecutiveShapePoints().toWkt());
-    }
-
-    @Test
-    public void testAsGeoJsonGeometry()
-    {
-        final PolyLine polyLine = PolyLine.wkt(
-                "LINESTRING (-75.616330 40.194570, -75.616330 40.194570, -75.616330 40.194570, -75.616340 40.194580, -75.616340 40.194590)");
-        final String geoJson = "{\"type\":\"LineString\",\"coordinates\":[[-75.61633,40.19457],[-75.61633,40.19457],[-75.61633,40.19457],[-75.61634,40.19458],[-75.61634,40.19459]]}";
-        final JsonObject geometry = polyLine.asGeoJsonGeometry();
-        Assert.assertEquals(geoJson, geometry.toString());
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -66,6 +66,37 @@ public class PolygonTest
     }
 
     @Test
+    public void testAntimeridian()
+    {
+        final Polygon antimeridianWest = new Polygon(Location.forString("47.6778433, -180"),
+                Location.forString("47.6779773, -180"), Location.forString("47.6776721, -180"),
+                Location.forString("47.6775366, -179.9"), Location.forString("47.6776969, -179.9"),
+                Location.forString("47.6778433, -179.9"));
+
+        final Polygon antimeridianEast = new Polygon(Location.forString("47.6778433, 180"),
+                Location.forString("47.6779773, 180"), Location.forString("47.6776721, 180"),
+                Location.forString("47.6775366, 179.9"), Location.forString("47.6776969, 179.9"),
+                Location.forString("47.6778433, 179.9"));
+
+        Assert.assertFalse(antimeridianWest.intersects(antimeridianEast));
+
+    }
+
+    @Test
+    public void testAsGeoJsonGeometry()
+    {
+        final Polygon tennisCourt = new Polygon(Location.forString("47.6778433, -122.2012807"),
+                Location.forString("47.6779773, -122.2008187"),
+                Location.forString("47.6776721, -122.2006229"),
+                Location.forString("47.6775366, -122.2010923"),
+                Location.forString("47.6776969, -122.2011787"),
+                Location.forString("47.6778433, -122.2012807"));
+        final String geoJson = "{\"type\":\"Polygon\",\"coordinates\":[[[-122.2012807,47.6778433],[-122.2008187,47.6779773],[-122.2006229,47.6776721],[-122.2010923,47.6775366],[-122.2011787,47.6776969],[-122.2012807,47.6778433]]]}";
+        final JsonObject geometry = tennisCourt.asGeoJsonGeometry();
+        Assert.assertEquals(geoJson, geometry.toString());
+    }
+
+    @Test
     public void testCenter()
     {
         // test for rectangle
@@ -106,6 +137,19 @@ public class PolygonTest
         polygon = Polygon.wkt(polygonWkt);
         Assert.assertTrue(polygon.isClockwise());
         Assert.assertFalse(polygon.reversed().isClockwise());
+    }
+
+    @Test
+    public void testClosedLoop()
+    {
+        final Polygon polygon = Polygon.SILICON_VALLEY;
+        final Polygon initialClosedLoop = new Polygon(polygon.closedLoop());
+        Assert.assertNotEquals(
+                "Last and Last - 1 locations for the polygon should not be duplicate.",
+                initialClosedLoop.last(), initialClosedLoop.get(initialClosedLoop.size() - 2));
+        final Polygon doubleClosedLoop = new Polygon(initialClosedLoop.closedLoop());
+        Assert.assertNotEquals("Last and Last - 1 locations for polygon should not be duplicate.",
+                doubleClosedLoop.last(), doubleClosedLoop.get(doubleClosedLoop.size() - 2));
     }
 
     @Test
@@ -746,6 +790,15 @@ public class PolygonTest
     }
 
     @Test
+    public void testToWkb()
+    {
+        final Polygon polygon = Polygon.wkt(
+                "POLYGON((-22.5092778 65.0717446,-22.5092214 65.0717039,-22.5091195 65.0716869,-22.509031 65.0716847,-22.5089264 65.071705,-22.5088164 65.0717638,-22.5085884 65.0717785,-22.508449 65.0717593,-22.5082612 65.0717378,-22.5079903 65.0717367,-22.5078401 65.0717333,-22.5074565 65.0717875,-22.5072849 65.0718531,-22.5071454 65.0719017,-22.5070113 65.07193,-22.5069094 65.0719797,-22.5067806 65.0720103,-22.5066465 65.0720487,-22.5065419 65.0720894,-22.5065741 65.0721583,-22.506676 65.0721697,-22.5068691 65.0722341,-22.5071883 65.0722488,-22.5075585 65.0722307,-22.5078964 65.0721923,-22.5081754 65.0721493,-22.508508 65.0720905,-22.5088862 65.0720091,-22.509023 65.0719277,-22.5091329 65.0719029,-22.5091544 65.0718644,-22.5091705 65.0718102,-22.5092214 65.0717751,-22.5092778 65.0717446))");
+        final String validPolygonWkb = "00000000030000000100000022C036826007A7942E4050449776A9AA89C036825C556B6C6040504496CBF45FB9C0368255A7D241814050449684A6C34EC036824FDB09A672405044967B6C87E9C03682490024122E40504496D0917D6BC0368241CAA5AB2040504497C7318259C0368232D9711FFE4050449804D98394C0368229B6B2AF1440504497B451ABC4C036821D67EFD362405044975A2438C4C036820BA6FD2F6B4050449755871B12C0368201CF0D18ED4050449747446230C03681E8AB4FA483405044982A9930BEC03681DD6C57412F405044993DBEA770C03681D447EB511C4050449A099681B7C03681CB7E1833D34050449A8049667BC03681C4D07F08F54050449B50BE5E75C03681BC5F973F4C4050449BD116DE69C03681B395C422034050449C72268E09C03681ACBADE8DBF4050449D1CDBD8D9C03681AED718802A4050449E3DD8A8A3C03681B584B1AB084050449E6DA950C7C03681C22C5FDA5B4050449F7BC649FCC03681D717A969F14050449FB96E4B37C03681EF5A964E8B4050449F6D83911AC03682057F9BC1924050449ECC73E179C0368217C873A1B84050449E1818FB7AC036822D948DC11E4050449D2178F68CC03682465DB262BE4050449BCC0E60ECC036824F54D1E96C4050449A76A3CB4CC036825688A2D1514050449A0E9EFF34C0368257F1589D50405044996D23EFC9C0368258FF7596854050449889CF213BC036825C556B6C6040504497F696CAB2C036826007A7942E4050449776A9AA89";
+        Assert.assertEquals(validPolygonWkb, WKBWriter.toHex(polygon.toWkb()));
+    }
+
+    @Test
     public void testTriangulate()
     {
         final Polygon polygon = Polygon.SILICON_VALLEY_2;
@@ -755,41 +808,5 @@ public class PolygonTest
         {
             Assert.assertEquals(3, triangle.size());
         }
-    }
-
-    @Test
-    public void testClosedLoop()
-    {
-        final Polygon polygon = Polygon.SILICON_VALLEY;
-        final Polygon initialClosedLoop = new Polygon(polygon.closedLoop());
-        Assert.assertNotEquals(
-                "Last and Last - 1 locations for the polygon should not be duplicate.",
-                initialClosedLoop.last(), initialClosedLoop.get(initialClosedLoop.size() - 2));
-        final Polygon doubleClosedLoop = new Polygon(initialClosedLoop.closedLoop());
-        Assert.assertNotEquals("Last and Last - 1 locations for polygon should not be duplicate.",
-                doubleClosedLoop.last(), doubleClosedLoop.get(doubleClosedLoop.size() - 2));
-    }
-
-    @Test
-    public void testAsGeoJsonGeometry()
-    {
-        final Polygon tennisCourt = new Polygon(Location.forString("47.6778433, -122.2012807"),
-                Location.forString("47.6779773, -122.2008187"),
-                Location.forString("47.6776721, -122.2006229"),
-                Location.forString("47.6775366, -122.2010923"),
-                Location.forString("47.6776969, -122.2011787"),
-                Location.forString("47.6778433, -122.2012807"));
-        final String geoJson = "{\"type\":\"Polygon\",\"coordinates\":[[[-122.2012807,47.6778433],[-122.2008187,47.6779773],[-122.2006229,47.6776721],[-122.2010923,47.6775366],[-122.2011787,47.6776969],[-122.2012807,47.6778433]]]}";
-        final JsonObject geometry = tennisCourt.asGeoJsonGeometry();
-        Assert.assertEquals(geoJson, geometry.toString());
-    }
-
-    @Test
-    public void testToWkb()
-    {
-        final Polygon polygon = Polygon.wkt(
-                "POLYGON((-22.5092778 65.0717446,-22.5092214 65.0717039,-22.5091195 65.0716869,-22.509031 65.0716847,-22.5089264 65.071705,-22.5088164 65.0717638,-22.5085884 65.0717785,-22.508449 65.0717593,-22.5082612 65.0717378,-22.5079903 65.0717367,-22.5078401 65.0717333,-22.5074565 65.0717875,-22.5072849 65.0718531,-22.5071454 65.0719017,-22.5070113 65.07193,-22.5069094 65.0719797,-22.5067806 65.0720103,-22.5066465 65.0720487,-22.5065419 65.0720894,-22.5065741 65.0721583,-22.506676 65.0721697,-22.5068691 65.0722341,-22.5071883 65.0722488,-22.5075585 65.0722307,-22.5078964 65.0721923,-22.5081754 65.0721493,-22.508508 65.0720905,-22.5088862 65.0720091,-22.509023 65.0719277,-22.5091329 65.0719029,-22.5091544 65.0718644,-22.5091705 65.0718102,-22.5092214 65.0717751,-22.5092778 65.0717446))");
-        final String validPolygonWkb = "00000000030000000100000022C036826007A7942E4050449776A9AA89C036825C556B6C6040504496CBF45FB9C0368255A7D241814050449684A6C34EC036824FDB09A672405044967B6C87E9C03682490024122E40504496D0917D6BC0368241CAA5AB2040504497C7318259C0368232D9711FFE4050449804D98394C0368229B6B2AF1440504497B451ABC4C036821D67EFD362405044975A2438C4C036820BA6FD2F6B4050449755871B12C0368201CF0D18ED4050449747446230C03681E8AB4FA483405044982A9930BEC03681DD6C57412F405044993DBEA770C03681D447EB511C4050449A099681B7C03681CB7E1833D34050449A8049667BC03681C4D07F08F54050449B50BE5E75C03681BC5F973F4C4050449BD116DE69C03681B395C422034050449C72268E09C03681ACBADE8DBF4050449D1CDBD8D9C03681AED718802A4050449E3DD8A8A3C03681B584B1AB084050449E6DA950C7C03681C22C5FDA5B4050449F7BC649FCC03681D717A969F14050449FB96E4B37C03681EF5A964E8B4050449F6D83911AC03682057F9BC1924050449ECC73E179C0368217C873A1B84050449E1818FB7AC036822D948DC11E4050449D2178F68CC03682465DB262BE4050449BCC0E60ECC036824F54D1E96C4050449A76A3CB4CC036825688A2D1514050449A0E9EFF34C0368257F1589D50405044996D23EFC9C0368258FF7596854050449889CF213BC036825C556B6C6040504497F696CAB2C036826007A7942E4050449776A9AA89";
-        Assert.assertEquals(validPolygonWkb, WKBWriter.toHex(polygon.toWkb()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/SegmentTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/SegmentTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * @author matthieun
@@ -13,6 +14,21 @@ public class SegmentTest
             .wkt("LINESTRING (112.9699474 -84.7999528, 112.9699948 -84.7999669)").segments().get(0);
     private static Segment SEGMENT_SAME_END_2 = PolyLine
             .wkt("LINESTRING (112.9650809 -84.7999622, 112.9699948 -84.7999669)").segments().get(0);
+
+    @Test
+    public void testAntimeridianNoIntersection()
+    {
+        final Segment antimeridianWest = new Segment(
+                new Location(Latitude.degrees(40), Longitude.ANTIMERIDIAN_WEST),
+                new Location(Latitude.degrees(41), Longitude.ANTIMERIDIAN_WEST));
+
+        final Segment antimeridianEast = new Segment(
+                new Location(Latitude.degrees(40), Longitude.ANTIMERIDIAN_EAST),
+                new Location(Latitude.degrees(41), Longitude.ANTIMERIDIAN_EAST));
+        Assert.assertNull(antimeridianEast.intersection(antimeridianWest));
+        Assert.assertTrue(antimeridianEast.length().equals(antimeridianWest.length()));
+        Assert.assertTrue(antimeridianEast.length().isLessThan(Distance.miles(100)));
+    }
 
     @Test
     public void testIntersection()
@@ -31,17 +47,6 @@ public class SegmentTest
     }
 
     @Test
-    public void testIntersectionWithSameEnd()
-    {
-        Assert.assertTrue("Same start is broken.",
-                SEGMENT_SAME_END_1.reversed().intersects(SEGMENT_SAME_END_2.reversed()));
-        Assert.assertTrue("Same start is broken.",
-                SEGMENT_SAME_END_2.reversed().intersects(SEGMENT_SAME_END_1.reversed()));
-        Assert.assertTrue("Same End is broken", SEGMENT_SAME_END_1.intersects(SEGMENT_SAME_END_2));
-        Assert.assertTrue("Same End is broken", SEGMENT_SAME_END_2.intersects(SEGMENT_SAME_END_1));
-    }
-
-    @Test
     public void testIntersectionOverflow()
     {
         final Segment maxXandYMovement = new Segment(
@@ -54,5 +59,16 @@ public class SegmentTest
         Assert.assertTrue("Overflow issue", maxXandYMovement.intersects(maxXandNegativeYMovement));
         Assert.assertTrue("Overflow issue", maxXandNegativeYMovement.intersects(maxXandYMovement));
 
+    }
+
+    @Test
+    public void testIntersectionWithSameEnd()
+    {
+        Assert.assertTrue("Same start is broken.",
+                SEGMENT_SAME_END_1.reversed().intersects(SEGMENT_SAME_END_2.reversed()));
+        Assert.assertTrue("Same start is broken.",
+                SEGMENT_SAME_END_2.reversed().intersects(SEGMENT_SAME_END_1.reversed()));
+        Assert.assertTrue("Same End is broken", SEGMENT_SAME_END_1.intersects(SEGMENT_SAME_END_2));
+        Assert.assertTrue("Same End is broken", SEGMENT_SAME_END_2.intersects(SEGMENT_SAME_END_1));
     }
 }


### PR DESCRIPTION
### Description:
This PR reworks antemeridian handling to allow for locations at both -180 and 180 longitude. Previously, the maximum longitude was 179.99999, with any values at 180 mapping back to -180. Now, entities with longitudes of 180 will *not* be mapped to -180, allowing for true representations of both the antimeridian east and antemeridian west. In order to maintain connectivity of the edge network across the antemeridian, MultiAtlas will still treat nodes at either -180 or 180 as having equivalent longitude and follow the same behavior as other overlapping nodes to merge the two together and create a connected network. It is worth noting, however, that this behavior lies in MultiAtlas-- should an Atlas be directly built with data from both sides of the antimeridian, the original data will be preserved as-is and not be treated as overlapped nodes.

Screenshots of the antimeridians in Fiji:
<img width="1173" alt="Screen Shot 2019-06-10 at 1 04 32 PM" src="https://user-images.githubusercontent.com/1475347/59225261-19b95b80-8b85-11e9-9769-8027045d9f15.png">
<img width="1211" alt="Screen Shot 2019-06-10 at 12 54 21 PM" src="https://user-images.githubusercontent.com/1475347/59225267-1d4ce280-8b85-11e9-8572-d877413b0769.png">

### Potential Impact:
Possible, but should be minimally impactful in a negative way as MultiAtlas behavior should remain the same across the antimeridian. 

### Unit Test Approach:
N/A -- existing tests covered behavior.

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)