### PR TITLE
Added a special exception for FeatureChange merge failures

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -12,7 +12,7 @@ public class FeatureChangeMergeException extends CoreException
 {
     private static final long serialVersionUID = -3583945839922744755L;
 
-    private final transient MergeFailureType failureType;
+    private final MergeFailureType failureType;
 
     public FeatureChangeMergeException(final MergeFailureType failureType, final String message)
     {

--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -1,0 +1,34 @@
+package org.openstreetmap.atlas.exception.change;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+
+/**
+ * A special exception for {@link FeatureChange} merge errors.
+ * 
+ * @author lcram
+ */
+public class FeatureChangeMergeException extends CoreException
+{
+    private static final long serialVersionUID = -3583945839922744755L;
+
+    private final transient MergeFailureType failureType;
+
+    public FeatureChangeMergeException(final MergeFailureType failureType, final String message)
+    {
+        super(message);
+        this.failureType = failureType;
+    }
+
+    public FeatureChangeMergeException(final MergeFailureType failureType, final String message,
+            final Object... arguments)
+    {
+        super(message, arguments);
+        this.failureType = failureType;
+    }
+
+    public MergeFailureType getFailureType()
+    {
+        return this.failureType;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.exception.change;
+
+/**
+ * @author lcram
+ */
+public enum MergeFailureType
+{
+    AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that ignores beforeView) failed"),
+    AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that assumes consistent beforeViews) failed"),
+    AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that accounts for conflicting beforeViews) failed"),
+    BEFORE_VIEW_MERGE_STRATEGY_FAILED("the beforeView merging function failed"),
+    MISSING_BEFORE_VIEW_MERGE_STRATEGY(
+            "beforeMembers conflict and no beforeView merging strategy provided"),
+    MISSING_AFTER_VIEW_MERGE_STRATEGY_WITH_BEFORE_MEMBER_CONFLICT_HANDLING(
+            "beforeMembers conflict and no beforeView-conflict-capable afterView merging strategy"),
+    MISSING_AFTER_VIEW_MERGE_STRATEGY(
+            "afterMembers conflict and no afterView merging strategy provided");
+
+    private final String description;
+
+    MergeFailureType(final String description)
+    {
+        this.description = description;
+    }
+
+    public String getDescription()
+    {
+        return this.description;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -7,9 +7,14 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.exception.change.FeatureChangeMergeException;
+import org.openstreetmap.atlas.exception.change.MergeFailureType;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
 import org.slf4j.Logger;
@@ -269,7 +274,7 @@ public final class MemberMerger<M>
         /*
          * In the case that both afterMembers are present, then we will need to resolve the
          * afterMember merge using one of the supplied merge strategies. In this case, beforeMembers
-         * that are either consistent or both null - so we can use the merged beforeMemberResult.
+         * are either consistent or both null - so we can use the merged beforeMemberResult.
          */
         if (afterMemberLeft != null && afterMemberRight != null)
         {
@@ -379,7 +384,8 @@ public final class MemberMerger<M>
 
         if (this.beforeViewMerger == null)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.MISSING_BEFORE_VIEW_MERGE_STRATEGY,
                     "Conflicting beforeMembers {} and no beforeView merge strategy was provided; beforeView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight);
         }
@@ -390,7 +396,8 @@ public final class MemberMerger<M>
         }
         catch (final Exception exception)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                     "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight, exception);
         }
@@ -410,7 +417,8 @@ public final class MemberMerger<M>
         }
         catch (final Exception exception)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                     "Tried merge strategy for hackForConflictingConnectedEdgeSet, but it failed for {}"
                             + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
@@ -444,7 +452,8 @@ public final class MemberMerger<M>
 
         if (this.afterViewConflictingBeforeViewMerger == null)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.MISSING_AFTER_VIEW_MERGE_STRATEGY_WITH_BEFORE_MEMBER_CONFLICT_HANDLING,
                     "Conflicting beforeMembers {} and no afterView merge strategy capable of handling"
                             + " conflicting beforeViews was provided; beforeView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight);
@@ -452,7 +461,8 @@ public final class MemberMerger<M>
 
         if (this.beforeViewMerger == null)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.MISSING_BEFORE_VIEW_MERGE_STRATEGY,
                     "Conflicting beforeMembers {} and no beforeView merge strategy was provided; beforeView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight);
         }
@@ -463,7 +473,8 @@ public final class MemberMerger<M>
         }
         catch (final Exception exception)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                     "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight, exception);
         }
@@ -475,7 +486,8 @@ public final class MemberMerger<M>
         }
         catch (final Exception exception)
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                     "Tried merge strategy for handling conflicting beforeViews. but it failed for {}"
                             + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
                     this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
@@ -524,7 +536,8 @@ public final class MemberMerger<M>
             }
             catch (final Exception exception)
             {
-                throw new CoreException(
+                throw new FeatureChangeMergeException(
+                        MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                         "Attempted afterViewConsistentBeforeMerge failed for {} with beforeView: {}; afterView: {} vs {}",
                         this.memberName, beforeMemberResult, afterMemberLeft, afterMemberRight,
                         exception);
@@ -543,7 +556,8 @@ public final class MemberMerger<M>
             }
             catch (final CoreException exception)
             {
-                throw new CoreException(
+                throw new FeatureChangeMergeException(
+                        MergeFailureType.AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
                         "Attempted afterViewNoBeforeMerge failed for {}; afterView: {} vs {}",
                         this.memberName, afterMemberLeft, afterMemberRight, exception);
             }
@@ -553,7 +567,8 @@ public final class MemberMerger<M>
          */
         else
         {
-            throw new CoreException(
+            throw new FeatureChangeMergeException(
+                    MergeFailureType.MISSING_AFTER_VIEW_MERGE_STRATEGY,
                     "Conflicting members and no merge strategy for {}; afterView: {} vs {}",
                     this.memberName, afterMemberLeft, afterMemberRight);
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/TagChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/TagChangeTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.exception.change.FeatureChangeMergeException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteItemType;
@@ -147,7 +148,7 @@ public class TagChangeTest
             catch (final CoreException e)
             {
                 Assert.assertTrue(e.getMessage().startsWith("Cannot merge two feature changes"));
-                Assert.assertEquals(e.getCause().getClass(), CoreException.class);
+                Assert.assertEquals(e.getCause().getClass(), FeatureChangeMergeException.class);
                 Assert.assertTrue(e.getCause().getMessage()
                         .contains("Attempted afterViewNoBeforeMerge failed for tags; afterView:"));
                 return;


### PR DESCRIPTION
### Description:
`FeatureChange` merge failures now throw a special exception type that also contains an enum detailing what type of merge failure occurred.

### Potential Impact:
N/A as is, but downstream code will have an easier time inspecting and handling merge errors

### Unit Test Approach:
Updated some tests to handle the new exception type

### Test Results:
Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
