### PR TITLE
A few more FeatureChangeMergeException improvements

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -132,7 +132,7 @@ public class FeatureChangeMergeException extends CoreException
      *            the subsequence of {@link MergeFailureType}s to check
      * @return if the subsequence is present
      */
-    public boolean traceContainsExactFailureSequence(final List<MergeFailureType> subSequence)
+    public boolean traceContainsExactFailureSubSequence(final List<MergeFailureType> subSequence)
     {
         if (subSequence.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
@@ -5,6 +5,9 @@ package org.openstreetmap.atlas.exception.change;
  */
 public enum MergeFailureType
 {
+    /*
+     * These are all root level failures.
+     */
     AUTOFAIL_TAG_MERGE("tag Map merge failed due to autofail strategy"),
     AUTOFAIL_LONG_SET_MERGE("Long Set merge failed due to autofail strategy"),
     AUTOFAIL_LONG_SORTED_SET_MERGE("Long SortedSet merge failed due to autofail strategy"),
@@ -12,19 +15,6 @@ public enum MergeFailureType
     AUTOFAIL_POLYLINE_MERGE("PolyLine merge failed due to autofail strategy"),
     AUTOFAIL_POLYGON_MERGE("Polygon merge failed due to autofail strategy"),
     AUTOFAIL_LONG_MERGE("Long merge failed due to autofail strategy"),
-    AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
-            "the afterView merging function (that ignores beforeView) failed"),
-    AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
-            "the afterView merging function (that assumes consistent beforeViews) failed"),
-    AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
-            "the afterView merging function (that accounts for conflicting beforeViews) failed"),
-    BEFORE_VIEW_MERGE_STRATEGY_FAILED("the beforeView merging function failed"),
-    MISSING_BEFORE_VIEW_MERGE_STRATEGY(
-            "beforeMembers conflict and no beforeView merging strategy provided"),
-    MISSING_AFTER_VIEW_MERGE_STRATEGY_WITH_BEFORE_MEMBER_CONFLICT_HANDLING(
-            "beforeMembers conflict and no beforeView-conflict-capable afterView merging strategy provided"),
-    MISSING_AFTER_VIEW_MERGE_STRATEGY(
-            "afterMembers conflict and no afterView merging strategy provided"),
     SIMPLE_TAG_MERGE_FAIL("simpleTagMerger failed"),
     SIMPLE_LONG_SET_MERGE_FAIL("simpleLongSetMerger failed"),
     SIMPLE_LONG_SORTED_SET_MERGE_FAIL("simpleLongSortedSetMerger failed"),
@@ -53,6 +43,28 @@ public enum MergeFailureType
             "left and right FeatureChanges disagreed on ID or ItemType"),
     FEATURE_CHANGE_IMBALANCED_BEFORE_VIEW(
             "left and right FeatureChanges did not both have beforeViews"),
+
+    /*
+     * These failures occur at the next level up from root. They differentiate between
+     * afterView/beforeView merge errors, and do not contain specific member information.
+     */
+    AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that ignores beforeView) failed"),
+    AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that assumes consistent beforeViews) failed"),
+    AFTER_VIEW_CONFLICTING_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
+            "the afterView merging function (that accounts for conflicting beforeViews) failed"),
+    BEFORE_VIEW_MERGE_STRATEGY_FAILED("the beforeView merging function failed"),
+    MISSING_BEFORE_VIEW_MERGE_STRATEGY(
+            "beforeMembers conflict and no beforeView merging strategy provided"),
+    MISSING_AFTER_VIEW_MERGE_STRATEGY_WITH_BEFORE_MEMBER_CONFLICT_HANDLING(
+            "beforeMembers conflict and no beforeView-conflict-capable afterView merging strategy provided"),
+    MISSING_AFTER_VIEW_MERGE_STRATEGY(
+            "afterMembers conflict and no afterView merging strategy provided"),
+
+    /*
+     * The generic highest level merge failure.
+     */
     HIGHEST_LEVEL_MERGE_FAILURE("the FeatureChange merge failed");
 
     private final String description;

