### PR TITLE
Checkstyle RequireThis changed and update was missed

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -111,6 +111,7 @@
 		<module name="ParameterAssignment"/>
 		<module name="RequireThis">
     		<property name="checkMethods" value="false"/>
+			<property name="validateOnlyOverlapping" value="false"/>
 		</module>
 		<module name="SimplifyBooleanExpression" />
 		<module name="SimplifyBooleanReturn" />

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaGeoJsonIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaGeoJsonIntegrationTest.java
@@ -23,40 +23,6 @@ public class AtlasDeltaGeoJsonIntegrationTest
     private Atlas after;
     private AtlasDelta delta;
 
-    @Before
-    public void readAtlases()
-    {
-        before = new TextAtlasBuilder()
-                .read(new InputStreamResource(() -> AtlasDeltaIntegrationTest.class
-                        .getResourceAsStream("DMA_9-168-233-base.txt.gz"))
-                                .withDecompressor(Decompressor.GZIP)
-                                .withName("DMA_9-168-233-base.txt.gz"));
-        after = new TextAtlasBuilder()
-                .read(new InputStreamResource(() -> AtlasDeltaIntegrationTest.class
-                        .getResourceAsStream("DMA_9-168-233-alter.txt.gz"))
-                                .withDecompressor(Decompressor.GZIP)
-                                .withName("DMA_9-168-233-alter.txt.gz"));
-        delta = new AtlasDelta(before, after, false).generate();
-    }
-
-    /**
-     * This is a basic test that should start failing if you change what the delta GeoJSON looks
-     * like.
-     */
-    @Test
-    public void testGeoJson()
-    {
-        final String geoJson = delta.toGeoJson();
-        Assert.assertEquals(22424431, geoJson.length());
-    }
-
-    @Test
-    public void testRelationsGeoJson()
-    {
-        final String relationsGeoJson = delta.toRelationsGeoJson();
-        Assert.assertEquals(454484, relationsGeoJson.length());
-    }
-
     /**
      * Tries parsing the GeoJSON string. We then check a few things about it, such as if it has the
      * applicable diff properties. Also, we count the number of features.
@@ -64,7 +30,7 @@ public class AtlasDeltaGeoJsonIntegrationTest
     @Test
     public void parseGeoJson()
     {
-        final String geoJsonStr = delta.toGeoJson();
+        final String geoJsonStr = this.delta.toGeoJson();
 
         final JsonObject geoJson = new JsonParser().parse(geoJsonStr).getAsJsonObject();
         final JsonArray features = geoJson.getAsJsonArray("features");
@@ -92,5 +58,39 @@ public class AtlasDeltaGeoJsonIntegrationTest
         }
 
         Assert.assertEquals(47646, idx);
+    }
+
+    @Before
+    public void readAtlases()
+    {
+        this.before = new TextAtlasBuilder()
+                .read(new InputStreamResource(() -> AtlasDeltaIntegrationTest.class
+                        .getResourceAsStream("DMA_9-168-233-base.txt.gz"))
+                                .withDecompressor(Decompressor.GZIP)
+                                .withName("DMA_9-168-233-base.txt.gz"));
+        this.after = new TextAtlasBuilder()
+                .read(new InputStreamResource(() -> AtlasDeltaIntegrationTest.class
+                        .getResourceAsStream("DMA_9-168-233-alter.txt.gz"))
+                                .withDecompressor(Decompressor.GZIP)
+                                .withName("DMA_9-168-233-alter.txt.gz"));
+        this.delta = new AtlasDelta(this.before, this.after, false).generate();
+    }
+
+    /**
+     * This is a basic test that should start failing if you change what the delta GeoJSON looks
+     * like.
+     */
+    @Test
+    public void testGeoJson()
+    {
+        final String geoJson = this.delta.toGeoJson();
+        Assert.assertEquals(22424431, geoJson.length());
+    }
+
+    @Test
+    public void testRelationsGeoJson()
+    {
+        final String relationsGeoJson = this.delta.toRelationsGeoJson();
+        Assert.assertEquals(454484, relationsGeoJson.length());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/event/EntityChangeEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/event/EntityChangeEvent.java
@@ -15,9 +15,9 @@ public abstract class EntityChangeEvent implements Serializable
 {
     private static final long serialVersionUID = -9159065869173338344L;
 
-    private CompleteItemType completeItemType;
-    private long identifier;
-    private Optional<Object> newValue;
+    private final CompleteItemType completeItemType;
+    private final long identifier;
+    private final Optional<Object> newValue;
 
     public EntityChangeEvent(final CompleteItemType completeItemType, final long identifier)
     {
@@ -35,16 +35,16 @@ public abstract class EntityChangeEvent implements Serializable
 
     public CompleteItemType getCompleteItemType()
     {
-        return completeItemType;
+        return this.completeItemType;
     }
 
     public long getIdentifier()
     {
-        return identifier;
+        return this.identifier;
     }
 
     public Optional<Object> getNewValue()
     {
-        return newValue;
+        return this.newValue;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/event/TagChangeEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/event/TagChangeEvent.java
@@ -18,20 +18,20 @@ public class TagChangeEvent extends EntityChangeEvent
 {
     private static final long serialVersionUID = -3108915161471760840L;
 
-    private FieldChangeOperation fieldOperation;
-
-    protected TagChangeEvent(final CompleteItemType completeItemType, final long identifier,
-            final Optional<Object> newValue, final FieldChangeOperation fieldOperation)
-    {
-        super(completeItemType, identifier, newValue);
-        this.fieldOperation = fieldOperation;
-    }
+    private final FieldChangeOperation fieldOperation;
 
     public static TagChangeEvent added(final CompleteItemType completeItemType,
             final long identifier, final Pair<String, String> addedTagPair)
     {
         return new TagChangeEvent(completeItemType, identifier, Optional.of(addedTagPair),
                 FieldChangeOperation.ADD);
+    }
+
+    public static TagChangeEvent overwrite(final CompleteItemType completeItemType,
+            final long identifier, final Map<String, String> newTags)
+    {
+        return new TagChangeEvent(completeItemType, identifier, Optional.ofNullable(newTags),
+                FieldChangeOperation.OVERWRITE);
     }
 
     public static TagChangeEvent remove(final CompleteItemType completeItemType,
@@ -48,15 +48,15 @@ public class TagChangeEvent extends EntityChangeEvent
                 FieldChangeOperation.REPLACE);
     }
 
-    public static TagChangeEvent overwrite(final CompleteItemType completeItemType,
-            final long identifier, final Map<String, String> newTags)
+    protected TagChangeEvent(final CompleteItemType completeItemType, final long identifier,
+            final Optional<Object> newValue, final FieldChangeOperation fieldOperation)
     {
-        return new TagChangeEvent(completeItemType, identifier, Optional.ofNullable(newTags),
-                FieldChangeOperation.OVERWRITE);
+        super(completeItemType, identifier, newValue);
+        this.fieldOperation = fieldOperation;
     }
 
     public FieldChangeOperation getFieldOperation()
     {
-        return fieldOperation;
+        return this.fieldOperation;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemType.java
@@ -23,14 +23,7 @@ public enum CompleteItemType
 
     private final Class<? extends CompleteEntity> completeEntityClass;
 
-    private ItemType itemType;
-
-    CompleteItemType(final Class<? extends CompleteEntity> completeEntityClass,
-            final ItemType itemType)
-    {
-        this.completeEntityClass = completeEntityClass;
-        this.itemType = itemType;
-    }
+    private final ItemType itemType;
 
     public static CompleteItemType from(final ItemType itemType)
     {
@@ -39,14 +32,19 @@ public enum CompleteItemType
                 .orElseThrow(IllegalArgumentException::new);
     }
 
-    public Class<? extends CompleteEntity> getCompleteEntityClass()
+    public static <C extends CompleteEntity> C shallowFrom(final AtlasEntity reference)
     {
-        return completeEntityClass;
+        final ItemType itemType = reference.getType();
+        final CompleteItemType completeItemType = CompleteItemType.from(itemType);
+        final C completeEntity = completeItemType.completeEntityShallowFrom(reference);
+        return completeEntity;
     }
 
-    public ItemType getItemType()
+    CompleteItemType(final Class<? extends CompleteEntity> completeEntityClass,
+            final ItemType itemType)
     {
-        return itemType;
+        this.completeEntityClass = completeEntityClass;
+        this.itemType = itemType;
     }
 
     public <C extends CompleteEntity> C completeEntityFrom(final AtlasEntity reference)
@@ -61,12 +59,14 @@ public enum CompleteItemType
         return (C) CompleteEntity.shallowFrom(reference);
     }
 
-    public static <C extends CompleteEntity> C shallowFrom(final AtlasEntity reference)
+    public Class<? extends CompleteEntity> getCompleteEntityClass()
     {
-        final ItemType itemType = reference.getType();
-        final CompleteItemType completeItemType = CompleteItemType.from(itemType);
-        final C completeEntity = completeItemType.completeEntityShallowFrom(reference);
-        return completeEntity;
+        return this.completeEntityClass;
+    }
+
+    public ItemType getItemType()
+    {
+        return this.itemType;
     }
 
     private void validate(final AtlasEntity reference)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/TagChangeDelegate.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/TagChangeDelegate.java
@@ -21,14 +21,14 @@ class TagChangeDelegate implements TagChangeListenable, Serializable
 
     private final List<TagChangeListener> tagChangeListeners = new ArrayList<>();
 
-    protected TagChangeDelegate()
-    {
-        super();
-    }
-
     static TagChangeDelegate newTagChangeDelegate()
     {
         return new TagChangeDelegate();
+    }
+
+    protected TagChangeDelegate()
+    {
+        super();
     }
 
     @Override
@@ -37,7 +37,7 @@ class TagChangeDelegate implements TagChangeListenable, Serializable
         Validate.notNull(tagChangeListener, "tagChangeListener is NULL.");
         synchronized (this.tagChangeListeners)
         {
-            tagChangeListeners.add(tagChangeListener);
+            this.tagChangeListeners.add(tagChangeListener);
         }
     }
 
@@ -45,11 +45,11 @@ class TagChangeDelegate implements TagChangeListenable, Serializable
     public void fireTagChangeEvent(final TagChangeEvent tagChangeEvent)
     {
         Validate.notNull(tagChangeEvent, "tagChangeEvent is EMPTY!");
-        if (!tagChangeListeners.isEmpty())
+        if (!this.tagChangeListeners.isEmpty())
         {
             synchronized (this.tagChangeListeners)
             {
-                tagChangeListeners.stream().forEach(
+                this.tagChangeListeners.stream().forEach(
                         tagChangeListener -> tagChangeListener.entityChanged(tagChangeEvent));
             }
         }
@@ -60,7 +60,7 @@ class TagChangeDelegate implements TagChangeListenable, Serializable
     {
         synchronized (this.tagChangeListeners)
         {
-            tagChangeListeners.removeIf(tagChangeListener -> true);
+            this.tagChangeListeners.removeIf(tagChangeListener -> true);
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/delta/AtlasDeltaGenerator.java
@@ -154,8 +154,9 @@ public class AtlasDeltaGenerator extends Command
             // You need to have the before dir be a dir of shards too for this to work.
             if (!Files.isDirectory(before))
             {
-                this.logger.error("Your -before parameter must point to a directory of atlas shards if "
-                        + "you want to compare shard by shard with an -after directory also of shards!");
+                this.logger.error(
+                        "Your -before parameter must point to a directory of atlas shards if "
+                                + "you want to compare shard by shard with an -after directory also of shards!");
                 System.exit(COMMAND_LINE_USAGE_ERROR_EXIT);
             }
 
@@ -187,7 +188,7 @@ public class AtlasDeltaGenerator extends Command
             final Atlas afterAtlas = load(after);
             compare(beforeAtlas, afterAtlas, outputDirectory);
         }
-    
+
         this.logger.info("AtlasDeltaGenerator complete. Total time: {}.", time.elapsedSince());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
@@ -92,8 +92,7 @@ public enum PolygonStringFormat
             case UNSUPPORTED:
             default:
                 logger.warn("No converter set up for {} format. Supported formats are {}",
-                        this.format,
-                        Arrays.copyOf(values(), values().length - 1));
+                        this.format, Arrays.copyOf(values(), values().length - 1));
                 return string -> Optional.empty();
         }
     }
@@ -134,8 +133,7 @@ public enum PolygonStringFormat
             case UNSUPPORTED:
             default:
                 logger.warn("No converter set up for {} format. Supported formats are {}",
-                        this.format,
-                        Arrays.copyOf(values(), values().length - 1));
+                        this.format, Arrays.copyOf(values(), values().length - 1));
                 return string -> Optional.empty();
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/PolygonStringFormat.java
@@ -31,7 +31,7 @@ public enum PolygonStringFormat
     UNSUPPORTED("UNSUPPORTED");
 
     private static final Logger logger = LoggerFactory.getLogger(PolygonStringFormat.class);
-    private String format;
+    private final String format;
 
     public static PolygonStringFormat getEnumForFormat(final String format)
     {
@@ -91,7 +91,8 @@ public enum PolygonStringFormat
                         .singletonList(new WktMultiPolygonConverter().backwardConvert(string)));
             case UNSUPPORTED:
             default:
-                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                logger.warn("No converter set up for {} format. Supported formats are {}",
+                        this.format,
                         Arrays.copyOf(values(), values().length - 1));
                 return string -> Optional.empty();
         }
@@ -132,7 +133,8 @@ public enum PolygonStringFormat
                         new WkbPolygonConverter().backwardConvert(WKBReader.hexToBytes(string))));
             case UNSUPPORTED:
             default:
