### PR TITLE
Fixed a bounds bug in CompleteRelation.withExtraMember

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
@@ -158,23 +158,8 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.polygon == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.polygon != null && this.tags != null
+                && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
@@ -44,6 +44,11 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
      */
     public static CompleteArea from(final Area area)
     {
+        if (area instanceof CompleteArea && !((CompleteArea) area).isFull())
+        {
+            throw new CoreException("Area parameter was a CompleteArea but it was not full: {}",
+                    area);
+        }
         return new CompleteArea(area.getIdentifier(), area.asPolygon(), area.getTags(),
                 area.relations().stream().map(Relation::getIdentifier).collect(Collectors.toSet()));
     }
@@ -60,6 +65,10 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
      */
     public static CompleteArea shallowFrom(final Area area)
     {
+        if (area.bounds() == null)
+        {
+            throw new CoreException("Area parameter bounds were null");
+        }
         return new CompleteArea(area.getIdentifier()).withBoundsExtendedBy(area.bounds());
     }
 
@@ -144,6 +153,28 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
     public int hashCode()
     {
         return super.hashCode();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.polygon == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
@@ -47,6 +47,11 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
      */
     public static CompleteEdge from(final Edge edge)
     {
+        if (edge instanceof CompleteEdge && !((CompleteEdge) edge).isFull())
+        {
+            throw new CoreException("Edge parameter was a CompleteEdge but it was not full: {}",
+                    edge);
+        }
         return new CompleteEdge(edge.getIdentifier(), edge.asPolyLine(), edge.getTags(),
                 edge.start().getIdentifier(), edge.end().getIdentifier(),
                 edge.relations().stream().map(Relation::getIdentifier).collect(Collectors.toSet()));
@@ -64,6 +69,10 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
      */
     public static CompleteEdge shallowFrom(final Edge edge)
     {
+        if (edge.bounds() == null)
+        {
+            throw new CoreException("Edge parameter bounds were null");
+        }
         return new CompleteEdge(edge.getIdentifier()).withBoundsExtendedBy(edge.bounds());
     }
 
@@ -164,6 +173,36 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
     public int hashCode()
     {
         return super.hashCode();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.polyLine == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.startNodeIdentifier == null)
+        {
+            return false;
+        }
+        if (this.endNodeIdentifier == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
@@ -178,31 +178,9 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.polyLine == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.startNodeIdentifier == null)
-        {
-            return false;
-        }
-        if (this.endNodeIdentifier == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.polyLine != null && this.tags != null
+                && this.startNodeIdentifier != null && this.endNodeIdentifier != null
+                && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -32,6 +32,12 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
  */
 public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeListenable
 {
+    /*
+     * TODO add an isFull method for better fail-fast messaging. E.g. when calling
+     * CompleteEntity.from(CompleteEntity), we want to fail fast if the CompleteEntity parameter is
+     * not full.
+     */
+
     static Map<String, String> addNewTag(final Map<String, String> tags, final String key,
             final String value)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -32,12 +32,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
  */
 public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeListenable
 {
-    /*
-     * TODO add an isFull method for better fail-fast messaging. E.g. when calling
-     * CompleteEntity.from(CompleteEntity), we want to fail fast if the CompleteEntity parameter is
-     * not full.
-     */
-
     static Map<String, String> addNewTag(final Map<String, String> tags, final String key,
             final String value)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -257,6 +257,13 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
     ItemType getType();
 
     /**
+     * A full {@link CompleteEntity} is one one that contains a non-null value for all its fields.
+     *
+     * @return if this entity is full
+     */
+    boolean isFull();
+
+    /**
      * A shallow {@link CompleteEntity} is one that contains only its identifier as effective data.
      *
      * @return if this entity is shallow

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
@@ -158,23 +158,8 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.polyLine == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.polyLine != null && this.tags != null
+                && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
@@ -44,6 +44,11 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
      */
     public static CompleteLine from(final Line line)
     {
+        if (line instanceof CompleteLine && !((CompleteLine) line).isFull())
+        {
+            throw new CoreException("Line parameter was a CompleteLine but it was not full: {}",
+                    line);
+        }
         return new CompleteLine(line.getIdentifier(), line.asPolyLine(), line.getTags(),
                 line.relations().stream().map(Relation::getIdentifier).collect(Collectors.toSet()));
     }
@@ -60,6 +65,10 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
      */
     public static CompleteLine shallowFrom(final Line line)
     {
+        if (line.bounds() == null)
+        {
+            throw new CoreException("Line parameter bounds were null");
+        }
         return new CompleteLine(line.getIdentifier()).withBoundsExtendedBy(line.bounds());
     }
 
@@ -144,6 +153,28 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
     public int hashCode()
     {
         return super.hashCode();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.polyLine == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -198,31 +198,9 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.location == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.inEdgeIdentifiers == null)
-        {
-            return false;
-        }
-        if (this.outEdgeIdentifiers == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.location != null && this.tags != null
+                && this.inEdgeIdentifiers != null && this.outEdgeIdentifiers != null
+                && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -51,6 +51,11 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
      */
     public static CompleteNode from(final Node node)
     {
+        if (node instanceof CompleteNode && !((CompleteNode) node).isFull())
+        {
+            throw new CoreException("Node parameter was a CompleteNode but it was not full: {}",
+                    node);
+        }
         return new CompleteNode(node.getIdentifier(), node.getLocation(), node.getTags(),
                 node.inEdges().stream().map(Edge::getIdentifier)
                         .collect(Collectors.toCollection(TreeSet::new)),
@@ -71,6 +76,10 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
      */
     public static CompleteNode shallowFrom(final Node node)
     {
+        if (node.bounds() == null)
+        {
+            throw new CoreException("Node parameter bounds were null");
+        }
         return new CompleteNode(node.getIdentifier()).withBoundsExtendedBy(node.bounds());
     }
 
@@ -184,6 +193,36 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this.inEdgeIdentifiers == null ? null
                 : this.inEdgeIdentifiers.stream().map(CompleteEdge::new)
                         .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.location == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.inEdgeIdentifiers == null)
+        {
+            return false;
+        }
+        if (this.outEdgeIdentifiers == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
@@ -157,23 +157,8 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.location == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.location != null && this.tags != null
+                && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
@@ -43,6 +43,11 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
      */
     public static CompletePoint from(final Point point)
     {
+        if (point instanceof CompletePoint && !((CompletePoint) point).isFull())
+        {
+            throw new CoreException("Point parameter was a CompletePoint but it was not full: {}",
+                    point);
+        }
         return new CompletePoint(point.getIdentifier(), point.getLocation(), point.getTags(), point
                 .relations().stream().map(Relation::getIdentifier).collect(Collectors.toSet()));
     }
@@ -59,6 +64,10 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
      */
     public static CompletePoint shallowFrom(final Point point)
     {
+        if (point.bounds() == null)
+        {
+            throw new CoreException("Point parameter bounds were null");
+        }
         return new CompletePoint(point.getIdentifier()).withBoundsExtendedBy(point.bounds());
     }
 
@@ -143,6 +152,28 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
     public int hashCode()
     {
         return super.hashCode();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.location == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -374,13 +374,13 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
     public CompleteRelation withExtraMember(final AtlasEntity newMember,
             final AtlasEntity memberFromWhichToCopyRole)
     {
-        final Relation sourceRelation = Iterables.stream(memberFromWhichToCopyRole.relations())
+        final Relation parentRelation = Iterables.stream(memberFromWhichToCopyRole.relations())
                 .firstMatching(relation -> relation.getIdentifier() == this.getIdentifier())
                 .orElseThrow(() -> new CoreException(
                         "Cannot copy role from {} {} as it does not have relation {} as parent",
                         memberFromWhichToCopyRole.getType(),
                         memberFromWhichToCopyRole.getIdentifier(), this.getIdentifier()));
-        final String role = sourceRelation.members().asBean()
+        final String role = parentRelation.members().asBean()
                 .getItemFor(memberFromWhichToCopyRole.getIdentifier(),
                         memberFromWhichToCopyRole.getType())
                 .orElseThrow(() -> new CoreException(
@@ -396,7 +396,7 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
     {
         this.members.addItem(
                 new RelationBeanItem(newMember.getIdentifier(), role, newMember.getType()));
-        this.updateBounds(newMember.bounds());
+        this.withBoundsExtendedBy(newMember.bounds());
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -203,35 +203,9 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
     @Override
     public boolean isFull()
     {
-        if (this.bounds == null)
-        {
-            return false;
-        }
-        if (this.tags == null)
-        {
-            return false;
-        }
-        if (this.members == null)
-        {
-            return false;
-        }
-        if (this.allRelationsWithSameOsmIdentifier == null)
-        {
-            return false;
-        }
-        if (this.allKnownOsmMembers == null)
-        {
-            return false;
-        }
-        if (this.osmRelationIdentifier == null)
-        {
-            return false;
-        }
-        if (this.relationIdentifiers == null)
-        {
-            return false;
-        }
-        return true;
+        return this.bounds != null && this.tags != null && this.members != null
+                && this.allRelationsWithSameOsmIdentifier != null && this.allKnownOsmMembers != null
+                && this.osmRelationIdentifier != null && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -54,6 +54,11 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
      */
     public static CompleteRelation from(final Relation relation)
     {
+        if (relation instanceof CompleteRelation && !((CompleteRelation) relation).isFull())
+        {
+            throw new CoreException(
+                    "Relation parameter was a CompleteRelation but it was not full: {}", relation);
+        }
         return new CompleteRelation(relation.getIdentifier(), relation.getTags(), relation.bounds(),
                 relation.members().asBean(),
                 relation.allRelationsWithSameOsmIdentifier().stream().map(Relation::getIdentifier)
@@ -75,6 +80,10 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
      */
     public static CompleteRelation shallowFrom(final Relation relation)
     {
+        if (relation.bounds() == null)
+        {
+            throw new CoreException("Relation parameter bounds were null");
+        }
         return new CompleteRelation(relation.getIdentifier())
                 .withBoundsExtendedBy(relation.bounds());
     }
@@ -189,6 +198,40 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
     public int hashCode()
     {
         return super.hashCode();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        if (this.bounds == null)
+        {
+            return false;
+        }
+        if (this.tags == null)
+        {
+            return false;
+        }
+        if (this.members == null)
+        {
+            return false;
+        }
+        if (this.allRelationsWithSameOsmIdentifier == null)
+        {
+            return false;
+        }
+        if (this.allKnownOsmMembers == null)
+        {
+            return false;
+        }
+        if (this.osmRelationIdentifier == null)
+        {
+            return false;
+        }
+        if (this.relationIdentifiers == null)
+        {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteAreaTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteAreaTest.java
@@ -30,6 +30,16 @@ public class CompleteAreaTest
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
+    public void testAreaShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("bounds were null");
+
+        final CompleteArea area = new CompleteArea(1L, null, null, null);
+        CompleteArea.shallowFrom(area);
+    }
+
+    @Test
     public void testBloatedEquals()
     {
         final CompleteArea area11 = new CompleteArea(123L, null, null, null);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteAreaTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteAreaTest.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -23,6 +25,9 @@ public class CompleteAreaTest
 {
     @Rule
     public CompleteTestRule rule = new CompleteTestRule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testBloatedEquals()
@@ -76,6 +81,16 @@ public class CompleteAreaTest
     {
         final CompleteArea superShallow = new CompleteArea(123L, null, null, null);
         Assert.assertTrue(superShallow.isShallow());
+    }
+
+    @Test
+    public void testNonFullAreaCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteArea area = new CompleteArea(1L, null, null, null);
+        CompleteArea.from(area);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -23,6 +25,9 @@ public class CompleteEdgeTest
 {
     @Rule
     public CompleteTestRule rule = new CompleteTestRule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testBloatedEquals()
@@ -96,6 +101,16 @@ public class CompleteEdgeTest
     {
         final CompleteEdge superShallow = new CompleteEdge(123L, null, null, null, null, null);
         Assert.assertTrue(superShallow.isShallow());
+    }
+
+    @Test
+    public void testNonFullEdgeCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteEdge edge = new CompleteEdge(1L, null, null, null, null, null);
+        CompleteEdge.from(edge);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
@@ -81,7 +81,7 @@ public class CompleteEdgeTest
     public void testEdgeShallowCopyNullBounds()
     {
         this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("but it was not full");
+        this.expectedException.expectMessage("bounds were null");
 
         final CompleteEdge edge = new CompleteEdge(1L, null, null, null, null, null);
         CompleteEdge.shallowFrom(edge);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdgeTest.java
@@ -78,6 +78,16 @@ public class CompleteEdgeTest
     }
 
     @Test
+    public void testEdgeShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteEdge edge = new CompleteEdge(1L, null, null, null, null, null);
+        CompleteEdge.shallowFrom(edge);
+    }
+
+    @Test
     public void testFull()
     {
         final Atlas atlas = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLineTest.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -23,6 +25,9 @@ public class CompleteLineTest
 {
     @Rule
     public CompleteTestRule rule = new CompleteTestRule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testBloatedEquals()
@@ -76,6 +81,16 @@ public class CompleteLineTest
     {
         final CompleteLine superShallow = new CompleteLine(123L, null, null, null);
         Assert.assertTrue(superShallow.isShallow());
+    }
+
+    @Test
+    public void testNonFullLineCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteLine line = new CompleteLine(1L, null, null, null);
+        CompleteLine.from(line);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLineTest.java
@@ -84,6 +84,16 @@ public class CompleteLineTest
     }
 
     @Test
+    public void testLineShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("bounds were null");
+
+        final CompleteLine line = new CompleteLine(1L, null, null, null);
+        CompleteLine.shallowFrom(line);
+    }
+
+    @Test
     public void testNonFullLineCopy()
     {
         this.expectedException.expect(CoreException.class);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -25,6 +27,9 @@ public class CompleteNodeTest
 {
     @Rule
     public CompleteTestRule rule = new CompleteTestRule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testBloatedEquals()
@@ -112,6 +117,16 @@ public class CompleteNodeTest
     {
         final CompleteNode superShallow = new CompleteNode(123L, null, null, null, null, null);
         Assert.assertTrue(superShallow.isShallow());
+    }
+
+    @Test
+    public void testNonFullNodeCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteNode node = new CompleteNode(1L, null, null, null, null, null);
+        CompleteNode.from(node);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
@@ -120,6 +120,16 @@ public class CompleteNodeTest
     }
 
     @Test
+    public void testNodeShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteNode node = new CompleteNode(1L, null, null, null, null, null);
+        CompleteNode.shallowFrom(node);
+    }
+
+    @Test
     public void testNonFullNodeCopy()
     {
         this.expectedException.expect(CoreException.class);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNodeTest.java
@@ -123,7 +123,7 @@ public class CompleteNodeTest
     public void testNodeShallowCopyNullBounds()
     {
         this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("but it was not full");
+        this.expectedException.expectMessage("bounds were null");
 
         final CompleteNode node = new CompleteNode(1L, null, null, null, null, null);
         CompleteNode.shallowFrom(node);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
@@ -96,7 +96,7 @@ public class CompletePointTest
     public void testPointShallowCopyNullBounds()
     {
         this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("but it was not full");
+        this.expectedException.expectMessage("bounds were null");
 
         final CompletePoint point = new CompletePoint(1L, null, null, null);
         CompletePoint.shallowFrom(point);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
@@ -93,6 +93,16 @@ public class CompletePointTest
     }
 
     @Test
+    public void testPointShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompletePoint point = new CompletePoint(1L, null, null, null);
+        CompletePoint.shallowFrom(point);
+    }
+
+    @Test
     public void testShallow()
     {
         final Atlas atlas = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePointTest.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -22,6 +24,9 @@ public class CompletePointTest
 {
     @Rule
     public CompleteTestRule rule = new CompleteTestRule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testBloatedEquals()
@@ -75,6 +80,16 @@ public class CompletePointTest
     {
         final CompletePoint superShallow = new CompletePoint(123L, null, null, null);
         Assert.assertTrue(superShallow.isShallow());
+    }
+
+    @Test
+    public void testNonFullPointCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompletePoint point = new CompletePoint(1L, null, null, null);
+        CompletePoint.from(point);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -118,6 +118,17 @@ public class CompleteRelationTest
     }
 
     @Test
+    public void testEdgeShallowCopyNullBounds()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteRelation relation = new CompleteRelation(1L, null, null, null, null, null,
+                null, null);
+        CompleteRelation.shallowFrom(relation);
+    }
+
+    @Test
     public void testFailWithMembersAndSource()
     {
         final CompleteRelation relation = new CompleteRelation(1L, null, null, null, null, null,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -163,6 +163,17 @@ public class CompleteRelationTest
     }
 
     @Test
+    public void testNonFullRelationCopy()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("but it was not full");
+
+        final CompleteRelation relation = new CompleteRelation(1L, null, null, null, null, null,
+                null, null);
+        CompleteRelation.from(relation);
+    }
+
+    @Test
     public void testShallow()
     {
         final Atlas atlas = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -211,4 +211,16 @@ public class CompleteRelationTest
         final CompleteRelation relation2 = new CompleteRelation(123L);
         Assert.assertNull(relation2.toWkt());
     }
+
+    @Test
+    public void testWithExtraMember()
+    {
+        final Atlas atlas = this.rule.getAtlas2();
+
+        final CompleteRelation cRelation = CompleteRelation.from(atlas.relation(1L));
+        Assert.assertEquals(atlas.relation(1L).bounds(), cRelation.bounds());
+        cRelation.withExtraMember(atlas.point(5L), "a");
+        Assert.assertEquals(Rectangle.forLocated(atlas.relation(1L).bounds(), atlas.point(5L)),
+                cRelation.bounds());
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -121,7 +121,7 @@ public class CompleteRelationTest
     public void testEdgeShallowCopyNullBounds()
     {
         this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("but it was not full");
+        this.expectedException.expectMessage("bounds were null");
 
         final CompleteRelation relation = new CompleteRelation(1L, null, null, null, null, null,
                 null, null);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteTestRule.java
@@ -20,6 +20,18 @@ public class CompleteTestRule extends CoreTestRule
     public static final String POINT_1_LOCATION = "37.331417,-122.0304871";
     public static final String POINT_2_LOCATION = "37.333364,-122.0200268";
 
+    private static final String ONE = "15.420563,-61.336198";
+    private static final String TWO = "15.429499,-61.332850";
+    private static final String THREE = "15.4855,-61.3041";
+    private static final String FOUR = "15.4809,-61.3366";
+    private static final String FIVE = "15.4852,-61.3816";
+    private static final String SIX = "15.4781,-61.3949";
+    private static final String SEVEN = "15.4145,-61.3826";
+    private static final String EIGHT = "15.4073,-61.3749";
+    private static final String NINE = "15.4075,-61.3746";
+    private static final String TEN = "15.4081,-61.3741";
+    private static final String ELEVEN = "15.4111,-62.3741";
+
     @TestAtlas(
 
             nodes = { @Node(id = "1", coordinates = @Loc(value = POINT_1_LOCATION)),
@@ -43,8 +55,42 @@ public class CompleteTestRule extends CoreTestRule
     )
     private Atlas atlas;
 
+    @TestAtlas(
+
+            points = {
+
+                    @Point(id = "1", coordinates = @Loc(value = ONE)),
+                    @Point(id = "2", coordinates = @Loc(value = TWO)),
+                    @Point(id = "3", coordinates = @Loc(value = THREE)),
+                    @Point(id = "4", coordinates = @Loc(value = FOUR)),
+                    @Point(id = "5", coordinates = @Loc(value = FIVE)),
+                    @Point(id = "6", coordinates = @Loc(value = SIX)),
+                    @Point(id = "7", coordinates = @Loc(value = SEVEN))
+
+            },
+
+            relations = {
+
+                    @Relation(id = "1", tags = { "type=relation" }, members = {
+
+                            @Member(id = "1", role = "a", type = "point"),
+                            @Member(id = "2", role = "a", type = "point"),
+                            @Member(id = "3", role = "a", type = "point")
+
+                    })
+
+            }
+
+    )
+    private Atlas atlas2;
+
     public Atlas getAtlas()
     {
         return this.atlas;
+    }
+
+    public Atlas getAtlas2()
+    {
+        return this.atlas2;
     }
 }


### PR DESCRIPTION
### Description:

`withExtraMember` was incorrectly resetting the bounds instead of extending it.

### Potential Impact:

N/A

### Unit Test Approach:

Added a unit test to verify correct behavior.

### Test Results:

Test pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)