--- a/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/MergeFailureType.java
@@ -5,6 +5,13 @@ package org.openstreetmap.atlas.exception.change;
  */
 public enum MergeFailureType
 {
+    AUTOFAIL_TAG_MERGE("tag Map merge failed due to autofail strategy"),
+    AUTOFAIL_LONG_SET_MERGE("Long Set merge failed due to autofail strategy"),
+    AUTOFAIL_LONG_SORTED_SET_MERGE("Long SortedSet merge failed due to autofail strategy"),
+    AUTOFAIL_LOCATION_MERGE("Location merge failed due to autofail strategy"),
+    AUTOFAIL_POLYLINE_MERGE("PolyLine merge failed due to autofail strategy"),
+    AUTOFAIL_POLYGON_MERGE("Polygon merge failed due to autofail strategy"),
+    AUTOFAIL_LONG_MERGE("Long merge failed due to autofail strategy"),
     AFTER_VIEW_NO_BEFORE_VIEW_MERGE_STRATEGY_FAILED(
             "the afterView merging function (that ignores beforeView) failed"),
     AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED(

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -79,7 +79,10 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityRight(afterEntityRight).withMemberExtractor(Taggable::getTags)
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleTagMerger)
                 .withAfterViewConsistentBeforeViewMerger(MemberMergeStrategies.diffBasedTagMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryTagMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryTagMerger).build()
+                .mergeMember();
 
         final MergedMemberBean<Set<Long>> mergedParentRelationsBean = new MemberMerger.Builder<Set<Long>>()
                 .withMemberName("parentRelations").withBeforeEntityLeft(beforeEntityLeft)
@@ -91,7 +94,10 @@ public final class FeatureChangeMergingHelpers
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSetMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongSetMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLongSetMerger).build()
+                .mergeMember();
 
         if (afterEntityLeft instanceof LocationItem)
         {
@@ -272,9 +278,13 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(atlasEntity -> ((Area) atlasEntity).asPolygon())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryPolygonMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedPolygonMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryPolygonMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryPolygonMerger).build()
+                .mergeMember();
 
         final CompleteArea mergedAfterArea = new CompleteArea(left.getIdentifier(),
                 mergedPolygonBean.getMergedAfterMember(), mergedTagsBean.getMergedAfterMember(),
@@ -328,8 +338,12 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(edge -> ((Edge) edge).start() == null ? null
                         : ((Edge) edge).start().getIdentifier())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryLongMerger)
                 .withAfterViewConsistentBeforeViewMerger(MemberMergeStrategies.diffBasedLongMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLongMerger).build()
+                .mergeMember();
 
         final MergedMemberBean<Long> mergedEndNodeIdentifierBean = new MemberMerger.Builder<Long>()
                 .withMemberName("endNode").withBeforeEntityLeft(beforeEntityLeft)
@@ -337,8 +351,12 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(edge -> ((Edge) edge).end() == null ? null
                         : ((Edge) edge).end().getIdentifier())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryLongMerger)
                 .withAfterViewConsistentBeforeViewMerger(MemberMergeStrategies.diffBasedLongMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLongMerger).build()
+                .mergeMember();
 
         final CompleteEdge mergedAfterEdge = new CompleteEdge(left.getIdentifier(),
                 mergedPolyLineBean.getMergedAfterMember(), mergedTagsBean.getMergedAfterMember(),
@@ -399,9 +417,13 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(atlasEntity -> ((LineItem) atlasEntity).asPolyLine())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryPolyLineMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedPolyLineMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryPolyLineMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryPolyLineMerger).build()
+                .mergeMember();
 
         if (afterEntityLeft instanceof Edge)
         {
@@ -493,9 +515,13 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(atlasEntity -> ((LocationItem) atlasEntity).getLocation())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryLocationMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLocationMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLocationMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLocationMerger).build()
+                .mergeMember();
 
         if (afterEntityLeft instanceof Node)
         {
@@ -543,6 +569,8 @@ public final class FeatureChangeMergingHelpers
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSortedSetMerger)
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongSortedSetMerger)
                 .withBeforeViewMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
                         (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
@@ -558,6 +586,8 @@ public final class FeatureChangeMergingHelpers
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSortedSetMerger)
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongSortedSetMerger)
                 .withBeforeViewMerger(MemberMergeStrategies.simpleLongSortedSetMerger)
                 .useHackForMergingConflictingConnectedEdgeSetBeforeViews(
                         (CompleteNode) afterEntityLeft, (CompleteNode) afterEntityRight)
@@ -681,7 +711,7 @@ public final class FeatureChangeMergingHelpers
                         MemberMergeStrategies.diffBasedRelationBeanMerger)
                 .withAfterViewConflictingBeforeViewMerger(
                         MemberMergeStrategies.conflictingBeforeViewRelationBeanMerger)