-                logger.warn("No converter set up for {} format. Supported formats are {}", format,
+                logger.warn("No converter set up for {} format. Supported formats are {}",
+                        this.format,
                         Arrays.copyOf(values(), values().length - 1));
                 return string -> Optional.empty();
         }

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -118,50 +118,6 @@ public class DynamicTileSharding extends Command implements Sharding
             return false;
         }
 
-        /**
-         * Does a deep equals with the other node
-         * 
-         * @param other
-         *            other Node
-         * @return true if entire structure is equal, false if not
-         */
-        private boolean deepEquals(final Node other)
-        {
-            final Comparator<Node> nodeCompare = Comparator.comparing(Node::getTile);
-            // BFS through both trees to get equality
-            final Queue<Node> queue = new LinkedList<>();
-            queue.offer(this);
-            queue.offer(other);
-            while (!queue.isEmpty())
-            {
-                // We always offer two at a time, so we can poll two at a time.
-                final Node node1 = queue.poll();
-                final Node node2 = queue.poll();
-                if (node1.equals(node2) && node1.getChildren().size() == node2.getChildren().size())
-                {
-                    final List<Node> children1 = node1.getChildren();
-                    final List<Node> children2 = node2.getChildren();
-                    children1.sort(nodeCompare);
-                    children2.sort(nodeCompare);
-                    for (int index = 0; index < children1.size(); index++)
-                    {
-                        queue.offer(children1.get(index));
-                        queue.offer(children2.get(index));
-                    }
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private List<Node> getChildren()
-        {
-            return this.children;
-        }
-
         public SlippyTile getTile()
         {
             return this.tile;
@@ -309,6 +265,50 @@ public class DynamicTileSharding extends Command implements Sharding
             return this.tile.getZoom();
         }
 
+        /**
+         * Does a deep equals with the other node
+         *
+         * @param other
+         *            other Node
+         * @return true if entire structure is equal, false if not
+         */
+        private boolean deepEquals(final Node other)
+        {
+            final Comparator<Node> nodeCompare = Comparator.comparing(Node::getTile);
+            // BFS through both trees to get equality
+            final Queue<Node> queue = new LinkedList<>();
+            queue.offer(this);
+            queue.offer(other);
+            while (!queue.isEmpty())
+            {
+                // We always offer two at a time, so we can poll two at a time.
+                final Node node1 = queue.poll();
+                final Node node2 = queue.poll();
+                if (node1.equals(node2) && node1.getChildren().size() == node2.getChildren().size())
+                {
+                    final List<Node> children1 = node1.getChildren();
+                    final List<Node> children2 = node2.getChildren();
+                    children1.sort(nodeCompare);
+                    children2.sort(nodeCompare);
+                    for (int index = 0; index < children1.size(); index++)
+                    {
+                        queue.offer(children1.get(index));
+                        queue.offer(children2.get(index));
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private List<Node> getChildren()
+        {
+            return this.children;
+        }
+
         private void save(final BufferedWriter writer)
         {
             try
@@ -391,7 +391,7 @@ public class DynamicTileSharding extends Command implements Sharding
         }
 
         final DynamicTileSharding that = (DynamicTileSharding) other;
-        return root.deepEquals(that.root);
+        return this.root.deepEquals(that.root);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/OptionalIterable.java
@@ -32,7 +32,7 @@ public class OptionalIterable<T> implements Iterable<T>
             @Override
             public boolean hasNext()
             {
-                if (previousElement.isPresent())
+                if (this.previousElement.isPresent())
                 {
                     return true;
                 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfigurationReader.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfigurationReader.java
@@ -48,7 +48,7 @@ public class ConfigurationReader
     public <R, T> T configurationValue(final Configuration configuration,
             final Function<R, T> defaultValue)
     {
-        return configuration.get(root, defaultValue).value();
+        return configuration.get(this.root, defaultValue).value();
     }
 
     public List<String> configurationValues(final Configuration configuration, final String key)

--- a/src/main/java/org/openstreetmap/atlas/utilities/matching/NameMatcher.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/matching/NameMatcher.java
@@ -66,22 +66,22 @@ public class NameMatcher implements Serializable, Predicate<String>
     {
         if (candidateName == null)
         {
-            return matchNull;
+            return this.matchNull;
         }
-        if (exactMatch)
+        if (this.exactMatch)
         {
-            return candidateName.equals(sourceName);
+            return candidateName.equals(this.sourceName);
         }
-        if (fuzzyMatch)
+        if (this.fuzzyMatch)
         {
-            return nameFuzzyMatch(sourceName, candidateName);
+            return nameFuzzyMatch(this.sourceName, candidateName);
         }
-        return candidateName.equalsIgnoreCase(sourceName);
+        return candidateName.equalsIgnoreCase(this.sourceName);
     }
 
     private boolean nameFuzzyMatch(final String nameA, final String nameB)
     {
         return nameA.equalsIgnoreCase(nameB) || StringUtils.getLevenshteinDistance(nameA, nameB,
-                lavenshteinDistanceThreshold) != -1;
+                this.lavenshteinDistanceThreshold) != -1;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/vectortiles/MinimumZoom.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/vectortiles/MinimumZoom.java
@@ -32,11 +32,35 @@ public enum MinimumZoom
 
     private String[] keys;
     private int[] defaults;
-    private List<Map<String, Integer>> valuesList = new ArrayList<>();
+    private final List<Map<String, Integer>> valuesList = new ArrayList<>();
 
     MinimumZoom()
     {
         processConfig(parseConfig());
+    }
+
+    public int get(final Map<String, String> tags)
+    {
+        for (int index = 0; index < this.keys.length; ++index)
+        {
+            final String key = this.keys[index];
+            final String value = tags.get(key);
+            if (value == null)
+            {
+                continue;
+            }
+            final Map<String, Integer> valuesMap = this.valuesList.get(index);
+            final Integer valueMinimumZoom = valuesMap.get(value);
+            if (valueMinimumZoom != null)
+            {
+                return valueMinimumZoom;
+            }
+            else
+            {
+                return this.defaults[index];
+            }
+        }
+        return DEFAULT_ZOOM;
     }
 
     private JsonArray parseConfig()
@@ -60,18 +84,18 @@ public enum MinimumZoom
     private void processConfig(final JsonArray config)
     {
         final int length = config.size();
-        keys = new String[length];
-        defaults = new int[length];
+        this.keys = new String[length];
+        this.defaults = new int[length];
         for (int index = 0; index < length; ++index)
         {
             try
             {
                 final JsonObject object = config.get(index).getAsJsonObject();
-                keys[index] = object.get("key").getAsString();
-                defaults[index] = object.get("default").getAsInt();
+                this.keys[index] = object.get("key").getAsString();
+                this.defaults[index] = object.get("default").getAsInt();
 
                 final Map<String, Integer> valuesMap = new HashMap<>();
-                valuesList.add(index, valuesMap);
+                this.valuesList.add(index, valuesMap);
 
                 // values is optional
                 final JsonElement valuesElement = object.get("values");
@@ -88,29 +112,5 @@ public enum MinimumZoom
                         exception);
             }
         }
-    }
-
-    public int get(final Map<String, String> tags)
-    {
-        for (int index = 0; index < keys.length; ++index)
-        {
-            final String key = keys[index];
-            final String value = tags.get(key);
-            if (value == null)
-            {
-                continue;
-            }
-            final Map<String, Integer> valuesMap = valuesList.get(index);
-            final Integer valueMinimumZoom = valuesMap.get(value);
-            if (valueMinimumZoom != null)
-            {
-                return valueMinimumZoom;
-            }
-            else
-            {
-                return defaults[index];
-            }
-        }
-        return DEFAULT_ZOOM;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/vectortiles/TippecanoeGeoJsonExtension.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/vectortiles/TippecanoeGeoJsonExtension.java
@@ -22,17 +22,17 @@ public class TippecanoeGeoJsonExtension
 
     public TippecanoeGeoJsonExtension addTo(final JsonObject feature)
     {
-        feature.add("tippecanoe", json);
+        feature.add("tippecanoe", this.json);
         return this;
     }
 
     public void layer(final String layer)
     {
-        json.addProperty("layer", layer);
+        this.json.addProperty("layer", layer);
     }
 
     public void minimumZoom(final int minimumZoom)
     {
-        json.addProperty("minzoom", minimumZoom);
+        this.json.addProperty("minzoom", minimumZoom);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasTest.java
@@ -21,23 +21,13 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
  */
 public class AtlasTest
 {
-
     @Rule
     public final AtlasTestRule rule = new AtlasTestRule();
 
     @Test
-    public void nodesByIds()
-    {
-        final Atlas atlas = rule.getAtlas();
-        final Iterable<Node> nodes = atlas.nodes(0L, 1L);
-        final long count = StreamSupport.stream(nodes.spliterator(), false).count();
-        Assert.assertEquals(2, count);
-    }
-
-    @Test
     public void entitiesByIds()
     {
-        final Atlas atlas = rule.getAtlas();
+        final Atlas atlas = this.rule.getAtlas();
         final Map<ItemType, ? extends Iterable<? extends AtlasEntity>> itemTypeToEntities = Arrays
                 .stream(ItemType.values())
                 .map(itemType -> Pair.of(itemType, itemType.entitiesForIdentifiers(atlas, 0L, 1L)))
@@ -59,7 +49,15 @@ public class AtlasTest
                                 + "; atlasEntityClass: " + atlasEntityClass,
                         memberClass.isAssignableFrom(atlasEntityClass));
             });
-
         });
+    }
+
+    @Test
+    public void nodesByIds()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final Iterable<Node> nodes = atlas.nodes(0L, 1L);
+        final long count = StreamSupport.stream(nodes.spliterator(), false).count();
+        Assert.assertEquals(2, count);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTest.java
@@ -13,42 +13,62 @@ public class CascadeDeleteTest
     @Rule
     public final CascadeDeleteTestRule rule = new CascadeDeleteTestRule();
 
-    private CascadeDeleteTestHelper helper = new CascadeDeleteTestHelper(rule);
-
-    @Test
-    public void deleteUnrelatedNode()
-    {
-        final Atlas atlas = helper.getAtlas();
-        final long nodeIdToDelete = CascadeDeleteTestRule.NON_EDGE_NODE_IDENTIFIER;
-        final long nodeRelationId = CascadeDeleteTestRule.NON_EDGE_NODE_RELATION_IDENTIFIER;
-        final Atlas changeAtlas = helper.deleteNode(atlas, nodeIdToDelete, nodeRelationId);
-        helper.verifyCounts(changeAtlas, helper.override(ItemType.NODE, -1));
-    }
+    private final CascadeDeleteTestHelper helper = new CascadeDeleteTestHelper(this.rule);
 
     @Test
     public void deleteEdgeStartNode()
     {
-        final Atlas atlas = helper.getAtlas();
+        final Atlas atlas = this.helper.getAtlas();
         final long nodeIdToDelete = CascadeDeleteTestRule.START_END_EDGE_NODE;
         final long nodeRelationId = CascadeDeleteTestRule.NON_EDGE_NODE_RELATION_IDENTIFIER;
-        final Atlas changeAtlas = helper.deleteNode(atlas, nodeIdToDelete, nodeRelationId);
-        helper.verifyCounts(changeAtlas, helper.override(ItemType.NODE, -1),
-                helper.override(ItemType.EDGE, -2));
+        final Atlas changeAtlas = this.helper.deleteNode(atlas, nodeIdToDelete, nodeRelationId);
+        this.helper.verifyCounts(changeAtlas, this.helper.override(ItemType.NODE, -1),
+                this.helper.override(ItemType.EDGE, -2));
+    }
+
+    @Test
+    public void deleteRelation()
+    {
+        final long entityIdentifier = CascadeDeleteTestRule.TOP_LEVEL_RELATION_IDENTIFIER;
+        final Atlas atlas = this.helper.getAtlas();
+        final Atlas changeAtlas = this.helper.deleteSimpleRelation(entityIdentifier, atlas);
+        this.helper.verifyCounts(changeAtlas, this.helper.override(ItemType.RELATION, -1));
+    }
+
+    @Test
+    public void deleteUnrelatedNode()
+    {
+        final Atlas atlas = this.helper.getAtlas();
+        final long nodeIdToDelete = CascadeDeleteTestRule.NON_EDGE_NODE_IDENTIFIER;
+        final long nodeRelationId = CascadeDeleteTestRule.NON_EDGE_NODE_RELATION_IDENTIFIER;
+        final Atlas changeAtlas = this.helper.deleteNode(atlas, nodeIdToDelete, nodeRelationId);
+        this.helper.verifyCounts(changeAtlas, this.helper.override(ItemType.NODE, -1));
+    }
+
+    @Test
+    public void testAutoDeleteEmptyRelations()
+    {
+        final ItemType itemType = ItemType.POINT;
+        final long entityIdentifier = CascadeDeleteTestRule.THE_ONLY_RELATION_MEMBER_POINT_IDENTIFIER;
+        final long entityRelationIdentifier = CascadeDeleteTestRule.ONE_MEMBER_RELATION_IDENTIFIER;
+        this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier, true);
+    }
+
+    @Test
+    public void testDeleteAreaToRelationMemberCascade()
+    {
+        final ItemType itemType = ItemType.AREA;
+        final long entityIdentifier = CascadeDeleteTestRule.AREA_IDENTIFIER;
+        final long entityRelationIdentifier = CascadeDeleteTestRule.AREA_RELATION_IDENTIFIER;
+    
+        this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 
     @Test
     public void testDeleteForwardEdgeToRelationMemberCascadeButNotReverseEdge()
     {
         final long edgeIdentifier = CascadeDeleteTestRule.EDGE_IDENTIFIER;
-        helper.deleteEdgeButNotReverse(edgeIdentifier,
-                CascadeDeleteTestRule.EDGE_RELATION_IDENTIFIER);
-    }
-
-    @Test
-    public void testDeleteReverseEdgeToRelationMemberCascadeButNotForwardEdge()
-    {
-        final long edgeIdentifier = -(CascadeDeleteTestRule.EDGE_IDENTIFIER);
-        helper.deleteEdgeButNotReverse(edgeIdentifier,
+        this.helper.deleteEdgeButNotReverse(edgeIdentifier,
                 CascadeDeleteTestRule.EDGE_RELATION_IDENTIFIER);
     }
 
@@ -58,18 +78,8 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.LINE;
         final long entityIdentifier = CascadeDeleteTestRule.LINE_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.LINE_RELATION_IDENTIFIER;
-
-        helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
-    }
-
-    @Test
-    public void testDeleteAreaToRelationMemberCascade()
-    {
-        final ItemType itemType = ItemType.AREA;
-        final long entityIdentifier = CascadeDeleteTestRule.AREA_IDENTIFIER;
-        final long entityRelationIdentifier = CascadeDeleteTestRule.AREA_RELATION_IDENTIFIER;
-
-        helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
+    
+        this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 
     @Test
@@ -78,17 +88,16 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.POINT;
         final long entityIdentifier = CascadeDeleteTestRule.POINT_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.POINT_RELATION_IDENTIFIER;
-
-        helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
+    
+        this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 
     @Test
-    public void deleteRelation()
+    public void testDeleteReverseEdgeToRelationMemberCascadeButNotForwardEdge()
     {
-        final long entityIdentifier = CascadeDeleteTestRule.TOP_LEVEL_RELATION_IDENTIFIER;
-        final Atlas atlas = helper.getAtlas();
-        final Atlas changeAtlas = helper.deleteSimpleRelation(entityIdentifier, atlas);
-        helper.verifyCounts(changeAtlas, helper.override(ItemType.RELATION, -1));
+        final long edgeIdentifier = -(CascadeDeleteTestRule.EDGE_IDENTIFIER);
+        this.helper.deleteEdgeButNotReverse(edgeIdentifier,
+                CascadeDeleteTestRule.EDGE_RELATION_IDENTIFIER);
     }
 
     @Test
@@ -97,15 +106,6 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.RELATION;
         final long entityIdentifier = CascadeDeleteTestRule.SUB_RELATION_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.PARENT_RELATION_IDENTIFIER;
-        helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
-    }
-
-    @Test
-    public void testAutoDeleteEmptyRelations()
-    {
-        final ItemType itemType = ItemType.POINT;
-        final long entityIdentifier = CascadeDeleteTestRule.THE_ONLY_RELATION_MEMBER_POINT_IDENTIFIER;
-        final long entityRelationIdentifier = CascadeDeleteTestRule.ONE_MEMBER_RELATION_IDENTIFIER;
-        helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier, true);
+        this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTest.java
@@ -60,7 +60,7 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.AREA;
         final long entityIdentifier = CascadeDeleteTestRule.AREA_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.AREA_RELATION_IDENTIFIER;
-    
+
         this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 
@@ -78,7 +78,7 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.LINE;
         final long entityIdentifier = CascadeDeleteTestRule.LINE_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.LINE_RELATION_IDENTIFIER;
-    
+
         this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 
@@ -88,7 +88,7 @@ public class CascadeDeleteTest
         final ItemType itemType = ItemType.POINT;
         final long entityIdentifier = CascadeDeleteTestRule.POINT_IDENTIFIER;
         final long entityRelationIdentifier = CascadeDeleteTestRule.POINT_RELATION_IDENTIFIER;
-    
+
         this.helper.testDeleteSimple(itemType, entityIdentifier, entityRelationIdentifier);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestHelper.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestHelper.java
@@ -27,59 +27,16 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
  */
 class CascadeDeleteTestHelper
 {
-    private CascadeDeleteTestRule rule;
-
-    CascadeDeleteTestHelper(final CascadeDeleteTestRule rule)
-    {
-        this.rule = rule;
-    }
+    private final CascadeDeleteTestRule rule;
 
     protected static <E extends AtlasEntity> long count(final Iterable<E> entities)
     {
         return StreamSupport.stream(entities.spliterator(), false).count();
     }
 
-    protected boolean isEntityPresentInRelation(final Atlas atlas, final ItemType itemType,
-            final long entityRelationIdentifier, final long entityIdentifier)
+    CascadeDeleteTestHelper(final CascadeDeleteTestRule rule)
     {
-        final Relation relation = atlas.relation(entityRelationIdentifier);
-
-        Assert.assertNotNull(relation);
-
-        return relation.members().stream()
-                .filter(relationMember -> relationMember.getEntity().getType() == itemType)
-                .filter(relationMember -> relationMember.getEntity()
-                        .getIdentifier() == entityIdentifier)
-                .findFirst().isPresent();
-    }
-
-    protected Atlas deleteNode(final Atlas atlas, final long nodeIdToDelete, final long relationId)
-    {
-        verifyCounts(atlas);
-        final Node node = atlas.node(nodeIdToDelete);
-        Assert.assertNotNull(node);
-
-        final Relation relation = atlas.relation(relationId);
-        Assert.assertNotNull(relation);
-        Assert.assertFalse(relation.membersOfType(ItemType.NODE).isEmpty());
-        Assert.assertTrue(isNodeMemberPresent(atlas, nodeIdToDelete, relationId));
-
-        final FeatureChange featureChangeRemoveNode = FeatureChange
-                .remove(CompleteEntity.shallowFrom(node), atlas);
-        final Change change = ChangeBuilder.newInstance().add(featureChangeRemoveNode).get();
-        final Atlas changeAtlas = new ChangeAtlas(atlas, change);
-        Assert.assertNull(changeAtlas.node(nodeIdToDelete));
-        Assert.assertFalse(isNodeMemberPresent(changeAtlas, nodeIdToDelete, relationId));
-        return changeAtlas;
-    }
-
-    protected boolean isNodeMemberPresent(final Atlas atlas, final long nodeIdToDelete,
-            final long relationId)
-    {
-        final Predicate<RelationMember> relationMemberPredicate = member -> member.getEntity()
-                .getType() == ItemType.NODE && member.getEntity().getIdentifier() == nodeIdToDelete;
-
-        return !atlas.relation(relationId).membersMatching(relationMemberPredicate).isEmpty();
+        this.rule = rule;
     }
 
     protected void deleteEdgeButNotReverse(final long edgeIdentifier, final long relationIdentifier)
@@ -157,6 +114,56 @@ class CascadeDeleteTestHelper
         verifyCounts(changedAtlas, Pair.of(ItemType.EDGE, CascadeDeleteTestRule.EDGE_COUNT - 1));
     }
 
+    protected Atlas deleteNode(final Atlas atlas, final long nodeIdToDelete, final long relationId)
+    {
+        verifyCounts(atlas);
+        final Node node = atlas.node(nodeIdToDelete);
+        Assert.assertNotNull(node);
+
+        final Relation relation = atlas.relation(relationId);
+        Assert.assertNotNull(relation);
+        Assert.assertFalse(relation.membersOfType(ItemType.NODE).isEmpty());
+        Assert.assertTrue(isNodeMemberPresent(atlas, nodeIdToDelete, relationId));
+
+        final FeatureChange featureChangeRemoveNode = FeatureChange
+                .remove(CompleteEntity.shallowFrom(node), atlas);
+        final Change change = ChangeBuilder.newInstance().add(featureChangeRemoveNode).get();
+        final Atlas changeAtlas = new ChangeAtlas(atlas, change);
+        Assert.assertNull(changeAtlas.node(nodeIdToDelete));
+        Assert.assertFalse(isNodeMemberPresent(changeAtlas, nodeIdToDelete, relationId));
+        return changeAtlas;
+    }
+
+    protected Atlas deleteSimpleRelation(final long entityIdentifier, final Atlas atlas)
+    {
+        verifyCounts(atlas);
+
+        final Relation relation = atlas.relation(entityIdentifier);
+
+        final FeatureChange featureChange = FeatureChange
+                .remove(CompleteRelation.shallowFrom(relation), atlas);
+
+        final Change change = ChangeBuilder.newInstance().add(featureChange).get();
+
+        return new ChangeAtlas(atlas, change);
+    }
+
+    protected Atlas getAtlas()
+    {
+        return this.rule.getAtlas();
+    }
+
+    protected Set<Long> getMatchingEdgesInRelation(final Atlas atlas, final long relationIdentifier,
+            final long edgeIdentifier)
+    {
+        return atlas.relation(relationIdentifier).members().stream()
+                .filter(relationMember -> relationMember.getEntity().getType() == ItemType.EDGE)
+                .filter(relationMember -> Math.abs(
+                        relationMember.getEntity().getIdentifier()) == Math.abs(edgeIdentifier))
+                .map(relationMember -> relationMember.getEntity().getIdentifier())
+                .collect(Collectors.toSet());
+    }
+
     protected boolean isEdgeRelatedToNode(final Atlas atlas, final long nodeId, final long edgeId,
             final ConnectedEdgeType connectedEdgeType)
     {
@@ -172,20 +179,32 @@ class CascadeDeleteTestHelper
                 .filter(edge -> edge.getIdentifier() == edgeId).findFirst().isPresent();
     }
 
-    protected Atlas getAtlas()
+    protected boolean isEntityPresentInRelation(final Atlas atlas, final ItemType itemType,
+            final long entityRelationIdentifier, final long entityIdentifier)
     {
-        return rule.getAtlas();
+        final Relation relation = atlas.relation(entityRelationIdentifier);
+
+        Assert.assertNotNull(relation);
+
+        return relation.members().stream()
+                .filter(relationMember -> relationMember.getEntity().getType() == itemType)
+                .filter(relationMember -> relationMember.getEntity()
+                        .getIdentifier() == entityIdentifier)
+                .findFirst().isPresent();
     }
 
-    protected Set<Long> getMatchingEdgesInRelation(final Atlas atlas, final long relationIdentifier,
-            final long edgeIdentifier)
+    protected boolean isNodeMemberPresent(final Atlas atlas, final long nodeIdToDelete,
+            final long relationId)
     {
-        return atlas.relation(relationIdentifier).members().stream()
-                .filter(relationMember -> relationMember.getEntity().getType() == ItemType.EDGE)
-                .filter(relationMember -> Math.abs(
-                        relationMember.getEntity().getIdentifier()) == Math.abs(edgeIdentifier))
-                .map(relationMember -> relationMember.getEntity().getIdentifier())
-                .collect(Collectors.toSet());
+        final Predicate<RelationMember> relationMemberPredicate = member -> member.getEntity()
+                .getType() == ItemType.NODE && member.getEntity().getIdentifier() == nodeIdToDelete;
+
+        return !atlas.relation(relationId).membersMatching(relationMemberPredicate).isEmpty();
+    }
+
+    protected Pair<ItemType, Long> override(final ItemType itemType, final int override)
+    {
+        return Pair.of(itemType, this.rule.getCountExpectationMapping().get(itemType) + override);
     }
 
     protected void testDeleteSimple(final ItemType itemType, final long entityIdentifier,
@@ -235,14 +254,9 @@ class CascadeDeleteTestHelper
         }
     }
 
-    protected Pair<ItemType, Long> override(final ItemType itemType, final int override)
-    {
-        return Pair.of(itemType, rule.getCountExpectationMapping().get(itemType) + override);
-    }
-
     protected void verifyCounts(final Atlas atlas, final Pair<ItemType, Long>... overrides)
     {
-        final Map<ItemType, Long> countExpectationMapping = rule.getCountExpectationMapping();
+        final Map<ItemType, Long> countExpectationMapping = this.rule.getCountExpectationMapping();
 
         final Map<ItemType, Long> overrideMapping = Arrays.stream(overrides)
                 .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
@@ -256,19 +270,5 @@ class CascadeDeleteTestHelper
             Assert.assertEquals("entry failed: " + entry, (long) entry.getValue(),
                     entry.getKey().numberOfEntities(atlas));
         }
-    }
-
-    protected Atlas deleteSimpleRelation(final long entityIdentifier, final Atlas atlas)
-    {
-        verifyCounts(atlas);
-
-        final Relation relation = atlas.relation(entityIdentifier);
-
-        final FeatureChange featureChange = FeatureChange
-                .remove(CompleteRelation.shallowFrom(relation), atlas);
-
-        final Change change = ChangeBuilder.newInstance().add(featureChange).get();
-
-        return new ChangeAtlas(atlas, change);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestRule.java
@@ -44,8 +44,10 @@ public class CascadeDeleteTestRule extends CoreTestRule
     private static final String FIVE = "38, -123";
     private static final String SIX = "39, -124";
 
-    private Map<ItemType, Long> countExpectationMapping = new HashMap()
+    private final Map<ItemType, Long> countExpectationMapping = new HashMap()
     {
+        private static final long serialVersionUID = 6255547290912151165L;
+    
         {
             put(ItemType.NODE, NODE_COUNT);
             put(ItemType.POINT, POINT_COUNT);
@@ -133,6 +135,6 @@ public class CascadeDeleteTestRule extends CoreTestRule
 
     public Map<ItemType, Long> getCountExpectationMapping()
     {
-        return new HashMap<>(countExpectationMapping);
+        return new HashMap<>(this.countExpectationMapping);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/CascadeDeleteTestRule.java
@@ -47,7 +47,7 @@ public class CascadeDeleteTestRule extends CoreTestRule
     private final Map<ItemType, Long> countExpectationMapping = new HashMap()
     {
         private static final long serialVersionUID = 6255547290912151165L;
-    
+
         {
             put(ItemType.NODE, NODE_COUNT);
             put(ItemType.POINT, POINT_COUNT);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
@@ -57,7 +57,7 @@ public class MultiCascadeDeleteTest
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
             private static final long serialVersionUID = 454060048188157314L;
-    
+
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
@@ -98,7 +98,7 @@ public class MultiCascadeDeleteTest
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
             private static final long serialVersionUID = 3346327267408295085L;
-    
+
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), true);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
@@ -137,7 +137,7 @@ public class MultiCascadeDeleteTest
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
             private static final long serialVersionUID = -8963613354545135623L;
-    
+
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), true);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultiCascadeDeleteTest.java
@@ -56,6 +56,8 @@ public class MultiCascadeDeleteTest
         // Step-3 Verify AtlasDiff
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
+            private static final long serialVersionUID = 454060048188157314L;
+    
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
@@ -95,6 +97,8 @@ public class MultiCascadeDeleteTest
         // Step-3 Verify AtlasDiff
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
+            private static final long serialVersionUID = 3346327267408295085L;
+    
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), true);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), false);
@@ -132,6 +136,8 @@ public class MultiCascadeDeleteTest
         // Step-3 Verify AtlasDiff
         final Map<AtlasEntityKey, Boolean> expectedChangedAndDeleted = new HashMap<AtlasEntityKey, Boolean>()
         {
+            private static final long serialVersionUID = -8963613354545135623L;
+    
             {
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeA), false);
                 put(AtlasEntityKey.from(ItemType.NODE, MultiCascadeDeleteTestRule.nodeB), true);
@@ -154,13 +160,6 @@ public class MultiCascadeDeleteTest
         return changedAtlas(atlas, featureChange, expectedNodes, expectedEdges);
     }
 
-    private FeatureChange createDeleteFeatureChange(final Atlas atlas, final ItemType itemType,
-            final Long entityIdToDelete)
-    {
-        return FeatureChange.remove(CompleteItemType
-                .shallowFrom(itemType.entityForIdentifier(atlas, entityIdToDelete)));
-    }
-
     private Atlas changedAtlas(final Atlas atlas, final FeatureChange featureChange,
             final long expectedNodes, final long expectedEdges)
     {
@@ -171,9 +170,16 @@ public class MultiCascadeDeleteTest
         return changeAtlas;
     }
 
+    private FeatureChange createDeleteFeatureChange(final Atlas atlas, final ItemType itemType,
+            final Long entityIdToDelete)
+    {
+        return FeatureChange.remove(CompleteItemType
+                .shallowFrom(itemType.entityForIdentifier(atlas, entityIdToDelete)));
+    }
+
     private Atlas originalAtlas()
     {
-        final Atlas atlas = rule.getAtlas();
+        final Atlas atlas = this.rule.getAtlas();
         Assert.assertEquals(3, atlas.numberOfNodes());
         Assert.assertEquals(2, atlas.numberOfEdges());
         Assert.assertEquals(1, atlas.numberOfRelations());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MultipleChangeAtlasTest.java
@@ -65,7 +65,7 @@ public class MultipleChangeAtlasTest
             {
                 return CompleteEdge.shallowFrom(edge).withPolyLine(
                         new PolyLine(edge.start().getLocation(), edge.end().getLocation()));
-            }).map(completeEdge -> FeatureChange.add(completeEdge, atlas)).collectToSet();
+            }).map(completeEdge -> FeatureChange.add(completeEdge, this.atlas)).collectToSet();
         });
         final long straightEdges = Iterables.size(this.changeAtlas.edges(straight));
         final long originalAtlasStraightEdges = Iterables.size(this.atlas.edges(straight));
