### PR TITLE
AtlasChangeGenerator to enforce Node location

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -76,11 +76,12 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
                     newBounds = newBounds.combine(bounds);
                 }
             }
-            CompleteNode newCompleteNode = originalCompleteNode.withBoundsExtendedBy(newBounds);
+            CompleteNode newCompleteNode = originalCompleteNode;
             if (originalCompleteNode.getLocation() == null && originalNode != null)
             {
                 newCompleteNode = newCompleteNode.withLocation(originalNode.getLocation());
             }
+            newCompleteNode.withBoundsExtendedBy(newBounds);
             final FeatureChange newFeatureChange = new FeatureChange(featureChange.getChangeType(),
                     newCompleteNode);
             result.add(newFeatureChange);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGenerator.java
@@ -76,8 +76,13 @@ public interface AtlasChangeGenerator extends Converter<Atlas, Set<FeatureChange
                     newBounds = newBounds.combine(bounds);
                 }
             }
+            CompleteNode newCompleteNode = originalCompleteNode.withBoundsExtendedBy(newBounds);
+            if (originalCompleteNode.getLocation() == null && originalNode != null)
+            {
+                newCompleteNode = newCompleteNode.withLocation(originalNode.getLocation());
+            }
             final FeatureChange newFeatureChange = new FeatureChange(featureChange.getChangeType(),
-                    originalCompleteNode.withBoundsExtendedBy(newBounds));
+                    newCompleteNode);
             result.add(newFeatureChange);
         }
         return result;

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -13,6 +13,7 @@ import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
 
@@ -25,6 +26,28 @@ public class AtlasChangeGeneratorTest
 
     @Rule
     public final AtlasChangeGeneratorTestRule rule = new AtlasChangeGeneratorTestRule();
+
+    @Test
+    public void testAddLocation()
+    {
+        final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
+        final Set<FeatureChange> result = new HashSet<>();
+        for (final Node node : source.nodes())
+        {
+            final CompleteNode completeNode = CompleteNode.shallowFrom(node)
+                    .withTags(node.getTags());
+            result.add(FeatureChange.add(completeNode));
+        }
+        final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
+        for (final FeatureChange featureChange : changes)
+        {
+            if (featureChange.getIdentifier() == 177633000000L)
+            {
+                Assert.assertEquals(Location.forWkt("POINT (4.2194855 38.8231656)"),
+                        ((CompleteNode) featureChange.getAfterView()).getLocation());
+            }
+        }
+    }
 
     @Test
     public void testEmptyChange()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -45,6 +45,10 @@ public class AtlasChangeGeneratorTest
             {
                 Assert.assertEquals(Location.forWkt("POINT (4.2194855 38.8231656)"),
                         ((CompleteNode) featureChange.getAfterView()).getLocation());
+                Assert.assertEquals(
+                        "POLYGON ((4.2177433 38.8228217, 4.2177433 38.8235147, 4.2197697 38.8235147,"
+                                + " 4.2197697 38.8228217, 4.2177433 38.8228217))",
+                        featureChange.bounds().toWkt());
             }
         }
     }


### PR DESCRIPTION
### Description:

This is to enforce the presence of a location in `FeatureChange` objects for `Node`s. Since their bounding box is altered, this is to make for easier debugging: get the original node's location.

### Potential Impact:

Not much, slightly larger geojson representation.

### Unit Test Approach:

Added one new unit test.

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
