### PR TITLE
Slicing fix and raw atlas ingest update

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/pbf/OsmPbfIngestIntegrationTest.java
@@ -47,7 +47,7 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
                 .boxAround(Distance.meters(300));
         final Atlas atlas = loadBahamas(bound);
 
-        Assert.assertEquals(24, atlas.numberOfAreas());
+        Assert.assertEquals(25, atlas.numberOfAreas());
         Assert.assertEquals(11, atlas.numberOfLines());
 
         final Area smallArea = atlas.area(522592143000000L);
@@ -78,7 +78,7 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
         final Rectangle bound = Location.forString("25.0693383, -77.3160218")
                 .boxAround(Distance.feet(1));
         final Atlas atlas = loadBahamas(bound);
-        Assert.assertEquals(6, atlas.numberOfEdges());
+        Assert.assertEquals(80, atlas.numberOfEdges());
 
         final Edge edgeForward = atlas.edge(63423376000000L);
         Assert.assertEquals(63423376000000L, edgeForward.getIdentifier());
@@ -132,8 +132,8 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
         final Rectangle bound = Location.forString("25.0735519,-77.3073068")
                 .boxAround(Distance.inches(1));
         final Atlas atlas = loadBahamas(bound);
-        Assert.assertEquals(1, atlas.numberOfPoints());
-        final Point point = atlas.points().iterator().next();
+        Assert.assertEquals(39, atlas.numberOfPoints());
+        final Point point = atlas.point(5665510971000000L);
 
         Assert.assertEquals(5665510971000000L, point.getIdentifier());
         Assert.assertEquals("POINT (-77.3073068 25.0735519)", point.getLocation().toString());
@@ -155,8 +155,8 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
         final Atlas smallAtlas = loadBahamas(polygon);
 
         Assert.assertTrue(bigAtlas.numberOfEdges() > smallAtlas.numberOfEdges());
-        Assert.assertEquals(40, smallAtlas.numberOfEdges());
-        Assert.assertEquals(7, smallAtlas.numberOfAreas());
+        Assert.assertEquals(126, smallAtlas.numberOfEdges());
+        Assert.assertEquals(10, smallAtlas.numberOfAreas());
     }
 
     @Test
@@ -168,7 +168,7 @@ public class OsmPbfIngestIntegrationTest extends AtlasIntegrationTest
 
         final Map<Long, Relation> relations = new HashMap<>();
         atlas.relations().forEach(relation -> relations.put(relation.getIdentifier(), relation));
-        Assert.assertEquals(3, relations.size());
+        Assert.assertEquals(6, relations.size());
 
         final Relation relation1 = relations.get(4309052000000L);
         Assert.assertEquals("restriction", relation1.getTags().get("type"));

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -215,7 +215,7 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(0, ivoryCoast.numberOfNodes());
         Assert.assertEquals(0, ivoryCoast.numberOfEdges());
         Assert.assertEquals(0, ivoryCoast.numberOfAreas());
-        Assert.assertEquals(34960, ivoryCoast.numberOfPoints());
+        Assert.assertEquals(37911, ivoryCoast.numberOfPoints());
         Assert.assertEquals(3637, ivoryCoast.numberOfLines());
         Assert.assertEquals(12, ivoryCoast.numberOfRelations());
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfCounter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfCounter.java
@@ -73,7 +73,7 @@ public class OsmPbfCounter implements Sink
 
     // Keep track of included nodes so that they can be used in calculating if a way intersects the
     // given shard
-    private final Map<Long, Location> nodeIdToLocation = new HashMap<>();
+    private final Map<Long, Location> nodeIdentifierToLocation = new HashMap<>();
 
     // Keep track of excluded ways to see if we need to add them later
     private final Map<Long, Way> waysToExclude = new HashMap<>();
