### PR TITLE
Implemented more CompleteRelation API methods for ease of use

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -342,6 +342,34 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
         return RelationBean.mergeBeans(this, other);
     }
 
+    public void removeItem(final Long identifier, final ItemType itemType)
+    {
+        int firstMatchingIndex = -1;
+        for (int i = 0; i < this.beanItems.size(); i++)
+        {
+            if (this.beanItems.get(i).getIdentifier().equals(identifier)
+                    && this.beanItems.get(i).getType().equals(itemType))
+            {
+                firstMatchingIndex = i;
+            }
+        }
+
+        if (firstMatchingIndex != -1)
+        {
+            this.beanItems.remove(firstMatchingIndex);
+        }
+    }
+
+    public void removeItem(final Long identifier, final String role, final ItemType itemType)
+    {
+        removeItem(new RelationBeanItem(identifier, role, itemType));
+    }
+
+    public void removeItem(final RelationBeanItem item)
+    {
+        this.beanItems.remove(item);
+    }
+
     /**
      * @return The number of members in this {@link RelationBean}
      */

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -85,7 +85,6 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     private static final long serialVersionUID = 8511830231633569713L;
 
     private final List<Long> memberIdentifiers;
-
     private final List<String> memberRoles;
     private final List<ItemType> memberTypes;
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -92,7 +92,7 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
     private static final long serialVersionUID = 8511830231633569713L;
 
-    private final List<RelationBeanItem> beanItems;
+    private List<RelationBeanItem> beanItems;
     /**
      * This set has no concept of how many {@link RelationBeanItem}s of a given value have been
      * removed. Technically, OSM allows for duplicate {@link RelationBeanItem}s in a given relation.
@@ -343,36 +343,38 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     }
 
     /**
-     * Remove an item from this {@link RelationBean} with a given identifier and {@link ItemType}.
-     * If an item is actually removed, this method will return its role wrapped in an
-     * {@link Optional}. If nothing was removed, then the {@link Optional} will be empty.
+     * Remove all matching item from this {@link RelationBean} with a given identifier and
+     * {@link ItemType}. If item(s) are actually removed, this method will return a {@link List} of
+     * their roles. If nothing was removed, then the {@link List} will be empty.
      * 
      * @param identifier
      *            the id to remove
      * @param itemType
      *            the type to remove
-     * @return an {@link Optional} wrapping the role of the removed item
+     * @return a {@link List} containing the roles of the removed items
      */
-    public Optional<String> removeItem(final Long identifier, final ItemType itemType)
+    public List<String> removeAllMatchingItems(final Long identifier, final ItemType itemType)
     {
-        int firstMatchingIndex = -1;
-        for (int i = 0; i < this.beanItems.size(); i++)
+        final List<RelationBeanItem> newBeanItems = new ArrayList<>();
+        final List<String> removedRoles = new ArrayList<>();
+
+        for (final RelationBeanItem item : this.beanItems)
         {
-            if (this.beanItems.get(i).getIdentifier().equals(identifier)
-                    && this.beanItems.get(i).getType().equals(itemType))
+            if (item.getIdentifier().equals(identifier) && item.getType().equals(itemType))
             {
-                firstMatchingIndex = i;
+                removedRoles.add(item.getRole());
+            }
+            else
+            {
+                newBeanItems.add(
+                        new RelationBeanItem(item.getIdentifier(), item.getRole(), item.getType()));
             }
         }
-
-        if (firstMatchingIndex != -1)
+        if (!removedRoles.isEmpty())
         {
-            final String removedRole = this.beanItems.get(firstMatchingIndex).getRole();
-            this.beanItems.remove(firstMatchingIndex);
-            return Optional.of(removedRole);
+            this.beanItems = newBeanItems;
         }
-
-        return Optional.empty();
+        return removedRoles;
     }
 
     public boolean removeItem(final Long identifier, final String role, final ItemType itemType)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -342,7 +342,18 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
         return RelationBean.mergeBeans(this, other);
     }
 
