### PR TITLE
Fix Sonar Warning about Jacoco

### DIFF
--- a/.travis/sonar.sh
+++ b/.travis/sonar.sh
@@ -7,7 +7,7 @@ then
 	echo "sonar.pullrequest.key=$TRAVIS_PULL_REQUEST"
 	echo "sonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH"
 	echo "sonar.pullrequest.base=$TRAVIS_BRANCH"
-	./gradlew sonarqube \
+	./gradlew jacocoTestReport sonarqube \
 		-Dsonar.organization=osmlab \
 		-Dsonar.host.url=https://sonarcloud.io \
 		-Dsonar.login=$SONAR_TOKEN \
@@ -22,7 +22,7 @@ then
 		-Dsonar.pullrequest.github.token.secured=$SONAR_PR_DECORATION_GITHUB_TOKEN
 else
 	echo "Running sonarqube in a regular build"
-	./gradlew sonarqube \
+	./gradlew jacocoTestReport sonarqube \
 		-Dsonar.branch.name=$TRAVIS_BRANCH \
 		-Dsonar.organization=osmlab \
 		-Dsonar.host.url=https://sonarcloud.io \

--- a/.travis/sonar.sh
+++ b/.travis/sonar.sh
@@ -12,7 +12,7 @@ then
 		-Dsonar.host.url=https://sonarcloud.io \
 		-Dsonar.login=$SONAR_TOKEN \
 		-Dsonar.junit.reportPaths=build/test-results/test \
-		-Dsonar.jacoco.reportPaths=build/jacoco/test.exec \
+		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml \
 		-Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST \
 		-Dsonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH \
 		-Dsonar.pullrequest.base=$TRAVIS_BRANCH \
@@ -28,5 +28,5 @@ else
 		-Dsonar.host.url=https://sonarcloud.io \
 		-Dsonar.login=$SONAR_TOKEN \
 		-Dsonar.junit.reportPaths=build/test-results/test \
-		-Dsonar.jacoco.reportPaths=build/jacoco/test.exec
+		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,8 @@ plugins {
 	id 'checkstyle'
 	id 'jacoco'
 	id "com.diffplug.gradle.spotless" version "3.18.0"
-	id 'org.sonarqube' version '2.6.2'
+	id 'org.sonarqube' version '2.7.1'
 	id 'com.google.protobuf' version '0.8.8'
-	// id "io.codearte.nexus-staging" version "0.12.0"
 }
 
 apply from: 'dependencies.gradle'

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -1,5 +1,11 @@
-jacoco {
+jacoco
+{
     toolVersion = versions.jacoco
+}
+
+checkstyle
+{
+    toolVersion = versions.checkstyle
 }
 
 sourceSets
@@ -37,8 +43,16 @@ task integrationTest(type: Test) {
     }
 }
 
+// Those 3 for atlas only here because ArrangementCheck is already in Atlas and 
+// Gradle does not allow third party dependency of itself.
+checkstyleMain.dependsOn jar
+checkstyleTest.dependsOn jar
+checkstyleIntegrationTest.dependsOn jar
+
 check.dependsOn integrationTest
 integrationTest.mustRunAfter test
+
+sonarqube.dependsOn jacocoTestReport
 
 tasks.withType(Test) {
     reports.html.destination = file("${reporting.baseDir}/${name}")
@@ -55,6 +69,7 @@ dependencies
     testCompile packages.slf4j.log4j12
     testCompile packages.log4j
     testCompile packages.junit
+
     integrationTestCompile packages.junit
 }
 
@@ -90,9 +105,4 @@ sonarqube {
     properties {
         property "sonar.exclusions", "src/generated/**/*.java"
     }
-}
-
-checkstyle
-{
-    toolVersion = versions.checkstyle
 }

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -43,7 +43,7 @@ task integrationTest(type: Test) {
     }
 }
 
-// Those 3 for atlas only here because ArrangementCheck is already in Atlas and 
+// Those 3 for atlas only here because ArrangementCheck is already in Atlas and
 // Gradle does not allow third party dependency of itself.
 checkstyleMain.dependsOn jar
 checkstyleTest.dependsOn jar
@@ -52,7 +52,7 @@ checkstyleIntegrationTest.dependsOn jar
 check.dependsOn integrationTest
 integrationTest.mustRunAfter test
 
-sonarqube.dependsOn jacocoTestReport
+check.dependsOn jacocoTestReport
 
 tasks.withType(Test) {
     reports.html.destination = file("${reporting.baseDir}/${name}")


### PR DESCRIPTION
### Description:

Sonar had a warning:

> Property 'sonar.jacoco.reportPaths' is deprecated (JaCoCo binary format). 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).

This PR enables XML for Jacoco test reports, and lets Sonar read it.

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)