### PR TITLE
Allow to retrieve the DynamicAtlasPolicy from a DynamicAtlas

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -173,6 +173,11 @@ public class DynamicAtlas extends BareAtlas // NOSONAR
         return getShardsLoaded().size();
     }
 
+    public DynamicAtlasPolicy getPolicy()
+    {
+        return this.expander.getPolicy();
+    }
+
     /**
      * @return All the shards explored by this {@link DynamicAtlas} including the ones that yielded
      *         no Atlas.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
@@ -78,6 +78,11 @@ class DynamicAtlasExpander
         this.initialized = true;
     }
 
+    public DynamicAtlasPolicy getPolicy()
+    {
+        return this.policy;
+    }
+
     boolean areaCovered(final Area area)
     {
         final Polygon polygon = area.asPolygon();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -68,6 +68,13 @@ public class DynamicAtlasTest
     }
 
     @Test
+    public void testGetPolicy()
+    {
+        Assert.assertEquals(this.policySupplier.get().getInitialShards(),
+                this.dynamicAtlas.getPolicy().getInitialShards());
+    }
+
+    @Test
     public void testLoadAreaByIdentifier()
     {
         // Already loaded: 12-1350-1870


### PR DESCRIPTION
### Description:

Allow to retrieve the `DynamicAtlasPolicy` from a `DynamicAtlas`

### Potential Impact:

The dynamic atlas user has now access to the policy, including the expansion rules, initial shard, etc.

### Unit Test Approach:

Added very simple test

### Test Results:

tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)