### PR TITLE
Special-case +180 in loxodromic midpoint

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -462,8 +462,16 @@ public class Location
             lambda = (lon1 + lon2) / 2;
         }
 
-        // Normalize to -180/180
-        lambda = (lambda + FACTOR_OF_3 * Math.PI) % (2 * Math.PI) - Math.PI;
+        // Normalize to [-180, +180), unless both input points are at +180, then return +180
+        if (this.getLongitude().equals(Longitude.MAXIMUM)
+                && that.getLongitude().equals(Longitude.MAXIMUM))
+        {
+            lambda = Longitude.MAXIMUM.asRadians();
+        }
+        else
+        {
+            lambda = (lambda + FACTOR_OF_3 * Math.PI) % (2 * Math.PI) - Math.PI;
+        }
 
         return new Location(Latitude.radians(pheta), Longitude.radians(lambda));
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -137,6 +137,20 @@ public class LocationTest extends Command
 
         Assert.assertEquals(49.0, midpoint2.getLatitude().asDegrees(), DELTA);
         Assert.assertEquals(-109.238, midpoint2.getLongitude().asDegrees(), DELTA);
+
+        final Location location5 = new Location(Latitude.degrees(40.0), Longitude.degrees(-180.0));
+        final Location location6 = new Location(Latitude.degrees(50.0), Longitude.degrees(-180.0));
+        final Location midpoint3 = location5.loxodromicMidPoint(location6);
+
+        Assert.assertEquals(45.0, midpoint3.getLatitude().asDegrees(), DELTA);
+        Assert.assertEquals(-180.0, midpoint3.getLongitude().asDegrees(), DELTA);
+
+        final Location location7 = new Location(Latitude.degrees(40.0), Longitude.degrees(180.0));
+        final Location location8 = new Location(Latitude.degrees(50.0), Longitude.degrees(180.0));
+        final Location midpoint4 = location7.loxodromicMidPoint(location8);
+
+        Assert.assertEquals(45.0, midpoint4.getLatitude().asDegrees(), DELTA);
+        Assert.assertEquals(180.0, midpoint4.getLongitude().asDegrees(), DELTA);
     }
 
     @Test


### PR DESCRIPTION
### Description:

Since https://github.com/osmlab/atlas/pull/457 adds support for distinguishing points on both the positive and negative side of the antimeridian, it’s best for this method to return +180˚ points when
both input Locations are on the positive antimeridian line. This mirrors a change to the other `Location.midPoint()` method made in the other PR.
 
### Potential Impact:

If a downstream user wants to subdivide meridian lines, for example because they are constructing grids or graticules using Atlas types, or are working with the boundaries of Fiji like in the aforelinked PR, this ensures that the resulting geometry remains in the eastern hemisphere if both input points were in that hemisphere. 

### Unit Test Approach:

The new tests check the midpoint along both the positive and negative antimeridian. In the general case, this method will continue to return -180˚ for points along the antimeridian.

### Test Results:

Lines along the very edge of the eastern hemisphere, like the boundaries of Fiji and Russia, now have a midpoint that preserves their (positive) sign.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)