### PR TITLE
Return Optional.empty overall heading for looping LineItems

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java
@@ -13,6 +13,8 @@ import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.LocationIterableProperties;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonObject;
 
@@ -25,6 +27,7 @@ import com.google.gson.JsonObject;
 public abstract class LineItem extends AtlasItem
 {
     private static final long serialVersionUID = -2053566750957119655L;
+    private static final Logger logger = LoggerFactory.getLogger(LineItem.class);
 
     protected LineItem(final Atlas atlas)
     {
@@ -102,6 +105,18 @@ public abstract class LineItem extends AtlasItem
      */
     public Optional<Heading> overallHeading()
     {
+        final PolyLine polyLine = this.asPolyLine();
+        if (polyLine.first().equals(polyLine.last()))
+        {
+            if (logger.isWarnEnabled())
+            {
+                logger.warn(
+                        "Cannot compute ({},{})'s overall heading when the polyline has "
+                                + "same start and end locations : {}",
+                        this.getType(), this.getIdentifier(), polyLine.first().toWkt());
+            }
+            return Optional.empty();
+        }
         return this.asPolyLine().overallHeading();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/LineItemTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/LineItemTest.java
@@ -1,0 +1,26 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+
+/**
+ * @author matthieun
+ */
+public class LineItemTest
+{
+    @Rule
+    public final LineItemTestRule rule = new LineItemTestRule();
+
+    @Test
+    public void testOverallHeading()
+    {
+        final Atlas atlas = this.rule.getoverallHeadingAtlas();
+        final Line linear = atlas.line(1L);
+        final Line loop = atlas.line(2L);
+        Assert.assertTrue(linear.overallHeading().isPresent());
+        Assert.assertEquals(725290933L, linear.overallHeading().get().asDm7());
+        Assert.assertFalse(loop.overallHeading().isPresent());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/LineItemTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/LineItemTestRule.java
@@ -1,0 +1,38 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * @author matthieun
+ */
+public class LineItemTestRule extends CoreTestRule
+{
+    private static final String ONE = "37.780574, -122.472852";
+    private static final String TWO = "37.780592, -122.472242";
+    private static final String THREE = "37.780724, -122.472249";
+    private static final String FOUR = "37.780825, -122.471896";
+
+    @TestAtlas(
+
+            lines = {
+
+                    @TestAtlas.Line(id = "1", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = THREE) }, tags = { "name=Linear" }),
+                    @TestAtlas.Line(id = "2", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO), @TestAtlas.Loc(value = THREE),
+                            @TestAtlas.Loc(value = FOUR),
+                            @TestAtlas.Loc(value = ONE) }, tags = { "name=Loop" })
+
+            }
+
+    )
+    private Atlas overallHeadingAtlas;
+
+    public Atlas getoverallHeadingAtlas()
+    {
+        return this.overallHeadingAtlas;
+    }
+}


### PR DESCRIPTION
### Description:

The contract of `overallHeading` for a `LineItem` and a `PolyLine` is to return `Optional.empty()` when the heading cannot be computed (mostly when the start and end locations are the same).
This was respected by `PolyLine` but not by `LineItem` and this PR fixes that.

### Potential Impact:

This should reduce the risk of exceptions being thrown when a polyline is a loop.

### Unit Test Approach:

Added one unit test

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
