### PR TITLE
Update area filter to allow in certain piers and footways

### DIFF
--- a/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
+++ b/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-area.json
@@ -1,8 +1,8 @@
 {
     "filters": [
-        "highway->platform,bus_stop,rest_area|highway->pedestrian&area->yes|highway->!",
+        "highway->platform,bus_stop,rest_area|highway->pedestrian,footway&area->yes|highway->!",
         "railway->!|railway->platform,traverser,station",
         "route->!ferry",
-        "man_made->!pier"
+        "man_made->!pier|man_made->pier&area->yes"
     ]
 }


### PR DESCRIPTION
### Description:

Following PR #434 which allowed certain types of pedestrian highways tagged as `area=yes` to be both Areas and Edges, this PR updates the default Area filter to allow in certain `highway=footway` and `man_made=pier,area=yes` entities to also be Areas. 

### Potential Impact:
Minimal-- some entities will now be added to Areas where previously they were only Edges. 

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)