@@ -85,7 +85,8 @@ public class MultipleChangeAtlasTest
             return Iterables.stream(atlas.nodes())
                     .map(node -> CompleteNode.shallowFrom(node).withAddedTag("highway",
                             "traffic_signals"))
-                    .map(completeNode -> FeatureChange.add(completeNode, atlas)).collectToSet();
+                    .map(completeNode -> FeatureChange.add(completeNode, this.atlas))
+                    .collectToSet();
         });
         final Predicate<Node> trafficSignal = node -> "traffic_signals".equals(node.tag("highway"));
         final long changeAtlasNodesWithTrafficSignals = Iterables

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/TagChangeTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/TagChangeTestRule.java
@@ -103,10 +103,10 @@ public class TagChangeTestRule extends CoreTestRule
                             @TestAtlas.Relation.Member(id = ID_STR_2, role = "some role 5", type = "area"),
                             @TestAtlas.Relation.Member(id = ID_STR_1, role = "some role 6", type = "relation"), }, tags = {
                                     MARS_ROVER, SINGLETON_EMPTY }) })
-    private Atlas atlas = null;
+    private final Atlas atlas = null;
 
     public Atlas getAtlas()
     {
-        return atlas;
+        return this.atlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/listener/TestTagChangeListenerImplementation.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/eventhandling/listener/TestTagChangeListenerImplementation.java
@@ -16,16 +16,16 @@ public class TestTagChangeListenerImplementation implements TagChangeListener
     public void entityChanged(final TagChangeEvent entityChangeEvent)
     {
         this.lastEvent = entityChangeEvent;
-        callCount++;
-    }
-
-    public TagChangeEvent getLastEvent()
-    {
-        return lastEvent;
+        this.callCount++;
     }
 
     public int getCallCount()
     {
-        return callCount;
+        return this.callCount;
+    }
+
+    public TagChangeEvent getLastEvent()
+    {
+        return this.lastEvent;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteItemTypeTest.java
@@ -22,7 +22,7 @@ public class CompleteItemTypeTest
     @Test
     public void shallowFrom()
     {
-        final Atlas atlas = rule.getAtlas();
+        final Atlas atlas = this.rule.getAtlas();
         final List<CompleteEntity> completeEntities = toCompleteEntities(atlas);
         validate(completeEntities);
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntityTest.java
@@ -9,14 +9,13 @@ import org.junit.Test;
  */
 public class AtlasEntityTest
 {
-
     @Rule
     public final AreaEntityTestRule rule = new AreaEntityTestRule();
 
     @Test
     public void getName()
     {
-        Assert.assertEquals("abc", rule.getAtlas().node(1).getName().get());
-        Assert.assertFalse(rule.getAtlas().node(2).getName().isPresent());
+        Assert.assertEquals("abc", this.rule.getAtlas().node(1).getName().get());
+        Assert.assertFalse(this.rule.getAtlas().node(2).getName().isPresent());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationOrAreaToMultiPolygonConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationOrAreaToMultiPolygonConverterTest.java
@@ -22,7 +22,7 @@ public class RelationOrAreaToMultiPolygonConverterTest
     public void innerOuterMultiPolygonTest()
     {
         final MultiPolygon multiPolygon = CONVERTER
-                .convert(setup.innerOuterMultiPolygonAtlas().relation(1447306000000L));
+                .convert(this.setup.innerOuterMultiPolygonAtlas().relation(1447306000000L));
         Assert.assertEquals(2, multiPolygon.outers().size());
         // Both inner rings should be mapped to one of the outer rings
         Assert.assertTrue(

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/walker/SimpleEdgeWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/walker/SimpleEdgeWalkerTest.java
@@ -21,7 +21,8 @@ public class SimpleEdgeWalkerTest
     public void collectAllTest()
     {
         Assert.assertEquals(3,
-                new SimpleEdgeWalker(this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
+                new SimpleEdgeWalker(
+                        this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
                         edge -> edge.outEdges().stream()).collectEdges().size());
     }
 
@@ -29,7 +30,8 @@ public class SimpleEdgeWalkerTest
     public void collectPrimaryQueueAllTest()
     {
         Assert.assertEquals(2,
-                new SimpleEdgeWalker(this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
+                new SimpleEdgeWalker(
+                        this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
                         connectedEdge -> Validators.isOfType(connectedEdge, HighwayTag.class,
                                 HighwayTag.PRIMARY),
                         edge -> edge.outEdges().stream()).collectEdges().size());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/walker/SimpleEdgeWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/walker/SimpleEdgeWalkerTest.java
@@ -13,16 +13,15 @@ import org.openstreetmap.atlas.tags.annotations.validation.Validators;
  */
 public class SimpleEdgeWalkerTest
 {
+    private static final long FIRST_EDGE_IDENTIFIER = 1000000001L;
     @Rule
     public SimpleEdgeWalkerTestRule setup = new SimpleEdgeWalkerTestRule();
-    private static final long FIRST_EDGE_IDENTIFIER = 1000000001L;
 
     @Test
     public void collectAllTest()
     {
         Assert.assertEquals(3,
-                new SimpleEdgeWalker(
-                        setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
+                new SimpleEdgeWalker(this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
                         edge -> edge.outEdges().stream()).collectEdges().size());
     }
 
@@ -30,8 +29,7 @@ public class SimpleEdgeWalkerTest
     public void collectPrimaryQueueAllTest()
     {
         Assert.assertEquals(2,
-                new SimpleEdgeWalker(
-                        setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
+                new SimpleEdgeWalker(this.setup.motorwayPrimaryTriangleAtlas().edge(FIRST_EDGE_IDENTIFIER),
                         connectedEdge -> Validators.isOfType(connectedEdge, HighwayTag.class,
                                 HighwayTag.PRIMARY),
                         edge -> edge.outEdges().stream()).collectEdges().size());

--- a/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
@@ -19,7 +19,7 @@ public class NameMatcherTestCase
     @Test
     public void testExactMatch()
     {
-        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchExactly())
+        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchExactly())
                 .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street" }, results);
     }
@@ -27,15 +27,15 @@ public class NameMatcherTestCase
     @Test
     public void testExactMatchWithNulls()
     {
-        final String[] results = Stream.of(data)
-                .filter(new NameMatcher(source).matchExactly().matchNulls()).toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchExactly().matchNulls()).toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", null }, results);
     }
 
     @Test
     public void testFuzzyMatch()
     {
-        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchSimilar())
+        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchSimilar())
                 .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street" },
                 results);
@@ -44,8 +44,8 @@ public class NameMatcherTestCase
     @Test
     public void testFuzzyMatchWithNulls()
     {
-        final String[] results = Stream.of(data)
-                .filter(new NameMatcher(source).matchSimilar().matchNulls()).toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchSimilar().matchNulls()).toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street", null },
                 results);
     }
@@ -53,7 +53,7 @@ public class NameMatcherTestCase
     @Test
     public void testReallyFuzzyMatch()
     {
-        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchSimilar(10))
+        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchSimilar(10))
                 .toArray(String[]::new);
         Assert.assertArrayEquals(
                 new String[] { "Main Street", "main street", "Rain Street", "Second Street" },
@@ -63,7 +63,7 @@ public class NameMatcherTestCase
     @Test
     public void testUncasedMatch()
     {
-        final String[] results = Stream.of(data).filter(new NameMatcher(source))
+        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source))
                 .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street" }, results);
     }
@@ -71,7 +71,7 @@ public class NameMatcherTestCase
     @Test
     public void testUncasedMatchWithNulls()
     {
-        final String[] results = Stream.of(data).filter(new NameMatcher(source).matchNulls())
+        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchNulls())
                 .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", null }, results);
     }

--- a/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/matching/NameMatcherTestCase.java
@@ -19,8 +19,8 @@ public class NameMatcherTestCase
     @Test
     public void testExactMatch()
     {
-        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchExactly())
-                .toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchExactly()).toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street" }, results);
     }
 
@@ -28,15 +28,16 @@ public class NameMatcherTestCase
     public void testExactMatchWithNulls()
     {
         final String[] results = Stream.of(this.data)
-                .filter(new NameMatcher(this.source).matchExactly().matchNulls()).toArray(String[]::new);
+                .filter(new NameMatcher(this.source).matchExactly().matchNulls())
+                .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", null }, results);
     }
 
     @Test
     public void testFuzzyMatch()
     {
-        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchSimilar())
-                .toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchSimilar()).toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street" },
                 results);
     }