-                .withBeforeViewMerger(MemberMergeStrategies.beforeViewRelationBeanMerger).build()
+                .withBeforeViewMerger(MemberMergeStrategies.simpleRelationBeanMerger).build()
                 .mergeMember();
 
         final MergedMemberBean<Set<Long>> mergedAllRelationsWithSameOsmIdentifierBean = new MemberMerger.Builder<Set<Long>>()
@@ -697,7 +727,10 @@ public final class FeatureChangeMergingHelpers
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleLongSetMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedLongSetMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongSetMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLongSetMerger).build()
+                .mergeMember();
 
         final MergedMemberBean<RelationBean> mergedAllKnownMembersBean = new MemberMerger.Builder<RelationBean>()
                 .withMemberName("allKnownOsmMembers").withBeforeEntityLeft(beforeEntityLeft)
@@ -709,7 +742,9 @@ public final class FeatureChangeMergingHelpers
                 .withAfterViewNoBeforeMerger(MemberMergeStrategies.simpleRelationBeanMerger)
                 .withAfterViewConsistentBeforeViewMerger(
                         MemberMergeStrategies.diffBasedRelationBeanMerger)
-                .withBeforeViewMerger(MemberMergeStrategies.beforeViewRelationBeanMerger).build()
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.conflictingBeforeViewRelationBeanMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.simpleRelationBeanMerger).build()
                 .mergeMember();
 
         final MergedMemberBean<Long> mergedOsmRelationIdentifier = new MemberMerger.Builder<Long>()
@@ -717,8 +752,12 @@ public final class FeatureChangeMergingHelpers
                 .withAfterEntityLeft(afterEntityLeft).withBeforeEntityRight(beforeEntityRight)
                 .withAfterEntityRight(afterEntityRight)
                 .withMemberExtractor(entity -> ((Relation) entity).osmRelationIdentifier())
+                .withAfterViewNoBeforeMerger(MemberMergeStrategies.autofailBinaryLongMerger)
                 .withAfterViewConsistentBeforeViewMerger(MemberMergeStrategies.diffBasedLongMerger)
