### PR TITLE
Added an option name to option mapping

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/parsing/SimpleOptionAndArgumentParser.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/parsing/SimpleOptionAndArgumentParser.java
@@ -206,20 +206,19 @@ public class SimpleOptionAndArgumentParser
         }
     }
 
-    private static final String MUST_REGISTER_AT_LEAST_ONE_CONTEXT = "Must register at least one context.";
-
-    private static final String PROVIDED_OPTION_LONG_FORM_WAS_AMBIGUOUS = "provided option long form {} was ambiguous";
-    private static final String CANNOT_GET_OPTIONS_BEFORE_PARSING = "Cannot get options before parsing!";
-
-    private static final Logger logger = LoggerFactory
-            .getLogger(SimpleOptionAndArgumentParser.class);
-
     public static final String LONG_FORM_PREFIX = "--";
     public static final String SHORT_FORM_PREFIX = "-";
     public static final String OPTION_ARGUMENT_DELIMITER = "=";
     public static final String END_OPTIONS_OPERATOR = "--";
 
     public static final int NO_CONTEXT = 0;
+
+    private static final String MUST_REGISTER_AT_LEAST_ONE_CONTEXT = "Must register at least one context.";
+    private static final String PROVIDED_OPTION_LONG_FORM_WAS_AMBIGUOUS = "provided option long form {} was ambiguous";
+    private static final String CANNOT_GET_OPTIONS_BEFORE_PARSING = "Cannot get options before parsing!";
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(SimpleOptionAndArgumentParser.class);
 
     private final Map<Integer, Set<SimpleOption>> contextToRegisteredOptions;
     private final Map<Integer, Map<String, ArgumentArity>> contextToArgumentHintToArity;
