### PR TITLE
Fixed a bug where some FeatureChange merges were too collision-strict

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -476,7 +476,7 @@ public class FeatureChange implements Located, Serializable
             throw new CoreException("Cannot merge two feature changes {} and {}.", this, other,
                     exception);
         }
-        FeatureChangeMergingHelpers.mergedMetaData(this, other).forEach(result::addMetaData);
+        FeatureChangeMergingHelpers.mergeMetaData(this, other).forEach(result::addMetaData);
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -709,8 +709,9 @@ public final class FeatureChangeMergingHelpers
                 .withMemberName("allKnownOsmMembers").withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
-                .withMemberExtractor(entity -> ((Relation) entity).allKnownOsmMembers() == null
-                        ? null : ((Relation) entity).allKnownOsmMembers().asBean())
+                .withMemberExtractor(
+                        entity -> ((Relation) entity).allKnownOsmMembers() == null ? null
+                                : ((Relation) entity).allKnownOsmMembers().asBean())
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleRelationBeanMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedRelationBeanMerger)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -126,7 +126,7 @@ public final class FeatureChangeMergingHelpers
      *            The right {@link FeatureChange}
      * @return The concatenated meta-data map
      */
-    public static Map<String, String> mergedMetaData(final FeatureChange left,
+    public static Map<String, String> mergeMetaData(final FeatureChange left,
             final FeatureChange right)
     {
         final Map<String, String> result = new HashMap<>();
@@ -709,9 +709,8 @@ public final class FeatureChangeMergingHelpers
                 .withMemberName("allKnownOsmMembers").withBeforeEntityLeft(beforeEntityLeft)
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
-                .withMemberExtractor(
-                        entity -> ((Relation) entity).allKnownOsmMembers() == null ? null
-                                : ((Relation) entity).allKnownOsmMembers().asBean())
+                .withMemberExtractor(entity -> ((Relation) entity).allKnownOsmMembers() == null
+                        ? null : ((Relation) entity).allKnownOsmMembers().asBean())
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleRelationBeanMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedRelationBeanMerger)


### PR DESCRIPTION
### Description:
When merging `Node` in/out `Edge` identifier sets, in the case that no beforeView was present, we were previously failing on identifier collisions. This is incorrect behavior, since the sets are key-only and so no conflict can ever arise. For instance, you may want to merge two in `Edge` identifier sets that look like `[123, 789]` and `[123, 456]`. In this case, the result should be `[123, 456, 789]`.

We also apply this logic to merging the `allRelationsWithSameOsmIdentifier` field.

### Potential Impact:
This may fix buggy downstream behavior.

### Unit Test Approach:
Same tests.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)