@@ -45,7 +46,8 @@ public class NameMatcherTestCase
     public void testFuzzyMatchWithNulls()
     {
         final String[] results = Stream.of(this.data)
-                .filter(new NameMatcher(this.source).matchSimilar().matchNulls()).toArray(String[]::new);
+                .filter(new NameMatcher(this.source).matchSimilar().matchNulls())
+                .toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", "Rain Street", null },
                 results);
     }
@@ -53,8 +55,8 @@ public class NameMatcherTestCase
     @Test
     public void testReallyFuzzyMatch()
     {
-        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchSimilar(10))
-                .toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchSimilar(10)).toArray(String[]::new);
         Assert.assertArrayEquals(
                 new String[] { "Main Street", "main street", "Rain Street", "Second Street" },
                 results);
@@ -71,8 +73,8 @@ public class NameMatcherTestCase
     @Test
     public void testUncasedMatchWithNulls()
     {
-        final String[] results = Stream.of(this.data).filter(new NameMatcher(this.source).matchNulls())
-                .toArray(String[]::new);
+        final String[] results = Stream.of(this.data)
+                .filter(new NameMatcher(this.source).matchNulls()).toArray(String[]::new);
         Assert.assertArrayEquals(new String[] { "Main Street", "main street", null }, results);
     }
 }


### PR DESCRIPTION
### Description:

The `RequireThis` plugin in Checkstyle was updated after `6.17`, and this update was missed.

Adding
```xml
<property name="validateOnlyOverlapping" value="false"/>
``` 
enforces the same behavior as before.

Thanks @Huyuntj for finding out!

- Fixes all the violations that sneaked in in the mean time.
- Updates code ordering when it was not alphabetical

### Potential Impact:

No impact, code style and readability only.

### Unit Test Approach:

Use same tests

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)