### PR TITLE
Reverted issue with country to shard listing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
@@ -58,9 +58,8 @@ public class CountryToShardListing extends Command
         try (SafeBufferedWriter writer = output.writer())
         {
             CountryShardListing.countryToShardList(countries, boundaries, sharding)
-                    .forEach((country, shardSet) -> shardSet.forEach(
-                            shard -> writer.writeLine(new CountryShard(country, shard).toString()
-                                    + " " + new CountryShard(country, shard).bounds())));
+                    .forEach((country, shardSet) -> shardSet.forEach(shard -> writer
+                            .writeLine(new CountryShard(country, shard).toString())));
         }
         catch (final Exception e)
         {


### PR DESCRIPTION
### Description:
This PR reverts a change to the country to shard listing functionality that was including shard bounding boxes by mistake.

### Potential Impact:
N/A

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