-    public void removeItem(final Long identifier, final ItemType itemType)
+    /**
+     * Remove an item from this {@link RelationBean} with a given identifier and {@link ItemType}.
+     * If an item is actually removed, this method will return its role wrapped in an
+     * {@link Optional}. If nothing was removed, then the {@link Optional} will be empty.
+     * 
+     * @param identifier
+     *            the id to remove
+     * @param itemType
+     *            the type to remove
+     * @return an {@link Optional} wrapping the role of the removed item
+     */
+    public Optional<String> removeItem(final Long identifier, final ItemType itemType)
     {
         int firstMatchingIndex = -1;
         for (int i = 0; i < this.beanItems.size(); i++)
@@ -356,18 +367,22 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
         if (firstMatchingIndex != -1)
         {
+            final String removedRole = this.beanItems.get(firstMatchingIndex).getRole();
             this.beanItems.remove(firstMatchingIndex);
+            return Optional.of(removedRole);
         }
+
+        return Optional.empty();
     }
 
-    public void removeItem(final Long identifier, final String role, final ItemType itemType)
+    public boolean removeItem(final Long identifier, final String role, final ItemType itemType)
     {
-        removeItem(new RelationBeanItem(identifier, role, itemType));
+        return removeItem(new RelationBeanItem(identifier, role, itemType));
     }
 
-    public void removeItem(final RelationBeanItem item)
+    public boolean removeItem(final RelationBeanItem item)
     {
-        this.beanItems.remove(item);
+        return this.beanItems.remove(item);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBeanItem;
@@ -39,6 +40,13 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
             this.identifier = identifier;
             this.role = role;
             this.type = type;
+        }
+
+        public RelationBeanItem(final RelationBeanItem item)
+        {
+            this.identifier = item.identifier;
+            this.role = item.role;
+            this.type = item.type;
         }
 
         @Override
@@ -78,15 +86,13 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
         @Override
         public String toString()
         {
-            return this.type + ", " + this.identifier + ", " + this.role;
+            return "[" + this.type + ", " + this.identifier + ", " + this.role + "]";
         }
     }
 
     private static final long serialVersionUID = 8511830231633569713L;
 
