### PR TITLE
CircleCI: Sonar and PyAtlas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,15 @@ jobs:
 
     steps:
       - checkout
-      - run: if [ -z "$SONAR_TOKEN" ]; then echo "SONAR_TOKEN missing"; else echo "SONAR_TOKEN is here"; fi
-      - run: echo $SONAR_TOKEN
+      # - run: if [ -z "$SONAR_TOKEN" ]; then echo "SONAR_TOKEN missing"; else echo "SONAR_TOKEN is here"; fi
+      # - run: echo $SONAR_TOKEN
       # Run jar first, as the checkstyle plugin depends on atlas itself here.
-      - run: ./gradlew jar
-      - run: ./gradlew check -x test -x integrationTest
       - run:
+          name: Quality checks (No tests)
+          command: ./gradlew jar check -x test -x integrationTest
+      - run:
+          name: Tests
           command: ./gradlew check
           no_output_timeout: 30m
-      - run: .circleci/sonar.sh
+      # - run: .circleci/sonar.sh
       # - run: ./gradlew cleanPyatlas buildPyatlas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - checkout
+      - run: if [ -z "$SONAR_TOKEN" ]; then echo "SONAR_TOKEN missing"; else echo "SONAR_TOKEN is here"; fi
       # Run jar first, as the checkstyle plugin depends on atlas itself here.
       - run: ./gradlew jar
       - run: ./gradlew check -x test -x integrationTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - checkout
       - run: if [ -z "$SONAR_TOKEN" ]; then echo "SONAR_TOKEN missing"; else echo "SONAR_TOKEN is here"; fi
+      - run: echo $SONAR_TOKEN
       # Run jar first, as the checkstyle plugin depends on atlas itself here.
       - run: ./gradlew jar
       - run: ./gradlew check -x test -x integrationTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,4 @@ jobs:
           command: ./gradlew check
           no_output_timeout: 30m
       - run: .circleci/sonar.sh
-      - run: ./gradlew cleanPyatlas buildPyatlas
+      # - run: ./gradlew cleanPyatlas buildPyatlas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,5 @@ jobs:
       - run:
           command: ./gradlew check
           no_output_timeout: 30m
+      - run: .circleci/sonar.sh
+      - run: ./gradlew cleanPyatlas buildPyatlas

--- a/.circleci/sonar.sh
+++ b/.circleci/sonar.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+if [ -z "$CIRCLE_PR_NUMBER" ];
+then
+    echo "Running sonarqube in a regular build"
+	#TODO: Remove echo below
+	echo ./gradlew jacocoTestReport sonarqube \
+		-Dsonar.branch.name=$CIRCLE_BRANCH \
+		-Dsonar.organization=osmlab \
+		-Dsonar.host.url=https://sonarcloud.io \
+		-Dsonar.login=$SONAR_TOKEN \
+		-Dsonar.junit.reportPaths=build/test-results/test \
+		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+else
+    CIRCLE_PR_BRANCH=`curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER | jq -r '.head.ref'`
+	SONAR_PULLREQUEST_BRANCH="$CIRCLE_PR_USERNAME/$CIRCLE_PR_BRANCH"
+	echo "Running sonarqube in Pull Request $CIRCLE_PR_NUMBER"
+	echo "sonar.pullrequest.key=$CIRCLE_PR_NUMBER"
+	echo "sonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH"
+	echo "sonar.pullrequest.base=$CIRCLE_BRANCH"
+	#TODO: Remove echo below
+	echo ./gradlew jacocoTestReport sonarqube \
+		-Dsonar.organization=osmlab \
+		-Dsonar.host.url=https://sonarcloud.io \
+		-Dsonar.login=$SONAR_TOKEN \
+		-Dsonar.junit.reportPaths=build/test-results/test \
+		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml \
+		-Dsonar.pullrequest.key=$CIRCLE_PR_NUMBER \
+		-Dsonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH \
+		-Dsonar.pullrequest.base=$CIRCLE_BRANCH \
+		-Dsonar.pullrequest.provider=github \
+		-Dsonar.pullrequest.github.repository=osmlab/atlas \
+		-Dsonar.pullrequest.github.endpoint=https://api.github.com/ \
+		-Dsonar.pullrequest.github.token.secured=$SONAR_PR_DECORATION_GITHUB_TOKEN
+fi

--- a/.circleci/sonar.sh
+++ b/.circleci/sonar.sh
@@ -3,6 +3,7 @@
 if [ -z "$CIRCLE_PR_NUMBER" ];
 then
     echo "Running sonarqube in a regular build"
+    echo "sonar.branch.name=$CIRCLE_BRANCH"
 	#TODO: Remove echo below
 	echo ./gradlew jacocoTestReport sonarqube \
 		-Dsonar.branch.name=$CIRCLE_BRANCH \
@@ -13,11 +14,12 @@ then
 		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 else
     CIRCLE_PR_BRANCH=`curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER | jq -r '.head.ref'`
+    CIRCLE_PR_TARGET_BRANCH=`curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER | jq -r '.base.ref'`
 	SONAR_PULLREQUEST_BRANCH="$CIRCLE_PR_USERNAME/$CIRCLE_PR_BRANCH"
 	echo "Running sonarqube in Pull Request $CIRCLE_PR_NUMBER"
 	echo "sonar.pullrequest.key=$CIRCLE_PR_NUMBER"
 	echo "sonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH"
-	echo "sonar.pullrequest.base=$CIRCLE_BRANCH"
+	echo "sonar.pullrequest.base=$CIRCLE_PR_TARGET_BRANCH"
 	#TODO: Remove echo below
 	echo ./gradlew jacocoTestReport sonarqube \
 		-Dsonar.organization=osmlab \
@@ -27,7 +29,7 @@ else
 		-Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml \
 		-Dsonar.pullrequest.key=$CIRCLE_PR_NUMBER \
 		-Dsonar.pullrequest.branch=$SONAR_PULLREQUEST_BRANCH \
-		-Dsonar.pullrequest.base=$CIRCLE_BRANCH \
+		-Dsonar.pullrequest.base=$CIRCLE_PR_TARGET_BRANCH \
 		-Dsonar.pullrequest.provider=github \
 		-Dsonar.pullrequest.github.repository=osmlab/atlas \
 		-Dsonar.pullrequest.github.endpoint=https://api.github.com/ \


### PR DESCRIPTION
### Description:

Add more elements to the CircleCI build:
- Build PyAtlas
- Run Sonar

Those are still disabled as there is not any good way (to the best of my knowledge) to hand over secrets to PR builds in circleci. (Like when travis sends the secrets to PR builds but makes them invisible in logs)

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)