### PR TITLE
Fix loxodromic midpoint on same circle of latitude

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -456,6 +456,12 @@ public class Location
         double lambda = ((lon2 - lon1) * Math.log(phi3) + lon1 * Math.log(phi2)
                 - lon2 * Math.log(phi1)) / Math.log(phi2 / phi1);
 
+        // Locations on the same circle of latitude
+        if (!Double.isFinite(lambda))
+        {
+            lambda = (lon1 + lon2) / 2;
+        }
+
         // Normalize to -180/180
         lambda = (lambda + FACTOR_OF_3 * Math.PI) % (2 * Math.PI) - Math.PI;
 

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -130,6 +130,13 @@ public class LocationTest extends Command
 
         Assert.assertEquals(51.0455, midpoint.getLatitude().asDegrees(), DELTA);
         Assert.assertEquals(1.5957265, midpoint.getLongitude().asDegrees(), DELTA);
+
+        final Location location3 = new Location(Latitude.degrees(49), Longitude.degrees(-95.153));
+        final Location location4 = new Location(Latitude.degrees(49), Longitude.degrees(-123.323));
+        final Location midpoint2 = location3.loxodromicMidPoint(location4);
+
+        Assert.assertEquals(49.0, midpoint2.getLatitude().asDegrees(), DELTA);
+        Assert.assertEquals(-109.238, midpoint2.getLongitude().asDegrees(), DELTA);
     }
 
     @Test


### PR DESCRIPTION
### Description:

Currently, the `Location.loxodromicMidPoint()` method does not produce correct longitude results when the two locations have the same latitude. This is because the intermediate longitude value, `lambda`, is not finite in this case. For points on the same circle of latitude, the midpoint's longitude may be calculated by simply taking the mean of the input longitudes.

### Potential Impact:

This fixes the correctness of this method, so downstream impact should be minimal unless someone was relying on incorrect behavior. Searching GitHub does not return any uses of this method in code outside Atlas.

### Unit Test Approach:

A unit test was added which calculates the midpoint of two locations on the same circle of latitude. With this fix, the test passes. 

### Test Results:

This method was tested on a sampling of real lines in some production Atlas files, and returns the expected results.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)