### PR TITLE
Ignore slow integration tests while better solution thought out

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -14,9 +14,7 @@ fi
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ];
 then
-	echo "Skip integration tests in pull request builds"
-	./gradlew clean build -x integrationTest
+	./gradlew clean build
 else
-	echo "Temporarily skip integration tests in all builds. Too heavy for Travis"
-	./gradlew clean build -x integrationTest
+	./gradlew clean build
 fi

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/PolygonPerformanceTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/PolygonPerformanceTest.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openstreetmap.atlas.utilities.scalars.Duration;
 import org.openstreetmap.atlas.utilities.time.Time;
@@ -69,6 +70,7 @@ public class PolygonPerformanceTest
                 overallTotalTimeWithBoundCheck, overallTotalTimeWithoutBoundCheck, iteration);
     }
 
+    @Ignore
     @Test
     public void testPerformance() throws Exception
     {

--- a/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/geography/atlas/raw/RawAtlasIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Location;
@@ -40,14 +41,14 @@ import org.slf4j.LoggerFactory;
  */
 public class RawAtlasIntegrationTest
 {
-    private static AtlasLoadingOption loadingOptionAll;
-    private static AtlasLoadingOption loadingOptionAntarctica;
-    private static AtlasLoadingOption loadingOptionIvoryCoast;
+    private static final AtlasLoadingOption loadingOptionAll;
+    private static final AtlasLoadingOption loadingOptionAntarctica;
+    private static final AtlasLoadingOption loadingOptionIvoryCoast;
 
-    private static AtlasLoadingOption loadingOptionIntersectionAtEnd;
-    private static AtlasLoadingOption loadingOptionIntersectionAtStart;
+    private static final AtlasLoadingOption loadingOptionIntersectionAtEnd;
+    private static final AtlasLoadingOption loadingOptionIntersectionAtStart;
 
-    private static AtlasLoadingOption loadingOptionIntersectionAtMiddle;
+    private static final AtlasLoadingOption loadingOptionIntersectionAtMiddle;
 
     private static final long LINE_OSM_IDENTIFIER_CROSSING_3_SHARDS = 541706;
 
@@ -176,6 +177,7 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(20, atlasFromz7x62y61.numberOfEdges());
     }
 
+    @Ignore
     @Test
     public void testPbfToSlicedRawAtlas()
     {
@@ -233,6 +235,7 @@ public class RawAtlasIntegrationTest
         Assert.assertEquals(23, finalAtlas.numberOfRelations());
     }
 
+    @Ignore
     @Test
     public void testSectioningFromShard()
     {


### PR DESCRIPTION
### Description:

Some integration tests took several minutes to complete processing complicated geometry checks, which is too heavy for CI tools. While we figure out ways to make those faster, we will be ignoring those tests.

### Potential Impact:

Reduces our test coverage slightly, but allows most other integration tests to be run at pull-request time.
Run time is now <2 mins for integration tests.

### Unit Test Approach:

Will run in travis/circleci

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