-    private final List<Long> memberIdentifiers;
-    private final List<String> memberRoles;
-    private final List<ItemType> memberTypes;
+    private final List<RelationBeanItem> beanItems;
     /**
      * This set has no concept of how many {@link RelationBeanItem}s of a given value have been
      * removed. Technically, OSM allows for duplicate {@link RelationBeanItem}s in a given relation.
@@ -138,10 +144,7 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
     public RelationBean()
     {
-        this.memberIdentifiers = new ArrayList<>();
-        this.memberRoles = new ArrayList<>();
-        this.memberTypes = new ArrayList<>();
-
+        this.beanItems = new ArrayList<>();
         this.explicitlyExcluded = new HashSet<>();
     }
 
@@ -154,9 +157,7 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
     public void addItem(final Long identifier, final String role, final ItemType itemType)
     {
-        this.memberIdentifiers.add(identifier);
-        this.memberRoles.add(role);
-        this.memberTypes.add(itemType);
+        this.beanItems.add(new RelationBeanItem(identifier, role, itemType));
     }
 
     public void addItem(final RelationBeanItem item)
@@ -182,13 +183,7 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
      */
     public List<RelationBeanItem> asList()
     {
-        final List<RelationBeanItem> result = new ArrayList<>();
-        for (int index = 0; index < size(); index++)
-        {
-            result.add(new RelationBeanItem(this.memberIdentifiers.get(index),
-                    this.memberRoles.get(index), this.memberTypes.get(index)));
-        }
-        return result;
+        return new ArrayList<>(this.beanItems);
     }
 
     /**
@@ -278,10 +273,10 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
     public Optional<RelationBeanItem> getItemFor(final long identifier, final ItemType type)
     {
-        for (int index = 0; index < this.memberIdentifiers.size(); index++)
+        for (int index = 0; index < this.beanItems.size(); index++)
         {
-            if (this.memberIdentifiers.get(index) == identifier
-                    && this.memberTypes.get(index) == type)
+            if (this.beanItems.get(index).getIdentifier() == identifier
+                    && this.beanItems.get(index).getType() == type)
             {
                 return Optional.of(getItemFor(index));
             }
@@ -292,11 +287,11 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     public Optional<RelationBeanItem> getItemFor(final long identifier, final String role,
             final ItemType type)
     {
-        for (int index = 0; index < this.memberIdentifiers.size(); index++)
+        for (int index = 0; index < this.beanItems.size(); index++)
         {
-            if (this.memberIdentifiers.get(index) == identifier
-                    && role.equals(this.memberRoles.get(index))
-                    && this.memberTypes.get(index) == type)
+            if (this.beanItems.get(index).getIdentifier() == identifier
+                    && role.equals(this.beanItems.get(index).getRole())
+                    && this.beanItems.get(index).getType() == type)
             {
                 return Optional.of(getItemFor(index));
             }
@@ -306,17 +301,18 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
 
     public List<Long> getMemberIdentifiers()
     {
-        return this.memberIdentifiers;
+        return this.beanItems.stream().map(RelationBeanItem::getIdentifier)
+                .collect(Collectors.toList());
     }
 
     public List<String> getMemberRoles()
     {
-        return this.memberRoles;
+        return this.beanItems.stream().map(RelationBeanItem::getRole).collect(Collectors.toList());
     }
 
     public List<ItemType> getMemberTypes()
     {
-        return this.memberTypes;
+        return this.beanItems.stream().map(RelationBeanItem::getType).collect(Collectors.toList());
     }
 
     @Override
@@ -332,19 +328,13 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     @Override
     public boolean isEmpty()
     {
-        return this.memberIdentifiers.isEmpty();
+        return this.beanItems.isEmpty();
     }
 
     @Override
     public Iterator<RelationBeanItem> iterator()
     {
-        final List<RelationBeanItem> result = new ArrayList<>();
-        for (int index = 0; index < this.memberIdentifiers.size(); index++)
-        {
-            result.add(new RelationBeanItem(this.memberIdentifiers.get(index),
-                    this.memberRoles.get(index), this.memberTypes.get(index)));
-        }
-        return result.iterator();
+        return this.beanItems.iterator();
     }
 
     public RelationBean merge(final RelationBean other)
@@ -358,24 +348,22 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     @Override
     public int size()
     {
-        return this.memberIdentifiers.size();
+        return this.beanItems.size();
     }
 
     @Override
     public String toString()
     {
-        return "RelationBean [memberIdentifiers=" + this.memberIdentifiers + ", memberRoles="
-                + this.memberRoles + ", memberTypes=" + this.memberTypes + "]";
+        return "RelationBean [" + this.beanItems + "]";
     }
 
     private RelationBeanItem getItemFor(final int index)
     {
-        if (index < 0 || index > this.memberIdentifiers.size())
+        if (index < 0 || index >= size())
         {
             throw new CoreException("Invalid index {}", index);
         }
-        return new RelationBeanItem(this.memberIdentifiers.get(index), this.memberRoles.get(index),
-                this.memberTypes.get(index));
+        return new RelationBeanItem(this.beanItems.get(index));
     }
 
     private boolean isExplicitlyExcluded(final RelationBeanItem relationBeanItem)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
@@ -254,6 +254,13 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
         return this.polygon.toWkt();
     }
 
+    @Override
+    public CompleteArea withAddedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers.add(relationIdentifier);
+        return this;
+    }
+
     public CompleteArea withBoundsExtendedBy(final Rectangle bounds)
     {
         if (this.bounds == null)
@@ -296,6 +303,15 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
     public CompleteArea withRelations(final Set<Relation> relations)
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
+    }
+
+    @Override
+    public CompleteArea withRemovedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers = this.relationIdentifiers.stream()
+                .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
@@ -299,6 +299,13 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
         return this.polyLine.toWkt();
     }
 
+    @Override
+    public CompleteEdge withAddedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers.add(relationIdentifier);
+        return this;
+    }
+
     public CompleteEdge withBoundsExtendedBy(final Rectangle bounds)
     {
         if (this.bounds == null)
@@ -348,6 +355,15 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
     public CompleteEdge withRelations(final Set<Relation> relations)
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
+    }
+
+    @Override
+    public CompleteEdge withRemovedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers = this.relationIdentifiers.stream()
+                .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -294,6 +294,8 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
      */
     String toWkt();
 
+    CompleteEntity withAddedRelationIdentifier(Long relationIdentifier);
+
     default C withAddedTag(final String key, final String value)
     {
         return CompleteEntity.withAddedTag((C) this, key, value, false);
@@ -306,6 +308,8 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
     CompleteEntity withRelationIdentifiers(Set<Long> relationIdentifiers);
 
     CompleteEntity withRelations(Set<Relation> relations);
+
+    CompleteEntity withRemovedRelationIdentifier(Long relationIdentifier);
 
     default C withRemovedTag(final String key)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
@@ -255,6 +255,13 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
         return this.polyLine.toWkt();
     }
 
