### PR TITLE
Make IsoLanguage Serializable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/locale/IsoLanguage.java
+++ b/src/main/java/org/openstreetmap/atlas/locale/IsoLanguage.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.locale;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -14,7 +15,7 @@ import org.openstreetmap.atlas.utilities.collections.EnhancedCollectors;
  *
  * @author robert_stack
  */
-public final class IsoLanguage implements Comparable<IsoLanguage>
+public final class IsoLanguage implements Comparable<IsoLanguage>, Serializable
 {
     // Use United States fixed Locale for display use cases
     private static final Locale LANGUAGE_LOCALE = Locale.US;

--- a/src/test/java/org/openstreetmap/atlas/locale/IsoLanguageTest.java
+++ b/src/test/java/org/openstreetmap/atlas/locale/IsoLanguageTest.java
@@ -2,8 +2,10 @@ package org.openstreetmap.atlas.locale;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 
 /**
  * Test case for IsoLanguage
@@ -35,5 +37,16 @@ public class IsoLanguageTest
         Assert.assertEquals("Spanish", isoLanguage3.get().getDisplayLanguage());
 
         Assert.assertTrue(IsoLanguage.allLanguageCodes().contains("ar"));
+    }
+
+    @Test
+    public void testSerialization()
+    {
+        final IsoLanguage spanish = IsoLanguage.forLanguageCode("es")
+                .orElseThrow(() -> new CoreException("es should correspond to Spanish."));
+        final IsoLanguage roundtrip = SerializationUtils
+                .deserialize(SerializationUtils.serialize(spanish));
+        Assert.assertEquals(spanish.getLanguageCode(), roundtrip.getLanguageCode());
+        Assert.assertEquals(spanish.getDisplayLanguage(), roundtrip.getDisplayLanguage());
     }
 }


### PR DESCRIPTION
### Description:

IsoLanguage is currently not serializable, which was giving me an error when I wanted to store it as a field in an object that needed to be serializable.

I found a workaround for the moment but also didn't see a reason for IsoLanguage to not be serializable.

### Potential Impact:

Downstream libraries can now use IsoLanguages as fields in their classes.
 
### Unit Test Approach:

Added a unit test that serializes/deserializes an IsoLanguage and verifies that it remains unchanged.

### Test Results:

Tests passing.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
