### PR TITLE
Fix maximum rectangle width issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
@@ -561,8 +561,13 @@ public final class Rectangle extends Polygon
      */
     public Angle width()
     {
-        return Angle.dm7(
-                this.upperRight.getLongitude().asDm7() - this.lowerLeft.getLongitude().asDm7());
+        long dm7Difference = this.upperRight.getLongitude().asDm7()
+                - this.lowerLeft.getLongitude().asDm7();
+        if (dm7Difference >= Angle.REVOLUTION_DM7)
+        {
+            dm7Difference = Angle.REVOLUTION_DM7 - 1;
+        }
+        return Angle.dm7(dm7Difference);
     }
 
     protected Rectangle2D asAwtRectangle()

--- a/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
@@ -178,5 +178,14 @@ public class RectangleTest
         Assert.assertTrue(surface.isLessThan(this.rectangle3.surface()));
         Assert.assertTrue(this.rectangle1.surface().add(this.rectangle2.surface())
                 .isLessThan(this.rectangle3.surface()));
+
+        Assert.assertEquals(6479999998200000000L, Rectangle.MAXIMUM.surface().asDm7Squared());
+    }
+
+    @Test
+    public void testWidth()
+    {
+        Assert.assertEquals(50160, this.rectangle1.width().asDm7());
+        Assert.assertEquals(-1, Rectangle.MAXIMUM.width().asDm7());
     }
 }


### PR DESCRIPTION
### Description:

This is a fix for #502 

### Potential Impact:

`Rectangle.MAXIMUM` now returns the right width

### Unit Test Approach:

Added new tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