+    @Override
+    public CompleteLine withAddedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers.add(relationIdentifier);
+        return this;
+    }
+
     public CompleteLine withBoundsExtendedBy(final Rectangle bounds)
     {
         if (this.bounds == null)
@@ -298,6 +305,15 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
     public CompleteLine withRelations(final Set<Relation> relations)
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
+    }
+
+    @Override
+    public CompleteLine withRemovedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers = this.relationIdentifiers.stream()
+                .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -345,6 +345,13 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this.location.toWkt();
     }
 
+    @Override
+    public CompleteNode withAddedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers.add(relationIdentifier);
+        return this;
+    }
+
     public CompleteNode withBoundsExtendedBy(final Rectangle bounds)
     {
         if (this.bounds == null)
@@ -482,6 +489,15 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     public CompleteNode withRelations(final Set<Relation> relations)
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
+    }
+
+    @Override
+    public CompleteNode withRemovedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers = this.relationIdentifiers.stream()
+                .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
@@ -254,6 +254,13 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
         return this.location.toWkt();
     }
 
+    @Override
+    public CompletePoint withAddedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers.add(relationIdentifier);
+        return this;
+    }
+
     public CompletePoint withBoundsExtendedBy(final Rectangle bounds)
     {
         if (this.bounds == null)
@@ -266,7 +273,7 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
     }
 
     @Override
