### PR TITLE
Check overall heading makes sense in PolyLine

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
@@ -843,8 +843,16 @@ public class PolyLine
     {
         if (this.isPoint())
         {
-            logger.warn("Cannot compute a segment's heading when the polyline has zero length : {}",
-                    this);
+            logger.warn("Cannot compute a PolyLine's heading when it has zero length : {}", this);
+            return Optional.empty();
+        }
+        if (this.first().equals(this.last()))
+        {
+            if (logger.isWarnEnabled())
+            {
+                logger.warn("Cannot compute overall heading when the polyline has "
+                        + "same start and end locations : {}", this.first().toWkt());
+            }
             return Optional.empty();
         }
         return Optional.ofNullable(this.first().headingTo(this.last()));

--- a/src/test/java/org/openstreetmap/atlas/geography/PolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolyLineTest.java
@@ -149,6 +149,19 @@ public class PolyLineTest
     }
 
     @Test
+    public void testOverallHeading()
+    {
+        final PolyLine line1 = new PolyLine(Location.CROSSING_85_280, Location.TEST_1);
+        final PolyLine line2 = new PolyLine(Location.CROSSING_85_280, Location.TEST_1,
+                Location.CROSSING_85_280);
+        final PolyLine line3 = new PolyLine(Location.CROSSING_85_280);
+        Assert.assertTrue(line1.overallHeading().isPresent());
+        Assert.assertEquals(Heading.degrees(85.5165015), line1.overallHeading().get());
+        Assert.assertFalse(line2.overallHeading().isPresent());
+        Assert.assertFalse(line3.overallHeading().isPresent());
+    }
+
+    @Test
     public void testOverlapsShape()
     {
         final PolyLine larger = new PolyLine(Location.CROSSING_85_280, Location.TEST_1,


### PR DESCRIPTION
### Description:

Calling `PolyLine.overallHeading()` would fail in case the `PolyLine` has same start and end locations. This fixes the issue, and is very similar to #498 

### Potential Impact:

Calls do not result in exception

### Unit Test Approach:

Added one test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
