### PR TITLE
ID generator no longer takes bounds into account for CompleteRelations

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -70,7 +70,7 @@ public class EntityIdentifierGenerator
     String getBasicPropertyString(final CompleteEntity<?> entity)
     {
         final String wkt = entity.toWkt();
-        if (wkt == null)
+        if (wkt == null && !(entity instanceof CompleteRelation))
         {
             throw new CoreException("Geometry must be set for entity {}", entity.prettify());
         }


### PR DESCRIPTION
### Description:

Previously, the `EntityIdentifierGenerator` would complain if a `CompleteRelation` did not provide bounds. However, computing the bounds of a `CompleteRelation` may be difficult in some cases. So now the generator skips using WKT for relations. Instead it uses only the tags and the member list, which should be sufficient for distinguishing relations.

### Potential Impact:

N/A

### Unit Test Approach:

Ran same test suite.

### Test Results:

Tests still pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)