-    public CompleteEntity withGeometry(final Iterable<Location> locations)
+    public CompletePoint withGeometry(final Iterable<Location> locations)
     {
         if (!locations.iterator().hasNext())
         {
@@ -301,6 +308,15 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
     public CompletePoint withRelations(final Set<Relation> relations)
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
+                .collect(Collectors.toSet());
+        return this;
+    }
+
+    @Override
+    public CompletePoint withRemovedRelationIdentifier(final Long relationIdentifier)
+    {
+        this.relationIdentifiers = this.relationIdentifiers.stream()
+                .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -521,13 +520,10 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
 
     public CompleteRelation withRemovedMember(final AtlasEntity memberToRemove)
     {
-        final Optional<String> role = this.members.removeItem(memberToRemove.getIdentifier(),
-                memberToRemove.getType());
-        if (role.isPresent())
-        {
-            this.members.addItemExplicitlyExcluded(memberToRemove.getIdentifier(), role.get(),
-                    memberToRemove.getType());
-        }
+        final List<String> roles = this.members
+                .removeAllMatchingItems(memberToRemove.getIdentifier(), memberToRemove.getType());
+        roles.forEach(role -> this.members.addItemExplicitlyExcluded(memberToRemove.getIdentifier(),
+                role, memberToRemove.getType()));
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -511,6 +511,29 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
         return this;
     }
 
+    public CompleteRelation withRemovedMember(final AtlasEntity memberToRemove)
+    {
+        return withRemovedMember(memberToRemove, null);
+    }
+
+    public CompleteRelation withRemovedMember(final AtlasEntity memberToRemove, final String role)
+    {
+        final RelationBean newMembers = new RelationBean();
+        for (final RelationBeanItem beanItem : this.members)
+        {
+            if (beanItem.getIdentifier() != memberToRemove.getIdentifier()
+                    || beanItem.getType() != memberToRemove.getType())
+            {
+                if (role == null || !beanItem.getRole().equals(role))
+                {
+                    newMembers.addItem(beanItem);
+                }
+            }
+        }
+        this.members = newMembers;
+        return this;
+    }
+
     private RelationMemberList membersFor(final RelationBean bean)
     {
         if (bean == null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -513,24 +513,13 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
 
     public CompleteRelation withRemovedMember(final AtlasEntity memberToRemove)
     {
-        return withRemovedMember(memberToRemove, null);
+        this.members.removeItem(memberToRemove.getIdentifier(), memberToRemove.getType());
+        return this;
     }
 
     public CompleteRelation withRemovedMember(final AtlasEntity memberToRemove, final String role)
     {
-        final RelationBean newMembers = new RelationBean();
-        for (final RelationBeanItem beanItem : this.members)
-        {
-            if (beanItem.getIdentifier() != memberToRemove.getIdentifier()
-                    || beanItem.getType() != memberToRemove.getType())
-            {
-                if (role == null || !beanItem.getRole().equals(role))
-                {
-                    newMembers.addItem(beanItem);
-                }
-            }
-        }
-        this.members = newMembers;
+        this.members.removeItem(memberToRemove.getIdentifier(), role, memberToRemove.getType());
         return this;
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -406,22 +406,27 @@ public class ChangeAtlasTest
         final Atlas atlas = this.rule.getPointAtlas();
         final ChangeBuilder changeBuilder = new ChangeBuilder();
 
+        /*
+         * Remove Point 1 role b, Point 2 role b, and Point 3 role c. The Point 3 remove will
+         * silently fail because Point 3 has role b and not role c.
+         */
         final CompleteRelation completeRelation = CompleteRelation.shallowFrom(atlas.relation(1L))
-                .withMembers(atlas.relation(1L).members());
-        completeRelation.withRemovedMember(atlas.point(1L));
+                .withMembers(atlas.relation(1L).members()).withRemovedMember(atlas.point(1L))
+                .withRemovedMember(atlas.point(2L), "b").withRemovedMember(atlas.point(3L), "c");
         changeBuilder.add(FeatureChange.add(completeRelation));
 
         final CompletePoint completePoint = CompletePoint.shallowFrom(atlas.point(1L))
-                .withRelations(atlas.point(1L).relations());
-        completePoint.withRelationIdentifiers(completePoint.relations().stream()
-                .filter(relation -> relation.getIdentifier() != 1L).map(Relation::getIdentifier)
-                .collect(Collectors.toSet()));
+                .withRelations(atlas.point(1L).relations()).withRemovedRelationIdentifier(1L);
         changeBuilder.add(FeatureChange.add(completePoint));
+        final CompletePoint completePoint2 = CompletePoint.shallowFrom(atlas.point(2L))
+                .withRelations(atlas.point(1L).relations()).withRemovedRelationIdentifier(1L);
+        changeBuilder.add(FeatureChange.add(completePoint2));
 
         final Atlas changeAtlas = new ChangeAtlas(atlas, changeBuilder.get());
-        System.out.println(changeAtlas.relation(1L));
         Assert.assertFalse(changeAtlas.relation(1L).members().asBean()
                 .contains(new RelationBean.RelationBeanItem(1L, "b", ItemType.POINT)));
+        Assert.assertFalse(changeAtlas.relation(1L).members().asBean()
+                .contains(new RelationBean.RelationBeanItem(2L, "b", ItemType.POINT)));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -401,6 +401,30 @@ public class ChangeAtlasTest
     }
 
     @Test
+    public void testRemoveRelationMemberEasy()
+    {
+        final Atlas atlas = this.rule.getPointAtlas();
+        final ChangeBuilder changeBuilder = new ChangeBuilder();
+
+        final CompleteRelation completeRelation = CompleteRelation.shallowFrom(atlas.relation(1L))
+                .withMembers(atlas.relation(1L).members());
+        completeRelation.withRemovedMember(atlas.point(1L));
+        changeBuilder.add(FeatureChange.add(completeRelation));
+
+        final CompletePoint completePoint = CompletePoint.shallowFrom(atlas.point(1L))
+                .withRelations(atlas.point(1L).relations());
+        completePoint.withRelationIdentifiers(completePoint.relations().stream()
+                .filter(relation -> relation.getIdentifier() != 1L).map(Relation::getIdentifier)
+                .collect(Collectors.toSet()));
+        changeBuilder.add(FeatureChange.add(completePoint));
+
+        final Atlas changeAtlas = new ChangeAtlas(atlas, changeBuilder.get());
+        System.out.println(changeAtlas.relation(1L));
+        Assert.assertFalse(changeAtlas.relation(1L).members().asBean()
+                .contains(new RelationBean.RelationBeanItem(1L, "b", ItemType.POINT)));
+    }
+
+    @Test
     public void testRemoveRelationMemberIsReflectedInMemberListAutomatically()
     {
         final Atlas atlas = this.rule.getAtlas();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTestRule.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
  * @author matthieun
@@ -92,6 +94,33 @@ public class ChangeAtlasTestRule extends CoreTestRule
     )
     private Atlas tagAtlas;
 
+    @TestAtlas(
+
+            points = {
+
+                    @Point(id = "1", coordinates = @Loc(value = ONE), tags = { "a=1", "b=2" }),
+                    @Point(id = "2", coordinates = @Loc(value = TWO), tags = { "a=1", "b=2" }),
+                    @Point(id = "3", coordinates = @Loc(value = THREE), tags = { "a=1", "b=2" }),
+                    @Point(id = "4", coordinates = @Loc(value = FOUR), tags = { "a=1", "b=2" })
+
+            },
+
+            relations = {
+
+                    @Relation(id = "1", tags = { "type=relation" }, members = {
+
+                            @Member(id = "1", role = "b", type = "point"),
+                            @Member(id = "2", role = "b", type = "point"),
+                            @Member(id = "3", role = "b", type = "point"),
+                            @Member(id = "4", role = "b", type = "point"),
+
+                    })
+
+            }
+
+    )
+    private Atlas pointAtlas;
+
     public Atlas differentNodeAndEdgeProperties1()
     {
         return this.differentNodeAndEdgeProperties1;
@@ -110,6 +139,11 @@ public class ChangeAtlasTestRule extends CoreTestRule
     public Atlas getAtlasEdge()
     {
         return this.atlasEdge;
+    }
+
+    public Atlas getPointAtlas()
+    {
+        return this.pointAtlas;
     }
 
     public Atlas getTagAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/MemberMergeStrategiesTest.java
@@ -501,7 +501,7 @@ public class MemberMergeStrategiesTest
          */
         this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
-                "diffBasedRelationBeanMerger failed due to ADD/ADD conflict on key: [AREA, 2, areaRole2]: beforeValue absolute count was 0 but addedLeft/Right diff counts conflict [1 vs 2]");
+                "diffBasedRelationBeanMerger failed due to ADD/ADD conflict on key: [[AREA, 2, areaRole2]]: beforeValue absolute count was 0 but addedLeft/Right diff counts conflict [1 vs 2]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
     }
 
@@ -544,7 +544,7 @@ public class MemberMergeStrategiesTest
          */
         this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
-                "diffBasedRelationBeanMerger failed due to ADD/REMOVE conflict(s) on key(s): [LINE, 1, lineRole1]");
+                "diffBasedRelationBeanMerger failed due to ADD/REMOVE conflict(s) on key(s): [[LINE, 1, lineRole1]]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
     }
 
@@ -584,7 +584,7 @@ public class MemberMergeStrategiesTest
          */
         this.expectedException.expect(FeatureChangeMergeException.class);
         this.expectedException.expectMessage(
-                "diffBasedRelationBeanMerger failed due to REMOVE/REMOVE conflict on key: [AREA, 1, areaRole1]: beforeValue absolute count was 2 but removedLeft/Right diff counts conflict [1 vs 2]");
+                "diffBasedRelationBeanMerger failed due to REMOVE/REMOVE conflict on key: [[AREA, 1, areaRole1]]: beforeValue absolute count was 2 but removedLeft/Right diff counts conflict [1 vs 2]");
         MemberMergeStrategies.diffBasedRelationBeanMerger.apply(beforeBean, afterBean1, afterBean2);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