-                .build().mergeMember();
+                .withAfterViewConflictingBeforeViewMerger(
+                        MemberMergeStrategies.autofailQuaternaryLongMerger)
+                .withBeforeViewMerger(MemberMergeStrategies.autofailBinaryLongMerger).build()
+                .mergeMember();
 
         final Rectangle mergedBounds = Rectangle.forLocated(afterEntityLeft, afterEntityRight);
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategies.java
@@ -37,6 +37,106 @@ import org.openstreetmap.atlas.utilities.function.TernaryOperator;
  */
 public final class MemberMergeStrategies
 {
+    static final BinaryOperator<Long> autofailBinaryLongMerger = (afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_MERGE,
+                "autofailBinaryLongMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<Long> autofailQuaternaryLongMerger = (beforeLeft, beforeRight,
+            afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_MERGE,
+                "autofailQuaternaryLongMerger: before: {} vs {}, after: {} vs {}", beforeLeft,
+                beforeRight, afterLeft, afterRight);
+    };
+
+    static final BinaryOperator<Map<String, String>> autofailBinaryTagMerger = (afterMapLeft,
+            afterMapRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_TAG_MERGE,
+                "autofailBinaryTagMerger: {} vs {}", afterMapLeft, afterMapRight);
+    };
+
+    static final QuaternaryOperator<Map<String, String>> autofailQuaternaryTagMerger = (
+            beforeMapLeft, afterMapLeft, beforeMapRight, afterMapRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_TAG_MERGE,
+                "autofailQuaternaryTagMerger: before: {} vs {}, after: {} vs {}", beforeMapLeft,
+                beforeMapRight, afterMapLeft, afterMapRight);
+    };
+
+    static final BinaryOperator<Set<Long>> autofailBinaryLongSetMerger = (afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_SET_MERGE,
+                "autofailBinaryLongSetMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<Set<Long>> autofailQuaternaryLongSetMerger = (beforeLeft,
+            afterLeft, beforeRight, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_SET_MERGE,
+                "autofailQuaternaryLongSetMerger: before: {} vs {}, after: {} vs {}", beforeLeft,
+                beforeRight, afterLeft, afterRight);
+    };
+
+    static final BinaryOperator<SortedSet<Long>> autofailBinaryLongSortedSetMerger = (afterLeft,
+            afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_SORTED_SET_MERGE,
+                "autofailBinaryLongSortedSetMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<SortedSet<Long>> autofailQuaternaryLongSortedSetMerger = (
+            beforeLeft, afterLeft, beforeRight, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LONG_SORTED_SET_MERGE,
+                "autofailQuaternaryLongSortedSetMerger: before: {} vs {}, after: {} vs {}",
+                beforeLeft, beforeRight, afterLeft, afterRight);
+    };
+
+    static final BinaryOperator<Location> autofailBinaryLocationMerger = (afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LOCATION_MERGE,
+                "autofailBinaryLocationMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<Location> autofailQuaternaryLocationMerger = (beforeLeft,
+            afterLeft, beforeRight, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_LOCATION_MERGE,
+                "autofailQuaternaryLocationMerger: before: {} vs {}, after: {} vs {}", beforeLeft,
+                beforeRight, afterLeft, afterRight);
+    };
+
+    static final BinaryOperator<PolyLine> autofailBinaryPolyLineMerger = (afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_POLYLINE_MERGE,
+                "autofailBinaryPolyLineMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<PolyLine> autofailQuaternaryPolyLineMerger = (beforeLeft,
+            afterLeft, beforeRight, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_POLYLINE_MERGE,
+                "autofailQuaternaryPolyLineMerger: before: {} vs {}, after: {} vs {}", beforeLeft,
+                beforeRight, afterLeft, afterRight);
+    };
+
+    static final BinaryOperator<Polygon> autofailBinaryPolygonMerger = (afterLeft, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_POLYGON_MERGE,
+                "autofailBinaryPolygonMerger: {} vs {}", afterLeft, afterRight);
+    };
+
+    static final QuaternaryOperator<Polygon> autofailQuaternaryPolygonMerger = (beforeLeft,
+            afterLeft, beforeRight, afterRight) ->
+    {
+        throw new FeatureChangeMergeException(MergeFailureType.AUTOFAIL_POLYGON_MERGE,
+                "autofailQuaternaryPolygonMerger: before: {} vs {}, after: {} vs {}", beforeLeft,
+                beforeRight, afterLeft, afterRight);
+    };
+
     static final BinaryOperator<Map<String, String>> simpleTagMerger = (afterMapLeft,
             afterMapRight) ->
     {
@@ -476,8 +576,6 @@ public final class MemberMergeStrategies
         return result;
     };
 
-    static final BinaryOperator<RelationBean> beforeViewRelationBeanMerger = RelationBean::mergeBeans;
-
     /**
      * A merger for cases when two {@link Set}s have conflicting beforeViews. This is useful for
      * merging {@link Node} in/out {@link Edge} sets, since different shards may occasionally have
@@ -601,7 +699,7 @@ public final class MemberMergeStrategies
          * we can apply the changes from our removedMerged and addedMerged sets to get the final
          * result.
          */
-        final Set<RelationBeanItem> mergedBeforeView = beforeViewRelationBeanMerger
+        final Set<RelationBeanItem> mergedBeforeView = simpleRelationBeanMerger
                 .apply(beforeLeftBean, beforeRightBean).asSet();
         mergedBeforeView.removeAll(removedMerged);
         mergedBeforeView.addAll(addedMerged);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/MemberMerger.java
@@ -168,6 +168,11 @@ public final class MemberMerger<M>
             {
                 throw new CoreException("Both \'beforeEntity\' fields must either be set or null");
             }
+
+            if (this.memberExtractor == null)
+            {
+                throw new CoreException("Required field \'memberExtractor\' was unset");
+            }
         }
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -68,7 +68,7 @@ public class FeatureChangeMergerTest
                     exception.rootLevelFailure());
             Assert.assertTrue(exception.traceContainsFailureType(
                     MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT));
