### PR TITLE
Added BUS_TRAP as a new BarrierTag type

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/BarrierTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/BarrierTag.java
@@ -47,7 +47,8 @@ public enum BarrierTag
     DOOR,
     HAMPSHIRE_GATE,
     WOOD_FENCE,
-    BUMP_GATE;
+    BUMP_GATE,
+    BUS_TRAP;
 
     @TagKey
     public static final String KEY = "barrier";
@@ -56,7 +57,7 @@ public enum BarrierTag
             BOLLARD, LIFT_GATE, RETAINING_WALL, STILE, CYCLE_BARRIER, KERB, YES, ENTRANCE, BLOCK,
             TOLL_BOOTH, CATTLE_GRID, DITCH, KISSING_GATE, CITY_WALL, GUARD_RAIL, HEDGE_BANK,
             WIRE_FENCE, LINE, SWING_GATE, CHAIN, TURNSTILE, EMBANKMENT, FIELD_BOUNDARY,
-            BORDER_CONTROL, SALLY_PORT, DOOR, HAMPSHIRE_GATE, WOOD_FENCE, BUMP_GATE);
+            BORDER_CONTROL, SALLY_PORT, DOOR, HAMPSHIRE_GATE, WOOD_FENCE, BUMP_GATE, BUS_TRAP);
 
     public static boolean isBarrier(final Taggable taggable)
     {

--- a/src/test/java/org/openstreetmap/atlas/tags/BarrierTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/BarrierTagTestCase.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+
+/**
+ * Test for {@link org.openstreetmap.atlas.tags.BarrierTag}
+ *
+ * @author alexhsieh
+ */
+public class BarrierTagTestCase
+{
+    @Test
+    public void busTrapIsBlockingTestCase()
+    {
+        final Taggable taggable = Taggable.with("barrier", "bus_trap");
+        Assert.assertTrue(BarrierTag.isBarrier(taggable));
+    }
+
+    @Test
+    public void busTrapTestCase()
+    {
+        final Taggable taggable = Taggable.with("barrier", "bus_trap");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, BarrierTag.class));
+    }
+}


### PR DESCRIPTION
### Description:
Added bus_trap to the BarrierTag enum list.  

The uses of barrier=bus_trap can be found here: https://taginfo.openstreetmap.org/keys/barrier#values 
It is mentioned in the OSM wiki: https://wiki.openstreetmap.org/wiki/Key:barrier

### Potential Impact:
Minimal impact.  If anyone is using the BarrierTag::isBarrier, there's  new data that could be considered a barrier now (anything tagged with barrier=bus_trap).

### Unit Test Approach:
Added test case to make sure barrier=bus_trap gets picked up as a barrier and a blocking barrier properly.

### Test Results:
All current unit tests as well as new unit tests have passed locally.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)