### PR TITLE
Implemented more robust FeatureChangeMergeException mechanics

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A special exception for {@link FeatureChange} merge errors.
@@ -16,8 +14,6 @@ import org.slf4j.LoggerFactory;
 public class FeatureChangeMergeException extends CoreException
 {
     private static final long serialVersionUID = -3583945839922744755L;
-
-    private static final Logger logger = LoggerFactory.getLogger(FeatureChangeMergeException.class);
 
     private final List<MergeFailureType> failureTypeTrace;
 
@@ -152,13 +148,9 @@ public class FeatureChangeMergeException extends CoreException
             boolean foundSubSequenceThisIteration = true;
             for (int j = 0, tmpI = i; j < subSequence.size(); j++, tmpI++)
             {
-                // We hit the end of the failure trace early
-                if (tmpI >= this.failureTypeTrace.size())
-                {
-                    foundSubSequenceThisIteration = false;
-                    break;
-                }
-                if (subSequence.get(j) != this.failureTypeTrace.get(tmpI))
+                // We hit the end of the failure trace early or we found a sequence mismatch
+                if (tmpI >= this.failureTypeTrace.size()
+                        || subSequence.get(j) != this.failureTypeTrace.get(tmpI))
                 {
                     foundSubSequenceThisIteration = false;
                     break;

--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -1,7 +1,12 @@
 package org.openstreetmap.atlas.exception.change;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A special exception for {@link FeatureChange} merge errors.
@@ -12,23 +17,214 @@ public class FeatureChangeMergeException extends CoreException
 {
     private static final long serialVersionUID = -3583945839922744755L;
 
-    private final MergeFailureType failureType;
+    private static final Logger logger = LoggerFactory.getLogger(FeatureChangeMergeException.class);
 
-    public FeatureChangeMergeException(final MergeFailureType failureType, final String message)
+    private final List<MergeFailureType> failureTypeTrace;
+
+    public FeatureChangeMergeException(final List<MergeFailureType> failureTypeTrace,
+            final String message)
     {
         super(message);
-        this.failureType = failureType;
+        this.failureTypeTrace = failureTypeTrace;
+        if (this.failureTypeTrace == null || this.failureTypeTrace.isEmpty())
+        {
+            throw new CoreException("failureTypeTrace cannot be null or empty");
+        }
     }
 
-    public FeatureChangeMergeException(final MergeFailureType failureType, final String message,
-            final Object... arguments)
+    public FeatureChangeMergeException(final List<MergeFailureType> failureTypeTrace,
+            final String message, final Object... arguments)
     {
         super(message, arguments);
-        this.failureType = failureType;
+        this.failureTypeTrace = failureTypeTrace;
+        if (this.failureTypeTrace == null || this.failureTypeTrace.isEmpty())
+        {
+            throw new CoreException("failureTypeTrace cannot be null or empty");
+        }
     }
 
-    public MergeFailureType getFailureType()
+    public FeatureChangeMergeException(final MergeFailureType rootLevelFailure,
+            final String message, final Object... arguments)
     {
-        return this.failureType;
+        super(message, arguments);
+        if (rootLevelFailure == null)
+        {
+            throw new CoreException("rootLevelFailure cannot be null");
+        }
+        this.failureTypeTrace = new ArrayList<>();
+        this.failureTypeTrace.add(rootLevelFailure);
+    }
+
+    public FeatureChangeMergeException(final MergeFailureType rootLevelFailure,
+            final String message)
+    {
+        super(message);
+        if (rootLevelFailure == null)
+        {
+            throw new CoreException("rootLevelFailure cannot be null");
+        }
+        this.failureTypeTrace = new ArrayList<>();
+        this.failureTypeTrace.add(rootLevelFailure);
+    }
+
+    /**
+     * Return the {@link MergeFailureType} at the provided stack index. If the index is out of
+     * bounds, this will return the top level failure.
+     * 
+     * @param index
+     *            the index to check
+     * @return the {@link MergeFailureType} at the provided index, or the most top level failure if
+     *         the index is out of bounds
+     */
+    public MergeFailureType failureAtFrameIndex(final int index)
+    {
+        if (index >= this.failureTypeTrace.size())
+        {
+            return topLevelFailure();
+        }
+        return this.failureTypeTrace.get(index);
+    }
+
+    /**
+     * Get the number of {@link MergeFailureType}s in the failure trace.
+     *
+     * @return the number of {@link MergeFailureType}s in the failure trace
+     */
+    public int failureTraceSize()
+    {
+        return this.failureTypeTrace.size();
+    }
+
+    public List<MergeFailureType> getMergeFailureTrace()
+    {
+        return new ArrayList<>(this.failureTypeTrace);
+    }
+
+    /**
+     * Return the root level {@link MergeFailureType}. This is the bottom-most failure reason, and
+     * will generally be the most specific failure reason available for a given
+     * {@link FeatureChangeMergeException}.
+     *
+     * @return the root level {@link MergeFailureType}
+     */
+    public MergeFailureType rootLevelFailure()
+    {
+        return this.failureTypeTrace.get(0);
+    }
+
+    /**
+     * Return the top level {@link MergeFailureType}. This is the top-most failure reason, and will
+     * generally be the most general failure reason available for a given
+     * {@link FeatureChangeMergeException}.
+     *
+     * @return the top level {@link MergeFailureType}
+     */
+    public MergeFailureType topLevelFailure()
+    {
+        return this.failureTypeTrace.get(this.failureTypeTrace.size() - 1);
+    }
+
+    /**
+     * Check if the failure trace contains an exact failure sequence of {@link MergeFailureType}s,
+     * in level order from root to top. E.g. suppose the failure trace list is [root: A, B, C, D,
+     * top: E], and our provided subsequence is [A, B]. In this case, the method would return true.
+     * Now suppose the provided subsequence is [A, C]. Now, the method will return false. This
+     * method may be useful if callers want to check for and recover from a specific failure
+     * sequence.
+     *
+     * @param subSequence
+     *            the subsequence of {@link MergeFailureType}s to check
+     * @return if the subsequence is present
+     */
+    public boolean traceContainsExactFailureSequence(final List<MergeFailureType> subSequence)
+    {
+        if (subSequence.isEmpty())
+        {
+            return true;
+        }
+        if (subSequence.size() > this.failureTypeTrace.size())
+        {
+            return false;
+        }
+
+        for (int i = 0; i < this.failureTypeTrace.size(); i++)
+        {
+            boolean foundSubSequenceThisIteration = true;
+            for (int j = 0, tmpI = i; j < subSequence.size(); j++, tmpI++)
+            {
+                // We hit the end of the failure trace early
+                if (tmpI >= this.failureTypeTrace.size())
+                {
+                    foundSubSequenceThisIteration = false;
+                    break;
+                }
+                if (subSequence.get(j) != this.failureTypeTrace.get(tmpI))
+                {
+                    foundSubSequenceThisIteration = false;
+                    break;
+                }
+            }
+            if (foundSubSequenceThisIteration)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if this exception trace contains a {@link MergeFailureType} that matches the given
+     * type.
+     *
+     * @param type
+     *            the {@link MergeFailureType} for which to check
+     * @return true if the trace contains the provided type
+     */
+    public boolean traceContainsFailureType(final MergeFailureType type)
+    {
+        for (final MergeFailureType currentType : this.failureTypeTrace)
+        {
+            if (type == currentType)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if the failure trace matches exact failure sequence of {@link MergeFailureType}s, in
+     * level order from root to top.
+     *
+     * @param sequence
+     *            the sequence of {@link MergeFailureType}s to check
+     * @return if the sequence is matches exactly
+     */
+    public boolean traceMatchesExactFailureSequence(final List<MergeFailureType> sequence)
+    {
+        if (sequence == null)
+        {
+            return false;
+        }
+        if (sequence.size() != this.failureTypeTrace.size())
+        {
+            return false;
+        }
+        return this.failureTypeTrace.equals(sequence);
+    }
+
+    /**
+     * Add a new top-level {@link MergeFailureType} to the failure trace.
+     * 
+     * @param type
+     *            the {@link MergeFailureType} to add
+     * @return the modified trace
+     */
+    public List<MergeFailureType> withNewTopLevelFailure(final MergeFailureType type)
+    {
+        final List<MergeFailureType> newList = new ArrayList<>(this.failureTypeTrace);
+        newList.add(type);
+        return newList;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
@@ -15,9 +15,38 @@ public enum MergeFailureType
     MISSING_BEFORE_VIEW_MERGE_STRATEGY(
             "beforeMembers conflict and no beforeView merging strategy provided"),
     MISSING_AFTER_VIEW_MERGE_STRATEGY_WITH_BEFORE_MEMBER_CONFLICT_HANDLING(
-            "beforeMembers conflict and no beforeView-conflict-capable afterView merging strategy"),
+            "beforeMembers conflict and no beforeView-conflict-capable afterView merging strategy provided"),
     MISSING_AFTER_VIEW_MERGE_STRATEGY(
-            "afterMembers conflict and no afterView merging strategy provided");
+            "afterMembers conflict and no afterView merging strategy provided"),
+    SIMPLE_TAG_MERGE_FAIL("simpleTagMerger failed"),
+    SIMPLE_LONG_SET_MERGE_FAIL("simpleLongSetMerger failed"),
+    SIMPLE_LONG_SORTED_SET_MERGE_FAIL("simpleLongSortedSetMerger failed"),
+    SIMPLE_RELATION_BEAN_MERGE_FAIL("simpleRelationBeanMerger failed"),
+    DIFF_BASED_RELATION_BEAN_REMOVE_REMOVE_CONFLICT(
+            "diffBasedRelationBeanMerger failed due to REMOVE/REMOVE conflict"),
+    DIFF_BASED_RELATION_BEAN_ADD_REMOVE_CONFLICT(
+            "diffBasedRelationBeanMerger failed due to ADD/REMOVE conflict"),
+    DIFF_BASED_RELATION_BEAN_ADD_ADD_CONFLICT(
+            "diffBasedRelationBeanMerger failed due to ADD/ADD conflict"),
+    DIFF_BASED_TAG_ADD_ADD_CONFLICT("diffBasedTagMerger failed due to ADD/ADD conflict"),
+    DIFF_BASED_TAG_ADD_REMOVE_CONFLICT("diffBasedTagMerger failed due to ADD/REMOVE conflict"),
+    DIFF_BASED_LONG_MERGE_FAIL("diffBasedLongMerger failed"),
+    DIFF_BASED_LOCATION_MERGE_FAIL("diffBasedLocationMerger failed"),
+    DIFF_BASED_POLYLINE_MERGE_FAIL("diffBasedPolyLineMerger failed"),
+    DIFF_BASED_POLYGON_MERGE_FAIL("diffBasedPolygonMerger failed"),
+    CONFLICTING_BEFORE_VIEW_SET_ADD_REMOVE_CONFLICT(
+            "conflictingBeforeViewSetMerger failed due to ADD/REMOVE conflict"),
+    CONFLICTING_BEFORE_VIEW_RELATION_BEAN_ADD_REMOVE_CONFLICT(
+            "conflictingBeforeViewRelationBeanMerger failed due to ADD/REMOVE conflict"),
+    MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT(
+            "diffBasedMutuallyExclusiveMerger failed due to ADD/ADD conflict"),
+    FEATURE_CHANGE_INVALID_ADD_REMOVE_MERGE(
+            "left and right FeatureChanges disagreed on ChangeType"),
+    FEATURE_CHANGE_INVALID_PROPERTIES_MERGE(
+            "left and right FeatureChanges disagreed on ID or ItemType"),
+    FEATURE_CHANGE_IMBALANCED_BEFORE_VIEW(
+            "left and right FeatureChanges did not both have beforeViews"),
+    HIGHEST_LEVEL_MERGE_FAILURE("the FeatureChange merge failed");
 
     private final String description;
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -491,8 +491,8 @@ public class FeatureChange implements Located, Serializable
         {
             throw new FeatureChangeMergeException(
                     exception.withNewTopLevelFailure(MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE),
-                    "Cannot merge two feature changes:\n{}\nAND\n{}", this.prettify(),
-                    other.prettify(), exception);
+                    "Cannot merge two feature changes:\n{}\nAND\n{}\nParent failureTrace: {}",
+                    this.prettify(), other.prettify(), exception.getMergeFailureTrace(), exception);
         }
         catch (final Exception exception)
         {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -88,8 +88,7 @@ public final class FeatureChangeMergingHelpers
                 .withMemberExtractor(atlasEntity -> atlasEntity.relations() == null ? null
                         : atlasEntity.relations().stream().map(Relation::getIdentifier)
                                 .collect(Collectors.toSet()))
-                .withAfterViewNoBeforeMerger(
-                        MemberMergeStrategies.simpleLongSetAllowCollisionsMerger)
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSetMerger)
                 .build().mergeMember();
@@ -205,14 +204,14 @@ public final class FeatureChangeMergingHelpers
 
             if (!leftInEdgeIdentifiers.equals(rightInEdgeIdentifiers))
             {
-                mergedBeforeNode.withInEdgeIdentifiers(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger
+                mergedBeforeNode
+                        .withInEdgeIdentifiers(MemberMergeStrategies.simpleLongSortedSetMerger
                                 .apply(leftInEdgeIdentifiers, rightInEdgeIdentifiers));
             }
             if (!leftOutEdgeIdentifiers.equals(rightOutEdgeIdentifiers))
             {
-                mergedBeforeNode.withOutEdgeIdentifiers(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger
+                mergedBeforeNode
+                        .withOutEdgeIdentifiers(MemberMergeStrategies.simpleLongSortedSetMerger
                                 .apply(leftOutEdgeIdentifiers, rightOutEdgeIdentifiers));
             }
             return new FeatureChange(ChangeType.REMOVE, left.getAfterView(), mergedBeforeNode);
@@ -541,12 +540,10 @@ public final class FeatureChangeMergingHelpers
                 .withMemberExtractor(atlasEntity -> ((Node) atlasEntity).inEdges() == null ? null
                         : ((Node) atlasEntity).inEdges().stream().map(Edge::getIdentifier)
                                 .collect(Collectors.toCollection(TreeSet::new)))
-                .withAfterViewNoBeforeMerger(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSortedSetMerger)
-                .withBeforeViewMerger(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
                         (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
                 .build().mergeMember();
@@ -558,12 +555,10 @@ public final class FeatureChangeMergingHelpers
                 .withMemberExtractor(atlasEntity -> ((Node) atlasEntity).outEdges() == null ? null
                         : ((Node) atlasEntity).outEdges().stream().map(Edge::getIdentifier)
                                 .collect(Collectors.toCollection(TreeSet::new)))
-                .withAfterViewNoBeforeMerger(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSortedSetMerger)
-                .withBeforeViewMerger(
-                        MemberMergeStrategies.simpleLongSortedSetAllowCollisionsMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
                         (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
                 .build().mergeMember();
@@ -580,12 +575,12 @@ public final class FeatureChangeMergingHelpers
          * simple merge will always succeed, since the sets are key only.
          */
         mergedAfterNode.setExplicitlyExcludedInEdgeIdentifiers(
-                MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
+                MemberMergeStrategies.simpleLongSetMerger.apply(
                         ((CompleteNode) afterEntityLeft).explicitlyExcludedInEdgeIdentifiers(),
                         ((CompleteNode) afterEntityRight).explicitlyExcludedInEdgeIdentifiers()));
 
         mergedAfterNode.setExplicitlyExcludedOutEdgeIdentifiers(
-                MemberMergeStrategies.simpleLongSetAllowCollisionsMerger.apply(
+                MemberMergeStrategies.simpleLongSetMerger.apply(
                         ((CompleteNode) afterEntityLeft).explicitlyExcludedOutEdgeIdentifiers(),
                         ((CompleteNode) afterEntityRight).explicitlyExcludedOutEdgeIdentifiers()));
 
@@ -699,8 +694,7 @@ public final class FeatureChangeMergingHelpers
                                 : ((Relation) atlasEntity).allRelationsWithSameOsmIdentifier()
                                         .stream().map(Relation::getIdentifier)
                                         .collect(Collectors.toSet()))
-                .withAfterViewNoBeforeMerger(
-                        MemberMergeStrategies.simpleLongSetAllowCollisionsMerger)
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSetMerger)
                 .build().mergeMember();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -394,6 +394,14 @@ public final class MemberMerger<M>
         {
             beforeMemberResult = this.beforeViewMerger.apply(beforeMemberLeft, beforeMemberRight);
         }
+        catch (final FeatureChangeMergeException exception)
+        {
+            throw new FeatureChangeMergeException(
+                    exception.withNewTopLevelFailure(
+                            MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                    "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, exception);
+        }
         catch (final Exception exception)
         {
             throw new FeatureChangeMergeException(
@@ -414,6 +422,15 @@ public final class MemberMerger<M>
                             explicitlyExcludedLeft, (SortedSet<Long>) beforeMemberRight,
                             (SortedSet<Long>) afterMemberRight, explicitlyExcludedRight);
             afterMemberResult = (M) mergeResult;
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            throw new FeatureChangeMergeException(exception.withNewTopLevelFailure(
+                    MergeFailureType.AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                    "Tried merge strategy for hackForConflictingConnectedEdgeSet, but it failed for {}"
+                            + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
+                    afterMemberRight, exception);
         }
         catch (final Exception exception)
         {
@@ -471,6 +488,14 @@ public final class MemberMerger<M>
         {
             beforeMemberResult = this.beforeViewMerger.apply(beforeMemberLeft, beforeMemberRight);
         }
+        catch (final FeatureChangeMergeException exception)
+        {
+            throw new FeatureChangeMergeException(
+                    exception.withNewTopLevelFailure(
+                            MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                    "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, exception);
+        }
         catch (final Exception exception)
         {
             throw new FeatureChangeMergeException(
@@ -483,6 +508,15 @@ public final class MemberMerger<M>
         {
             afterMemberResult = this.afterViewConflictingBeforeViewMerger.apply(beforeMemberLeft,
                     afterMemberLeft, beforeMemberRight, afterMemberRight);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            throw new FeatureChangeMergeException(exception.withNewTopLevelFailure(
+                    MergeFailureType.AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                    "Tried merge strategy for handling conflicting beforeViews. but it failed for {}"
+                            + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
+                    this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
+                    afterMemberRight, exception);
         }
         catch (final Exception exception)
         {
@@ -534,6 +568,14 @@ public final class MemberMerger<M>
                 afterMemberResult = this.afterViewConsistentBeforeViewMerger
                         .apply(beforeMemberResult, afterMemberLeft, afterMemberRight);
             }
+            catch (final FeatureChangeMergeException exception)
+            {
+                throw new FeatureChangeMergeException(exception.withNewTopLevelFailure(
+                        MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                        "Attempted afterViewConsistentBeforeMerge failed for {} with beforeView: {}; afterView: {} vs {}",
+                        this.memberName, beforeMemberResult, afterMemberLeft, afterMemberRight,
+                        exception);
+            }
             catch (final Exception exception)
             {
                 throw new FeatureChangeMergeException(
@@ -554,7 +596,15 @@ public final class MemberMerger<M>
                 afterMemberResult = this.afterViewNoBeforeViewMerger.apply(afterMemberLeft,
                         afterMemberRight);
             }
-            catch (final CoreException exception)
+            catch (final FeatureChangeMergeException exception)
+            {
+                throw new FeatureChangeMergeException(
+                        exception.withNewTopLevelFailure(
+                                MergeFailureType.AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED),
+                        "Attempted afterViewNoBeforeMerge failed for {}; afterView: {} vs {}",
+                        this.memberName, afterMemberLeft, afterMemberRight, exception);
+            }
+            catch (final Exception exception)
             {
                 throw new FeatureChangeMergeException(
                         MergeFailureType.AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -17,8 +17,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.utilities.function.QuaternaryOperator;
 import org.openstreetmap.atlas.utilities.function.TernaryOperator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class encapsulates the logic and configuration for {@link CompleteEntity} member merging in
@@ -204,7 +202,6 @@ public final class MemberMerger<M>
         }
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(MemberMerger.class);
     private String memberName;
     private AtlasEntity beforeEntityLeft;
     private AtlasEntity afterEntityLeft;
@@ -399,7 +396,7 @@ public final class MemberMerger<M>
             throw new FeatureChangeMergeException(
                     exception.withNewTopLevelFailure(
                             MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED),
-                    "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}",
+                    "Attempted beforeView merge strategy failed for {} with beforeView: {} vs {}", // NOSONAR
                     this.memberName, beforeMemberLeft, beforeMemberRight, exception);
         }
         catch (final Exception exception)
@@ -428,7 +425,7 @@ public final class MemberMerger<M>
             throw new FeatureChangeMergeException(exception.withNewTopLevelFailure(
                     MergeFailureType.AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED),
                     "Tried merge strategy for hackForConflictingConnectedEdgeSet, but it failed for {}"
-                            + "\nbeforeView: {} vs {};\nafterView: {} vs {}",
+                            + "\nbeforeView: {} vs {};\nafterView: {} vs {}", // NOSONAR
                     this.memberName, beforeMemberLeft, beforeMemberRight, afterMemberLeft,
                     afterMemberRight, exception);
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -5,10 +5,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.exception.change.FeatureChangeMergeException;
+import org.openstreetmap.atlas.exception.change.MergeFailureType;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -41,9 +40,6 @@ public class FeatureChangeMergerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(FeatureChangeMergerTest.class);
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void testMergeAreasFail()
     {
@@ -60,9 +56,33 @@ public class FeatureChangeMergerTest
          * This merge will fail, because the FeatureChanges have conflicting changed polygons. There
          * is no way to resolve conflicting geometry during a merge.
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceContainsFailureType(
+                    MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT));
+            Assert.assertTrue(exception.traceContainsExactFailureSequence(Arrays.asList(
+                    MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
+                    MergeFailureType.DIFF_BASED_POLYGON_MERGE_FAIL,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED)));
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
+                    MergeFailureType.DIFF_BASED_POLYGON_MERGE_FAIL,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -141,11 +161,34 @@ public class FeatureChangeMergerTest
                 123L, PolyLine.TEST_POLYLINE, Maps.hashMap("a", "3"), 1L, null, null), beforeEdge1);
 
         /*
-         * This merge will fail, because the FeatureChanges have conflicting tag changes.
+         * This merge will fail, because the FeatureChanges have a tag ADD/ADD conflict (a->2 vs.
+         * a->3).
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception
+                    .traceContainsFailureType(MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT));
+            Assert.assertTrue(exception.traceContainsExactFailureSequence(Arrays.asList(
+                    MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED)));
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -205,9 +248,27 @@ public class FeatureChangeMergerTest
         final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
                 new CompleteArea(123L, Polygon.CENTER, null, null), null);
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.FEATURE_CHANGE_INVALID_ADD_REMOVE_MERGE,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceContainsFailureType(
+                    MergeFailureType.FEATURE_CHANGE_INVALID_ADD_REMOVE_MERGE));
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(
+                    Arrays.asList(MergeFailureType.FEATURE_CHANGE_INVALID_ADD_REMOVE_MERGE,
+                            MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -218,9 +279,27 @@ public class FeatureChangeMergerTest
         final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD,
                 new CompleteArea(456L, Polygon.SILICON_VALLEY, null, null), null);
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceContainsFailureType(
+                    MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE));
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(
+                    Arrays.asList(MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE,
+                            MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -231,16 +310,34 @@ public class FeatureChangeMergerTest
         final FeatureChange featureChange2 = new FeatureChange(ChangeType.REMOVE,
                 new CompletePoint(123L, Location.CENTER, null, null), null);
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceContainsFailureType(
+                    MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE));
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(
+                    Arrays.asList(MergeFailureType.FEATURE_CHANGE_INVALID_PROPERTIES_MERGE,
+                            MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
     public void testMergeLinesFail()
     {
-        final CompleteLine beforeLine1 = new CompleteLine(123L, PolyLine.TEST_POLYLINE, null,
-                Sets.hashSet(1L, 2L, 3L));
+        final CompleteLine beforeLine1 = new CompleteLine(123L, PolyLine.TEST_POLYLINE,
+                Maps.hashMap(), Sets.hashSet(1L, 2L, 3L));
 
         final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD,
                 new CompleteLine(123L, PolyLine.TEST_POLYLINE_2, Maps.hashMap("a", "1"),
@@ -252,11 +349,29 @@ public class FeatureChangeMergerTest
                 beforeLine1);
 
         /*
-         * This merge will fail, because the FeatureChanges have conflicting tags.
+         * This merge will fail, because the FeatureChanges have an ADD/ADD tag conflict (a->1 vs.
+         * a->2)
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -376,11 +491,28 @@ public class FeatureChangeMergerTest
 
         /*
          * This merge will fail, because featureChange1 removes tag [b=2], while featureChange2
-         * modifies it to [b=3]. This generates an ADD/REMOVE collision.
+         * modifies it to [b=3]. This generates a tag ADD/REMOVE conflict.
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.DIFF_BASED_TAG_ADD_REMOVE_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.DIFF_BASED_TAG_ADD_REMOVE_CONFLICT,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -517,9 +649,27 @@ public class FeatureChangeMergerTest
          * This merge will fail, because featureChange1 and featureChange2 have conflicting changed
          * locations.
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
+                    MergeFailureType.DIFF_BASED_LOCATION_MERGE_FAIL,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test
@@ -685,9 +835,26 @@ public class FeatureChangeMergerTest
         /*
          * This merge will fail due to an ADD/ADD conflict in the member list bean.
          */
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("Cannot merge two feature changes");
-        featureChange1.merge(featureChange2);
+        boolean caught = false;
+        try
+        {
+            featureChange1.merge(featureChange2);
+        }
+        catch (final FeatureChangeMergeException exception)
+        {
+            caught = true;
+            Assert.assertEquals(MergeFailureType.DIFF_BASED_RELATION_BEAN_ADD_ADD_CONFLICT,
+                    exception.rootLevelFailure());
+            Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(
+                    MergeFailureType.DIFF_BASED_RELATION_BEAN_ADD_ADD_CONFLICT,
+                    MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED,
+                    MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE)));
+        }
+
+        if (!caught)
+        {
+            Assert.fail("Did not catch expected FeatureChangeMergeException");
+        }
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.exception.change.FeatureChangeMergeException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -57,7 +58,7 @@ public class MemberMergeStrategiesTest
          * afterBean2 explicitly removes it. This conflict is only possible in cases where we are
          * merging RelationBeans with conflicting beforeViews.
          */
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException
                 .expectMessage("conflictingBeforeViewRelationBeanMerger failed due to ADD/REMOVE");
         MemberMergeStrategies.conflictingBeforeViewRelationBeanMerger.apply(beforeBean1, afterBean1,
@@ -192,7 +193,7 @@ public class MemberMergeStrategiesTest
          * This will fail because the left side added 6L, while the right side explicitly removed
          * 6L.
          */
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException
                 .expectMessage("conflictingBeforeViewSetMerger failed due to ADD/REMOVE");
         MemberMergeStrategies.conflictingBeforeViewSetMerger.apply(beforeSet1, afterSet1,
@@ -261,9 +262,8 @@ public class MemberMergeStrategiesTest
         final Location afterLeft = Location.COLOSSEUM;
         final Location afterRight = Location.EIFFEL_TOWER;
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException
-                .expectMessage("diffBasedMutuallyExclusiveMerger failed due to ADD/ADD conflict");
+        this.expectedException.expect(FeatureChangeMergeException.class);
+        this.expectedException.expectMessage("mutually exclusive Location merge failed");
         MemberMergeStrategies.diffBasedLocationMerger.apply(before, afterLeft, afterRight);
     }
 
@@ -299,9 +299,8 @@ public class MemberMergeStrategiesTest
         final Long afterLeft = 1L;
         final Long afterRight = 2L;
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException
-                .expectMessage("diffBasedMutuallyExclusiveMerger failed due to ADD/ADD conflict");
+        this.expectedException.expect(FeatureChangeMergeException.class);
+        this.expectedException.expectMessage("mutually exclusive Long merge failed");
         MemberMergeStrategies.diffBasedLongMerger.apply(before, afterLeft, afterRight);
     }
 
@@ -397,9 +396,8 @@ public class MemberMergeStrategiesTest
         final PolyLine afterLeft = PolyLine.TEST_POLYLINE_2;
         final PolyLine afterRight = PolyLine.CENTER;
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException
-                .expectMessage("diffBasedMutuallyExclusiveMerger failed due to ADD/ADD conflict");
+        this.expectedException.expect(FeatureChangeMergeException.class);
+        this.expectedException.expectMessage("mutually exclusive PolyLine merge failed");
         MemberMergeStrategies.diffBasedPolyLineMerger.apply(before, afterLeft, afterRight);
     }
 
@@ -435,9 +433,8 @@ public class MemberMergeStrategiesTest
         final Polygon afterLeft = Polygon.SILICON_VALLEY;
         final Polygon afterRight = Polygon.SILICON_VALLEY_2;
 
-        this.expectedException.expect(CoreException.class);
-        this.expectedException
-                .expectMessage("diffBasedMutuallyExclusiveMerger failed due to ADD/ADD conflict");
+        this.expectedException.expect(FeatureChangeMergeException.class);
+        this.expectedException.expectMessage("mutually exclusive Polygon merge failed");
         MemberMergeStrategies.diffBasedPolygonMerger.apply(before, afterLeft, afterRight);
     }
 
@@ -502,7 +499,7 @@ public class MemberMergeStrategiesTest
         /*
          * The merge will fail, since the number of added [2, AREA, areaRole2] conflict.
          */
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
                 "diffBasedRelationBeanMerger failed due to ADD/ADD conflict on key: [AREA, 2, areaRole2]: beforeValue absolute count was 0 but addedLeft/Right diff counts conflict [1 vs 2]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
@@ -545,7 +542,7 @@ public class MemberMergeStrategiesTest
          * The merge will fail, since one afterView tries to add an additional [1, LINE, lineRole1]
          * while the other afterView removes it entirely.
          */
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
                 "diffBasedRelationBeanMerger failed due to ADD/REMOVE conflict(s) on key(s): [LINE, 1, lineRole1]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
@@ -585,7 +582,7 @@ public class MemberMergeStrategiesTest
         /*
          * The merge will fail, since the number of removed [1, AREA, areaRole1] conflict.
          */
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
                 "diffBasedRelationBeanMerger failed due to REMOVE/REMOVE conflict on key: [AREA, 1, areaRole1]: beforeValue absolute count was 2 but removedLeft/Right diff counts conflict [1 vs 2]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
@@ -682,7 +679,7 @@ public class MemberMergeStrategiesTest
         final Map<String, String> after1A = Maps.hashMap("a", "10", "b", "2");
         final Map<String, String> after1B = Maps.hashMap("b", "2");
 
-        this.expectedException.expect(CoreException.class);
+        this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
                 "diffBasedTagMerger failed due to ADD/REMOVE conflict(s) on key(s): [a]");
         MemberMergeStrategies.diffBasedTagMerger.apply(before1, after1A, after1B);


### PR DESCRIPTION
### Description:
`FeatureChangeMergeException` now contains detailed state information about why a merge failed. Consider the following code snippets:
```java
// This code snippet will forgive merge failures when one FeatureChange tries to modify a
// feature while another tries to remove said feature. It will choose the remove.
try
{
    featureChange1.merge(featureChange2)
}
catch (FeatureChangeMergeException e)
{
    if (e.rootLevelFailure() == MergeFailureType.FEATURE_CHANGE_INVALID_ADD_REMOVE_MERGE)
    {
        return featureChange1.getChangeType() == ChangeType.REMOVE ? 
            featureChange1 : featureChange2;
    }
    else
    {
        throw new CoreException("rethrowing", e);
    }
}
```

```java
// This code snippet will forgive merge failures only when the failure is due to a PolyLine
// incompatibility in the afterViews of the FeatureChanges.
try
{
    featureChange1.merge(featureChange2)
}
catch (FeatureChangeMergeException e)
{
    if (e.traceContainsExactFailureSequence(
        MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
        MergeFailureType.DIFF_BASED_POLYGON_MERGE_FAIL,
        MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED))
    {
        return featureChange1;
    }
    else
    {
        throw new CoreException("rethrowing", e);
    }
}
```

And here is an example stack trace for an area merge that failed due to conflicting tags. As you can see, the trace shows both FeatureChanges in question, the full failure list detailing each `MergeFailureType`, and then additional exceptions detailing both the type of tag merge failure (ADD/REMOVE in this case) as well as the key that caused the conflict ("b" in this case).
```
org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: Cannot merge two feature changes:
FeatureChange [
changeType: ADD, 
itemType: AREA, 
identifier: 123, 
bounds: POLYGON ((-122.052138 0, -122.052138 37.390535, 0 37.390535, 0 0, -122.052138 0)), 
bfView: CompleteArea [identifier: 123, polygon: POLYGON ((0 0, 0 0, 0 0, 0 0)), tags: {a=1, b=2}, ], 
afView: CompleteArea [identifier: 123, polygon: POLYGON ((-122.052138 37.317585, -122.0304871 37.3314171, -122.028464 37.321628, -122.009566 37.33531, -122.031007 37.390535, -122.052138 37.317585)), tags: {a=1, b=3}, ], 
metadata: {}
]
AND
FeatureChange [
changeType: ADD, 
itemType: AREA, 
identifier: 123, 
bounds: POLYGON ((-122.052138 0, -122.052138 37.390535, 0 37.390535, 0 0, -122.052138 0)), 
bfView: CompleteArea [identifier: 123, polygon: POLYGON ((0 0, 0 0, 0 0, 0 0)), tags: {a=1, b=2}, ], 
afView: CompleteArea [identifier: 123, polygon: POLYGON ((-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535, -122.052138 37.317585)), tags: {a=1}, ], 
metadata: {}
]
Parent failureTrace: [DIFF_BASED_TAG_ADD_REMOVE_CONFLICT, AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED]

	at org.openstreetmap.atlas.geography.atlas.change.FeatureChange.merge(FeatureChange.java:495)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChangeMergerTest.testBlah(FeatureChangeMergerTest.java:57)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: Attempted afterViewConsistentBeforeMerge failed for tags with beforeView: {a=1, b=2}; afterView: {a=1, b=3} vs {a=1}
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMembersWithConsistentBeforeViews(MemberMerger.java:573)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMember(MemberMerger.java:281)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChangeMergingHelpers.mergeADDFeatureChangePair(FeatureChangeMergingHelpers.java:82)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChange.merge(FeatureChange.java:481)
	... 23 more
Caused by: org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: diffBasedTagMerger failed due to ADD/REMOVE conflict(s) on key(s): [b]
	at org.openstreetmap.atlas.geography.atlas.change.MemberMergeStrategies.lambda$static$20(MemberMergeStrategies.java:451)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMembersWithConsistentBeforeViews(MemberMerger.java:569)
	... 26 more
```

### Potential Impact:
N/A

### Unit Test Approach:
Modified many unit tests to account for the new mechanics.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)