@@ -352,6 +351,24 @@ public class SimpleOptionAndArgumentParser
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Get a mapping from option names to {@link SimpleOption}s.
+     *
+     * @return the mapping
+     */
+    public Map<String, SimpleOption> getOptionNameToRegisteredOption()
+    {
+        final Set<SimpleOption> allOptions = getRegisteredOptions();
+        final Map<String, SimpleOption> map = new HashMap<>();
+
+        for (final SimpleOption option : allOptions)
+        {
+            map.put(option.getLongForm(), option);
+        }
+
+        return map;
     }
 
     /**
@@ -1377,18 +1394,6 @@ public class SimpleOptionAndArgumentParser
         this.registeredContexts.add(context);
     }
 
-    private Optional<SimpleOption> registeredOptionForLongForm(final int context,
-            final String longForm) throws AmbiguousAbbreviationException
-    {
-        return checkForLongOption(longForm, this.contextToRegisteredOptions.get(context), true);
-    }
-
-    private Optional<SimpleOption> registeredOptionForShortForm(final int context,
-            final Character shortForm)
-    {
-        return checkForShortOption(shortForm, this.contextToRegisteredOptions.get(context));
-    }
-
     private void registerOptionHelper(final int context, final String longForm,
             final Character shortForm, final String description,
             final OptionOptionality optionality, final OptionArgumentType type,
@@ -1406,6 +1411,18 @@ public class SimpleOptionAndArgumentParser
         this.contextToRegisteredOptions.put(context, registeredOptionsForContext);
 
         this.registeredContexts.add(context);
+    }
+
+    private Optional<SimpleOption> registeredOptionForLongForm(final int context,
+            final String longForm) throws AmbiguousAbbreviationException
+    {
+        return checkForLongOption(longForm, this.contextToRegisteredOptions.get(context), true);
+    }
+
+    private Optional<SimpleOption> registeredOptionForShortForm(final int context,
+            final Character shortForm)
+    {
+        return checkForShortOption(shortForm, this.contextToRegisteredOptions.get(context));
     }
 
     private void throwIfArgumentHintSeen(final String hint)

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/SimpleOptionAndArgumentParserTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/SimpleOptionAndArgumentParserTest.java
@@ -64,6 +64,29 @@ public class SimpleOptionAndArgumentParserTest
         }
     }
 
+    @Test(expected = UnparsableContextException.class)
+    public void testMultipleParseContextUnparsable() throws UnparsableContextException
+    {
+        final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser();
+        parser.registerOption("opt1", 'a', "an option", OptionOptionality.OPTIONAL, 1);
+        parser.registerOption("opt2", 'b', "an option", OptionOptionality.OPTIONAL, 1);
+        parser.registerOption("opt3", 'c', "an option", OptionOptionality.OPTIONAL, 2);
+        parser.registerArgument("single1", ArgumentArity.UNARY, ArgumentOptionality.REQUIRED, 2);
+        parser.registerOptionWithRequiredArgument("opt4", 'd', "an option",
+                OptionOptionality.OPTIONAL, "hint", 3);
+        parser.registerArgument("single2", ArgumentArity.UNARY, ArgumentOptionality.OPTIONAL, 3);
+
+        final List<String> arguments = Arrays.asList("--opt2", "--opt3");
+        try
+        {
+            parser.parse(arguments);
+        }
+        catch (AmbiguousAbbreviationException | UnknownOptionException e)
+        {
+            Assert.fail(e.getMessage());
+        }
+    }
+
     @Test
     public void testMultipleParseContexts()
     {
@@ -127,29 +150,6 @@ public class SimpleOptionAndArgumentParserTest
         Assert.assertEquals("optarg", parser.getOptionArgument("opt4").get());
         Assert.assertFalse(parser.getUnaryArgument("single1").isPresent());
         Assert.assertFalse(parser.getUnaryArgument("single2").isPresent());
-    }
-
-    @Test(expected = UnparsableContextException.class)
-    public void testMultipleParseContextUnparsable() throws UnparsableContextException
-    {
-        final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser();
-        parser.registerOption("opt1", 'a', "an option", OptionOptionality.OPTIONAL, 1);
-        parser.registerOption("opt2", 'b', "an option", OptionOptionality.OPTIONAL, 1);
-        parser.registerOption("opt3", 'c', "an option", OptionOptionality.OPTIONAL, 2);
-        parser.registerArgument("single1", ArgumentArity.UNARY, ArgumentOptionality.REQUIRED, 2);
-        parser.registerOptionWithRequiredArgument("opt4", 'd', "an option",
-                OptionOptionality.OPTIONAL, "hint", 3);
-        parser.registerArgument("single2", ArgumentArity.UNARY, ArgumentOptionality.OPTIONAL, 3);
-
-        final List<String> arguments = Arrays.asList("--opt2", "--opt3");
-        try
-        {
-            parser.parse(arguments);
-        }
-        catch (AmbiguousAbbreviationException | UnknownOptionException e)
-        {
-            Assert.fail(e.getMessage());
-        }
     }
 
     @Test
@@ -359,6 +359,23 @@ public class SimpleOptionAndArgumentParserTest
 
         Assert.assertEquals("newArg", parser.getOptionArgument("opt1").get());
         Assert.assertFalse(parser.getOptionArgument("opt2").isPresent());
+    }
+
+    @Test
+    public void testOptionMap()
+    {
+        final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser();
+        parser.registerOption("opt1", 'a', "the 1st option", OptionOptionality.OPTIONAL, 1);
+        parser.registerOptionWithRequiredArgument("opt2", 'b', "the 2nd option",
+                OptionOptionality.OPTIONAL, "ARG", 1);
+        parser.registerOption("opt3", 'c', "the 3rd option", OptionOptionality.OPTIONAL, 1);
+
+        Assert.assertEquals("the 1st option",
+                parser.getOptionNameToRegisteredOption().get("opt1").getDescription());
+        Assert.assertEquals("the 2nd option",
+                parser.getOptionNameToRegisteredOption().get("opt2").getDescription());
+        Assert.assertEquals("the 3rd option",
+                parser.getOptionNameToRegisteredOption().get("opt3").getDescription());
     }
 
     @Test


### PR DESCRIPTION
### Description:

Clients of `SimpleOptionAndArgumentParser` can now fetch the underlying `SimpleOption` objects by providing the long option string.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)