@@ -76,7 +76,7 @@ public class EntityIdentifierGeneratorTest
         final CompleteRelation relation = new CompleteRelation(1L, Maps.hashMap("a", "b", "c", "d"),
                 Rectangle.MINIMUM, bean, null, null, null, Sets.hashSet());
 
-        final String goldenPropertyString = ";RelationBean [memberIdentifiers=[1, 10], memberRoles=[role, role], memberTypes=[POINT, AREA]]";
+        final String goldenPropertyString = ";RelationBean [[[POINT, 1, role], [AREA, 10, role]]]";
         Assert.assertEquals(goldenPropertyString,
                 new EntityIdentifierGenerator().getTypeSpecificPropertyString(relation));
     }


### PR DESCRIPTION
### Description:
Added a `withRemovedMember` method to CompleteRelation. Instead of using clunky `stream().filter().collect()` calls, you can now do something like:
```java
final CompleteRelation completeRelation = CompleteRelation.shallowFrom(atlas.relation(1L))
.withMembers(atlas.relation(1L).members())
.withRemovedMember(atlas.point(1L));
```

### Potential Impact:
Downstream code that is using `FeatureChange` to remove relation members can be much simpler now.

### Unit Test Approach:
Added some unit tests to ensure this works.

### Test Results:
Tests OK.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)