-            Assert.assertTrue(exception.traceContainsExactFailureSequence(Arrays.asList(
+            Assert.assertTrue(exception.traceContainsExactFailureSubSequence(Arrays.asList(
                     MergeFailureType.MUTUALLY_EXCLUSIVE_ADD_ADD_CONFLICT,
                     MergeFailureType.DIFF_BASED_POLYGON_MERGE_FAIL,
                     MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED)));
@@ -176,7 +176,7 @@ public class FeatureChangeMergerTest
                     exception.rootLevelFailure());
             Assert.assertTrue(exception
                     .traceContainsFailureType(MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT));
-            Assert.assertTrue(exception.traceContainsExactFailureSequence(Arrays.asList(
+            Assert.assertTrue(exception.traceContainsExactFailureSubSequence(Arrays.asList(
                     MergeFailureType.DIFF_BASED_TAG_ADD_ADD_CONFLICT,
                     MergeFailureType.AFTER_VIEW_CONSISTENT_BEFORE_VIEW_MERGE_STRATEGY_FAILED)));
             Assert.assertTrue(exception.traceMatchesExactFailureSequence(Arrays.asList(


### PR DESCRIPTION
### Description:
`FeatureChangeMergeException` now supports detection for conflicting beforeViews. See the code snippet:
```java
// This code snippet will forgive merge failures only when the failure is due to a PolyLine
// incompatibility in the beforeViews of the FeatureChanges.
try
{
    featureChange1.merge(featureChange2)
}
catch (FeatureChangeMergeException e)
{
    if (e.traceContainsExactFailureSubSequence(
        MergeFailureType.AUTOFAIL_POLYLINE_MERGE,
        MergeFailureType.BEFORE_VIEW_MERGE_STRATEGY_FAILED))
    {
        return featureChange1;
    }
    else
    {
        throw new CoreException("rethrowing", e);
    }
}
```

See this stack trace, which shows the error that occurs when attempting to merge two `Line` `FeatureChange`s that have conflicting polyline beforeViews.
```
org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: Cannot merge two feature changes:
FeatureChange [
changeType: ADD, 
itemType: LINE, 
identifier: 123, 
bounds: POLYGON ((-122.052138 1, -122.052138 37.390535, 2 37.390535, 2 1, -122.052138 1)), 
bfView: CompleteLine [identifier: 123, polyLine: LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535), tags: {a=1, b=2}, parentRelations: [1, 2, 3], ], 
afView: CompleteLine [identifier: 123, polyLine: LINESTRING (1 1, 2 2), tags: {a=1, b=2, c=3}, parentRelations: [1, 2, 3, 4], ], 
metadata: {}
]
AND
FeatureChange [
changeType: ADD, 
itemType: LINE, 
identifier: 123, 
bounds: POLYGON ((-122.052138 1, -122.052138 37.390535, 2 37.390535, 2 1, -122.052138 1)), 
bfView: CompleteLine [identifier: 123, polyLine: LINESTRING (-122.009566 37.33531, -122.031007 37.390535, -122.028932 37.332451, -122.052138 37.317585, -122.0304871 37.3314171), tags: {a=1, b=2}, parentRelations: [1, 2, 3], ], 
afView: CompleteLine [identifier: 123, polyLine: LINESTRING (1 1, 2 2), tags: {a=1, b=12}, parentRelations: [2, 3], ], 
metadata: {}
]
Parent failureTrace: [AUTOFAIL_POLYLINE_MERGE, BEFORE_VIEW_MERGE_STRATEGY_FAILED]

	at org.openstreetmap.atlas.geography.atlas.change.FeatureChange.merge(FeatureChange.java:495)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChangeMergerTest.testMergeLinesSuccess(FeatureChangeMergerTest.java:396)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: Attempted beforeView merge strategy failed for polyLine with beforeView: LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535) vs LINESTRING (-122.009566 37.33531, -122.031007 37.390535, -122.028932 37.332451, -122.052138 37.317585, -122.0304871 37.3314171)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMemberWithConflictingBeforeViews(MemberMerger.java:496)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMember(MemberMerger.java:270)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChangeMergingHelpers.mergeLineItems(FeatureChangeMergingHelpers.java:426)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChangeMergingHelpers.mergeADDFeatureChangePair(FeatureChangeMergingHelpers.java:108)
	at org.openstreetmap.atlas.geography.atlas.change.FeatureChange.merge(FeatureChange.java:481)
	... 23 more
Caused by: org.openstreetmap.atlas.exception.change.FeatureChangeMergeException: autofailBinaryPolyLineMerger: LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535) vs LINESTRING (-122.009566 37.33531, -122.031007 37.390535, -122.028932 37.332451, -122.052138 37.317585, -122.0304871 37.3314171)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMergeStrategies.lambda$static$10(MemberMergeStrategies.java:114)
	at org.openstreetmap.atlas.geography.atlas.change.MemberMerger.mergeMemberWithConflictingBeforeViews(MemberMerger.java:491)
	... 27 more
```

### Potential Impact:
N/A

### Unit Test Approach:
Updated the tests.

### Test Results:
Tests still pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