@@ -150,9 +150,9 @@ public class OsmPbfCounter implements Sink
             if (rawEntity instanceof Node)
             {
                 final Node node = (Node) rawEntity;
-                final String nodeLatLon = node.getLatitude() + "," + node.getLongitude();
-                final Location nodeLocation = Location.forString(nodeLatLon);
-                this.nodeIdToLocation.put(rawEntity.getId(), nodeLocation);
+                final Location nodeLocation = new Location(Latitude.degrees(node.getLatitude()),
+                        Longitude.degrees(node.getLongitude()));
+                this.nodeIdentifierToLocation.put(rawEntity.getId(), nodeLocation);
             }
             if (shouldLoadOsmNode(rawEntity))
             {
@@ -407,7 +407,7 @@ public class OsmPbfCounter implements Sink
         for (final WayNode node : way.getWayNodes())
         {
             // nodes are processed first so allNodes will contain all node locations
-            wayNodesLocations.add(this.nodeIdToLocation.get(node.getNodeId()));
+            wayNodesLocations.add(this.nodeIdentifierToLocation.get(node.getNodeId()));
             if (this.nodeIdentifiersToInclude.contains(node.getNodeId()))
             {
                 this.wayIdentifiersToInclude.add(way.getId());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfCounter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfCounter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Latitude;
@@ -402,7 +403,7 @@ public class OsmPbfCounter implements Sink
     {
         // CASE 1: Line crosses (or is enclosed by) the shard bounds and has at least one shapepoint
         // within the shard bounds
-        final ArrayList<Location> wayNodesLocations = new ArrayList<>();
+        ArrayList<Location> wayNodesLocations = new ArrayList<>();
         for (final WayNode node : way.getWayNodes())
         {
             // nodes are processed first so allNodes will contain all node locations
@@ -416,7 +417,8 @@ public class OsmPbfCounter implements Sink
 
         // CASE 2: Line crossed the shard but has no shapepoints within it, so we must check for
         // intersections
-        wayNodesLocations.stream().filter(node -> node != null);
+        wayNodesLocations = wayNodesLocations.stream().filter(node -> node != null)
+                .collect(Collectors.toCollection(ArrayList::new));
         if (wayNodesLocations.isEmpty())
         {
             return false;

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -278,21 +278,17 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         {
             for (final Geometry slice : mergedSlices.get(countryCode))
             {
+                final long lineSliceIdentifier = lineIdentifierFactory.nextIdentifier();
+                final List<Long> newLineShapePoints = processSlice(slice, pointIdentifierFactory,
+                        line);
                 // Check if the slice is within the working bound and mark all points for this
                 // slice for removal if so
                 if (isOutsideWorkingBound(slice))
                 {
-                    // increment the identifier factory, but don't bother slicing the line
-                    // this guarantees deterministic id assignment regardless of which countries
-                    // are being sliced
-                    lineIdentifierFactory.nextIdentifier();
                     removeShapePointsFromFilteredSliced(slice);
                 }
                 else
                 {
-                    final long lineSliceIdentifier = lineIdentifierFactory.nextIdentifier();
-                    final List<Long> newLineShapePoints = processSlice(slice,
-                            pointIdentifierFactory, line);
                     // Extract relevant tag values for this slice
                     final Map<String, String> lineTags = createLineTags(slice, line.getTags());
                     createdLines.add(

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -416,16 +416,26 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
 
                 // filter out all AtlasEntities that are not in the list of countries being sliced
                 // for this shard
-                final Atlas countrySubAtlas = atlas.subAtlas(isInCountry, AtlasCutType.SILK_CUT)
-                        .orElseThrow(() -> new CoreException(
-                                "Cannot have an empty atlas after relation slicing {}",
-                                getShardOrAtlasName()));
-
-                // then, filter out all remaining entities based on the shard bounds
-                return countrySubAtlas.subAtlas(this.initialShard.bounds(), AtlasCutType.SILK_CUT)
-                        .orElseThrow(() -> new CoreException(
-                                "Cannot have an empty atlas after relation slicing {}",
-                                getShardOrAtlasName()));
+                final Optional<Atlas> countrySubAtlas = atlas.subAtlas(isInCountry,
+                        AtlasCutType.SILK_CUT);
+                if (countrySubAtlas.isPresent())
+                {
+                    // then, filter out all remaining entities based on the shard bounds
+                    final Optional<Atlas> finalSubAtlas = countrySubAtlas.get()
+                            .subAtlas(this.initialShard.bounds(), AtlasCutType.SILK_CUT);
+                    if (finalSubAtlas.isPresent())
+                    {
+                        return finalSubAtlas.get();
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    return null;
+                }
             }
             else
             {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/ChangeSetHandler.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/changeset/ChangeSetHandler.java
@@ -46,12 +46,15 @@ public abstract class ChangeSetHandler
     protected String atlasStatistics(final Atlas atlas)
     {
         final StringBuilder builder = new StringBuilder();
-        builder.append("Points: ");
-        builder.append(atlas.numberOfPoints());
-        builder.append(" Lines: ");
-        builder.append(atlas.numberOfLines());
-        builder.append(" Relations: ");
-        builder.append(atlas.numberOfRelations());
+        if (atlas != null)
+        {
+            builder.append("Points: ");
+            builder.append(atlas.numberOfPoints());
+            builder.append(" Lines: ");
+            builder.append(atlas.numberOfLines());
+            builder.append(" Relations: ");
+            builder.append(atlas.numberOfRelations());
+        }
         return builder.toString();
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
@@ -58,8 +58,9 @@ public class CountryToShardListing extends Command
         try (SafeBufferedWriter writer = output.writer())
         {
             CountryShardListing.countryToShardList(countries, boundaries, sharding)
-                    .forEach((country, shardSet) -> shardSet.forEach(shard -> writer
-                            .writeLine(new CountryShard(country, shard).toString())));
+                    .forEach((country, shardSet) -> shardSet.forEach(
+                            shard -> writer.writeLine(new CountryShard(country, shard).toString()
+                                    + " " + new CountryShard(country, shard).bounds())));
         }
         catch (final Exception e)
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
@@ -163,8 +163,8 @@ public class RawAtlasGeneratorTest
 
         // Verify Atlas Entities
         assertBasicRawAtlasPrinciples(atlas);
-        Assert.assertEquals(3346, atlas.numberOfPoints());
-        Assert.assertEquals(29, atlas.numberOfLines());
+        Assert.assertEquals(3851, atlas.numberOfPoints());
+        Assert.assertEquals(36, atlas.numberOfLines());
         Assert.assertEquals(1, atlas.numberOfRelations());
     }
 


### PR DESCRIPTION
### Description:

This PR fixes an issue in country slicing that was causing two different nodes to be assigned the same identifier. The issue was that nodes of segments of a line that fell outside a given country boundary were not processed in the same way as other lines, meaning that there were collisions in the point identifier space.

This PR also adds additional logic to the raw atlas ingest. Previously, only lines that had shape points within a given shard bounds were included in the raw atlas. However, this meant that long lines with great stretches between shape points might cross a shard boundary, but not have any nodes fall within the boundary. These lines were therefore filtered out in the process of creating the raw atlas, leaving holes in some entities when stitching atlases together.

Unit tests were updated in this PR because the number of points and lines ingested to the raw atlas increased. The country slicing fix involved processing the nodes of lines beyond the country boundary, meaning that each atlas now includes more total points than before. Also, the raw atlas ingest update now includes extra lines that were filtered out before, increasing the line and point count further.

### Potential Impact:

Raw atlases will now include more shape points and lines.

### Unit Test Approach:

Existing unit tests were updated.

### Test Results:

Updated tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)