### PR TITLE
Atlas Command: AtlasShardingConverterCommand

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -431,7 +431,7 @@ public class DynamicTileSharding extends Command implements Sharding
     public Shard shardForName(final String name)
     {
         final SlippyTile result = SlippyTile.forName(name);
-        if (!this.root.leafNodesCovering(result.bounds().center()).equals(result))
+        if (!this.root.leafNodesCovering(result.bounds().center()).contains(new Node(result)))
         {
             throw new CoreException("This tree does not contain tile {}", name);
         }

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/DynamicTileSharding.java
@@ -428,6 +428,17 @@ public class DynamicTileSharding extends Command implements Sharding
     }
 
     @Override
+    public Shard shardForName(final String name)
+    {
+        final SlippyTile result = SlippyTile.forName(name);
+        if (!this.root.leafNodesCovering(result.bounds().center()).equals(result))
+        {
+            throw new CoreException("This tree does not contain tile {}", name);
+        }
+        return result;
+    }
+
+    @Override
     public Iterable<Shard> shards(final GeometricSurface surface)
     {
         return Iterables.stream(this.root.leafNodes(surface)).map(Node::getTile);

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/GeoHashSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/GeoHashSharding.java
@@ -41,6 +41,18 @@ public class GeoHashSharding implements Sharding
     }
 
     @Override
+    public Shard shardForName(final String name)
+    {
+        if (name.length() != this.precision)
+        {
+            throw new CoreException(
+                    "This geohash sharding is of precision {}. \"{}\" is not the correct length.",
+                    this.precision, name);
+        }
+        return GeoHashTile.forName(name);
+    }
+
+    @Override
     public Iterable<Shard> shards(final GeometricSurface surface)
     {
         return Iterables.stream(GeoHashTile.allTiles(this.precision, surface))

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/Sharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/Sharding.java
@@ -71,6 +71,15 @@ public interface Sharding extends Serializable
     Iterable<Shard> neighbors(Shard shard);
 
     /**
+     * Get a shard given its name
+     * 
+     * @param name
+     *            The name of the shard
+     * @return The corresponding shard
+     */
+    Shard shardForName(String name);
+
+    /**
      * Generate shards for the whole planet. This needs to be deterministic!
      *
      * @return The shards {@link Iterable}, covering the whole planet.

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTileSharding.java
@@ -39,6 +39,17 @@ public class SlippyTileSharding implements Sharding
     }
 
     @Override
+    public Shard shardForName(final String name)
+    {
+        final SlippyTile result = SlippyTile.forName(name);
+        if (result.getZoom() != this.zoom)
+        {
+            throw new CoreException("This sharding is of zoom {}, and \"{}\" is not.", this.zoom, name);
+        }
+        return result;
+    }
+
+    @Override
     public Iterable<Shard> shards(final GeometricSurface surface)
     {
         return Iterables.stream(SlippyTile.allTiles(this.zoom, surface.bounds()))

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTileSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTileSharding.java
@@ -44,7 +44,8 @@ public class SlippyTileSharding implements Sharding
         final SlippyTile result = SlippyTile.forName(name);
         if (result.getZoom() != this.zoom)
         {
-            throw new CoreException("This sharding is of zoom {}, and \"{}\" is not.", this.zoom, name);
+            throw new CoreException("This sharding is of zoom {}, and \"{}\" is not.", this.zoom,
+                    name);
         }
         return result;
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommand.java
@@ -26,6 +26,9 @@ import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgume
 import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 
 /**
+ * This command provides an easy way to change the sharding in which a folder of atlas files is
+ * described.
+ * 
  * @author matthieun
  */
 public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsCommand
@@ -41,6 +44,7 @@ public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsComman
 
     private static final Pattern FILE_MATCHER = Pattern
             .compile("^[A-Za-z0-9]+_{1}([A-Za-z0-9]|-)+\\.atlas$");
+    private static final String EXCEPTION_MESSAGE = "{} needs to be specified.";
 
     private final OptionAndArgumentDelegate optionAndArgumentDelegate;
     private final CommandOutputDelegate outputDelegate;
@@ -60,9 +64,9 @@ public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsComman
     public int execute()
     {
         final File inputFolder = new File(this.optionAndArgumentDelegate.getOptionArgument(INPUT)
-                .orElseThrow(() -> new CoreException("{} needs to be specified.", INPUT)));
+                .orElseThrow(() -> new CoreException(EXCEPTION_MESSAGE, INPUT)));
         final File outputFolder = new File(this.optionAndArgumentDelegate.getOptionArgument(OUTPUT)
-                .orElseThrow(() -> new CoreException("{} needs to be specified.", OUTPUT)));
+                .orElseThrow(() -> new CoreException(EXCEPTION_MESSAGE, OUTPUT)));
         if (!inputFolder.exists())
         {
             throw new CoreException("{} does not exist.", inputFolder);
@@ -71,12 +75,12 @@ public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsComman
         {
             throw new CoreException("{} already exists.", outputFolder);
         }
-        final Sharding inputSharding = Sharding.forString(
-                this.optionAndArgumentDelegate.getOptionArgument(INPUT_SHARDING).orElseThrow(
-                        () -> new CoreException("{} needs to be specified.", INPUT_SHARDING)));
-        final Sharding outputSharding = Sharding.forString(
-                this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_SHARDING).orElseThrow(
-                        () -> new CoreException("{} needs to be specified.", OUTPUT_SHARDING)));
+        final Sharding inputSharding = Sharding
+                .forString(this.optionAndArgumentDelegate.getOptionArgument(INPUT_SHARDING)
+                        .orElseThrow(() -> new CoreException(EXCEPTION_MESSAGE, INPUT_SHARDING)));
+        final Sharding outputSharding = Sharding
+                .forString(this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_SHARDING)
+                        .orElseThrow(() -> new CoreException(EXCEPTION_MESSAGE, OUTPUT_SHARDING)));
         final List<File> inputFiles = inputFolder.listFilesRecursively().stream()
                 .filter(file -> FILE_MATCHER.matcher(file.getName()).matches())
                 .collect(Collectors.toList());
@@ -161,9 +165,9 @@ public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsComman
         registerOptionWithRequiredArgument(OUTPUT, OUTPUT_DESCRIPTION, OptionOptionality.REQUIRED,
                 "/path/to/output");
         registerOptionWithRequiredArgument(INPUT_SHARDING, INPUT_SHARDING_DESCRIPTION,
-                OptionOptionality.REQUIRED, "slippy@10");
+                OptionOptionality.REQUIRED, "type@parameter");
         registerOptionWithRequiredArgument(OUTPUT_SHARDING, OUTPUT_SHARDING_DESCRIPTION,
-                OptionOptionality.REQUIRED, "geohash@4");
+                OptionOptionality.REQUIRED, "type@parameter");
         super.registerOptionsAndArguments();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommand.java
@@ -1,0 +1,169 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
+import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
+
+/**
+ * @author matthieun
+ */
+public class AtlasShardingConverterCommand extends AbstractAtlasShellToolsCommand
+{
+    private static final String INPUT = "input";
+    private static final String INPUT_DESCRIPTION = "The input folder containing XXX_<old_shard_name>.atlas files";
+    private static final String OUTPUT = "output";
+    private static final String OUTPUT_DESCRIPTION = "The output folder where XXX_<new_shard_name>.atlas files will be saved";
+    private static final String INPUT_SHARDING = "inputSharding";
+    private static final String INPUT_SHARDING_DESCRIPTION = "The input sharding";
+    private static final String OUTPUT_SHARDING = "outputSharding";
+    private static final String OUTPUT_SHARDING_DESCRIPTION = "The output sharding";
+
+    private static final Pattern FILE_MATCHER = Pattern
+            .compile("^[A-Za-z0-9]+_{1}([A-Za-z0-9]|-)+\\.atlas$");
+
+    private final OptionAndArgumentDelegate optionAndArgumentDelegate;
+    private final CommandOutputDelegate outputDelegate;
+
+    public static void main(final String[] args)
+    {
+        new AtlasShardingConverterCommand().runSubcommandAndExit(args);
+    }
+
+    public AtlasShardingConverterCommand()
+    {
+        this.optionAndArgumentDelegate = this.getOptionAndArgumentDelegate();
+        this.outputDelegate = this.getCommandOutputDelegate();
+    }
+
+    @Override
+    public int execute()
+    {
+        final File inputFolder = new File(this.optionAndArgumentDelegate.getOptionArgument(INPUT)
+                .orElseThrow(() -> new CoreException("{} needs to be specified.", INPUT)));
+        final File outputFolder = new File(this.optionAndArgumentDelegate.getOptionArgument(OUTPUT)
+                .orElseThrow(() -> new CoreException("{} needs to be specified.", OUTPUT)));
+        if (!inputFolder.exists())
+        {
+            throw new CoreException("{} does not exist.", inputFolder);
+        }
+        if (outputFolder.exists())
+        {
+            throw new CoreException("{} already exists.", outputFolder);
+        }
+        final Sharding inputSharding = Sharding.forString(
+                this.optionAndArgumentDelegate.getOptionArgument(INPUT_SHARDING).orElseThrow(
+                        () -> new CoreException("{} needs to be specified.", INPUT_SHARDING)));
+        final Sharding outputSharding = Sharding.forString(
+                this.optionAndArgumentDelegate.getOptionArgument(OUTPUT_SHARDING).orElseThrow(
+                        () -> new CoreException("{} needs to be specified.", OUTPUT_SHARDING)));
+        final List<File> inputFiles = inputFolder.listFilesRecursively().stream()
+                .filter(file -> FILE_MATCHER.matcher(file.getName()).matches())
+                .collect(Collectors.toList());
+        this.outputDelegate.printlnCommandMessage("Found input files: " + inputFiles);
+        final Map<Shard, File> inputShardToAtlas = new HashMap<>();
+        final Set<String> countries = new HashSet<>();
+        final Set<Shard> inputShards = inputFiles.stream().map(file ->
+        {
+            final StringList split = StringList.split(file.getName(), "_");
+            String shardName = split.get(1);
+            shardName = shardName.substring(0, shardName.indexOf(FileSuffix.ATLAS.toString()));
+            final Shard inputShard = inputSharding.shardForName(shardName);
+            inputShardToAtlas.put(inputShard, file);
+            countries.add(split.get(0));
+            return inputShard;
+        }).collect(Collectors.toSet());
+        if (countries.size() > 1)
+        {
+            throw new CoreException("Found more than one country in the folder: {}", countries);
+        }
+        this.outputDelegate.printlnCommandMessage(
+                "Found " + inputShards.size() + " input shards: " + inputShards);
+        this.outputDelegate.printlnCommandMessage("Found country: " + countries.iterator().next());
+        final Set<Shard> outputShards = inputShards.stream().flatMap(
+                inputShard -> Iterables.asList(outputSharding.shards(inputShard.bounds())).stream())
+                .collect(Collectors.toSet());
+        if (outputShards.isEmpty())
+        {
+            throw new CoreException("There are no resulting output shards.");
+        }
+        else
+        {
+            outputFolder.mkdirs();
+        }
+        this.outputDelegate.printlnCommandMessage(
+                "Found " + outputShards.size() + " output shards: " + outputShards);
+        for (final Shard outputShard : outputShards)
+        {
+            this.outputDelegate.printlnCommandMessage("Processing output shard " + outputShard);
+            final List<File> inputAtlases = new ArrayList<>();
+            Iterables.stream(inputSharding.shards(outputShard.bounds()))
+                    .filter(inputShardToAtlas::containsKey)
+                    .forEach(inputShard -> inputAtlases.add(inputShardToAtlas.get(inputShard)));
+            this.outputDelegate.printlnCommandMessage("Loading Atlas with " + inputAtlases);
+            final Atlas combined = new AtlasResourceLoader().load(inputAtlases);
+            final Optional<Atlas> result = combined.subAtlas(outputShard.bounds(),
+                    AtlasCutType.SOFT_CUT);
+            final File outputFile = outputFolder.child(
+                    countries.iterator().next() + "_" + outputShard.getName() + FileSuffix.ATLAS);
+            this.outputDelegate.printlnCommandMessage("Saving Atlas to " + outputFile);
+            result.ifPresent(atlas -> atlas.save(outputFile));
+        }
+        return 0;
+    }
+
+    @Override
+    public String getCommandName()
+    {
+        return "sharding-converter";
+    }
+
+    @Override
+    public String getSimpleDescription()
+    {
+        return "Translate Atlas files from one Sharding to another";
+    }
+
+    @Override
+    public void registerManualPageSections()
+    {
+        addManualPageSection("DESCRIPTION", AtlasShardingConverterCommand.class
+                .getResourceAsStream("AtlasShardingConverterCommandDescriptionSection.txt"));
+        addManualPageSection("EXAMPLES", AtlasShardingConverterCommand.class
+                .getResourceAsStream("AtlasShardingConverterCommandExamplesSection.txt"));
+    }
+
+    @Override
+    public void registerOptionsAndArguments()
+    {
+        registerOptionWithRequiredArgument(INPUT, INPUT_DESCRIPTION, OptionOptionality.REQUIRED,
+                "/path/to/atlases");
+        registerOptionWithRequiredArgument(OUTPUT, OUTPUT_DESCRIPTION, OptionOptionality.REQUIRED,
+                "/path/to/output");
+        registerOptionWithRequiredArgument(INPUT_SHARDING, INPUT_SHARDING_DESCRIPTION,
+                OptionOptionality.REQUIRED, "slippy@10");
+        registerOptionWithRequiredArgument(OUTPUT_SHARDING, OUTPUT_SHARDING_DESCRIPTION,
+                OptionOptionality.REQUIRED, "geohash@4");
+        super.registerOptionsAndArguments();
+    }
+}

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandDescriptionSection.txt
@@ -1,0 +1,2 @@
+This command provides an easy way to change the sharding in which a folder
+of atlas files is described.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandExamplesSection.txt
@@ -1,0 +1,2 @@
+Convert a folder from geohash precision 4 to slippy tile zoom 7
+#$ shardingConverter --input=/path/to/in --result=/path/to/out --inputSharding=geohash@4 --outputSharding=slippy@7

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandExamplesSection.txt
@@ -1,2 +1,2 @@
 Convert a folder from geohash precision 4 to slippy tile zoom 7
-#$ shardingConverter --input=/path/to/in --result=/path/to/out --inputSharding=geohash@4 --outputSharding=slippy@7
+#$ shardingConverter --input=/path/to/in --output=/path/to/out --inputSharding=geohash@4 --outputSharding=slippy@7

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/DynamicTileShardingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/DynamicTileShardingTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 
@@ -23,6 +24,8 @@ public class DynamicTileShardingTest
     {
         final Map<SlippyTile, Long> countsAtZoom2 = new HashMap<SlippyTile, Long>()
         {
+            private static final long serialVersionUID = 8166718906410476661L;
+
             {
                 put(new SlippyTile(0, 0, 2), (long) 5);
                 put(new SlippyTile(1, 0, 2), (long) 3);
@@ -89,5 +92,24 @@ public class DynamicTileShardingTest
         Assert.assertNotEquals(shardingTreeOriginal, missingChildren);
         // child order ignore
         Assert.assertEquals(shardingTreeOriginal, differentChildOrdering);
+    }
+
+    @Test
+    public void testForName()
+    {
+        final DynamicTileSharding shardingTreeOriginal = new DynamicTileSharding(
+                new InputStreamResource(() -> DynamicTileShardingTest.class
+                        .getResourceAsStream("testDynamicSharding.txt")));
+        Assert.assertEquals(SlippyTile.forName("8-13-39"),
+                shardingTreeOriginal.shardForName("8-13-39"));
+    }
+
+    @Test(expected = CoreException.class)
+    public void testForNameError()
+    {
+        final DynamicTileSharding shardingTreeOriginal = new DynamicTileSharding(
+                new InputStreamResource(() -> DynamicTileShardingTest.class
+                        .getResourceAsStream("testDynamicSharding.txt")));
+        shardingTreeOriginal.shardForName("7-6-19");
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/GeoHashShardingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/GeoHashShardingTest.java
@@ -16,6 +16,20 @@ public class GeoHashShardingTest
     private final Sharding sharding = Sharding.forString("geohash@7");
 
     @Test
+    public void testForName()
+    {
+        final Sharding sharding = Sharding.forString("geohash@4");
+        Assert.assertEquals(GeoHashTile.forName("gbsf"), sharding.shardForName("gbsf"));
+    }
+
+    @Test(expected = CoreException.class)
+    public void testForNameError()
+    {
+        final Sharding sharding = Sharding.forString("geohash@4");
+        sharding.shardForName("something");
+    }
+
+    @Test
     public void testGetPrecision()
     {
         Assert.assertEquals(7, ((GeoHashSharding) this.sharding).getPrecision());

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/SlippyTileShardingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/SlippyTileShardingTest.java
@@ -1,0 +1,25 @@
+package org.openstreetmap.atlas.geography.sharding;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * @author matthieun
+ */
+public class SlippyTileShardingTest
+{
+    @Test
+    public void testForName()
+    {
+        final Sharding sharding = Sharding.forString("slippy@11");
+        Assert.assertEquals(SlippyTile.forName("11-998-709"), sharding.shardForName("11-998-709"));
+    }
+
+    @Test(expected = CoreException.class)
+    public void testForNameError()
+    {
+        final Sharding sharding = Sharding.forString("slippy@11");
+        sharding.shardForName("10-498-354");
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardingConverterCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardingConverterCommandTest.java
@@ -1,0 +1,92 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.testing.OsmFileParser;
+import org.openstreetmap.atlas.utilities.testing.OsmFileToPbf;
+
+/**
+ * @author matthieun
+ */
+public class ShardingConverterCommandTest
+{
+    @Test
+    public void testConvert()
+    {
+        final File folder = File.temporaryFolder();
+        try
+        {
+            createTestAtlas(folder);
+            final File output = folder.child("output");
+            final StringList arguments = new StringList();
+            arguments.add("--input=" + folder.child("input").getAbsolutePath());
+            arguments.add("--inputSharding=slippy@11");
+            arguments.add("--output=" + output.getAbsolutePath());
+            arguments.add("--outputSharding=geohash@4");
+
+            final String[] args = new String[arguments.size()];
+            for (int index = 0; index < arguments.size(); index++)
+            {
+                args[index] = arguments.get(index);
+            }
+            final AtlasShardingConverterCommand command = new AtlasShardingConverterCommand();
+            command.runSubcommand(args);
+
+            Assert.assertEquals(2, output.listFilesRecursively().size());
+            Assert.assertEquals(5,
+                    new AtlasResourceLoader().load(output.child("FRA_gbsf.atlas")).numberOfEdges());
+            Assert.assertEquals(8,
+                    new AtlasResourceLoader().load(output.child("FRA_gbsg.atlas")).numberOfEdges());
+        }
+        finally
+        {
+            folder.deleteRecursively();
+        }
+    }
+
+    private void createTestAtlas(final File folder)
+    {
+        final Resource resource = new InputStreamResource(() -> PbfToAtlasCommandTest.class
+                .getResourceAsStream("shardingConverter.josm.osm"));
+        final File pbfFile = folder.child("shardingConverter.pbf");
+        final StringResource osmFile = new StringResource();
+        new OsmFileParser().update(resource, osmFile);
+        new OsmFileToPbf().update(osmFile, pbfFile);
+
+        final StringList arguments = new StringList();
+        arguments.add(pbfFile.getAbsolutePath());
+        arguments.add("--output=" + folder.getAbsolutePath());
+        arguments.add("--countryName=FRA");
+
+        final String[] args = new String[arguments.size()];
+        for (int index = 0; index < arguments.size(); index++)
+        {
+            args[index] = arguments.get(index);
+        }
+        new PbfToAtlasCommand().runSubcommand(args);
+
+        final Atlas full = new AtlasResourceLoader()
+                .load(folder.child("FRA_shardingConverter.atlas"));
+        final File input = folder.child("input");
+        input.mkdirs();
+        final SlippyTile tile1 = SlippyTile.forName("11-998-708");
+        full.subAtlas(tile1.bounds(), AtlasCutType.SOFT_CUT)
+                .orElseThrow(() -> new CoreException("Should be there."))
+                .save(input.child("FRA_" + tile1.getName() + FileSuffix.ATLAS));
+        final SlippyTile tile2 = SlippyTile.forName("11-998-709");
+        full.subAtlas(tile2.bounds(), AtlasCutType.SOFT_CUT)
+                .orElseThrow(() -> new CoreException("Should be there."))
+                .save(input.child("FRA_" + tile2.getName() + FileSuffix.ATLAS));
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/utilities/command/subcommands/shardingConverter.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/command/subcommands/shardingConverter.josm.osm
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-194075' action='modify' visible='true' lat='48.34286153221' lon='-4.44799965592' />
+  <node id='-194076' action='modify' visible='true' lat='48.34124777257' lon='-4.44881305288' />
+  <node id='-194078' action='modify' visible='true' lat='48.34024017084' lon='-4.44782711717' />
+  <node id='-194080' action='modify' visible='true' lat='48.3386590971' lon='-4.44855424476' />
+  <node id='-194088' action='modify' visible='true' lat='48.34091190754' lon='-4.44546087148' />
+  <node id='-194090' action='modify' visible='true' lat='48.33946192824' lon='-4.44361224203' />
+  <node id='-194092' action='modify' visible='true' lat='48.33849525246' lon='-4.44048189616' />
+  <node id='-194101' action='modify' visible='true' lat='48.34333663952' lon='-4.44896094324' />
+  <node id='-194103' action='modify' visible='true' lat='48.34333663952' lon='-4.44654540076' />
+  <node id='-194112' action='modify' visible='true' lat='48.33820033077' lon='-4.4497496918' />
+  <node id='-194114' action='modify' visible='true' lat='48.33815936929' lon='-4.44737112191' />
+  <node id='-194122' action='modify' visible='true' lat='48.34243775021' lon='-4.43492532849' />
+  <node id='-194123' action='modify' visible='true' lat='48.33967789637' lon='-4.43547249913' />
+  <node id='-194125' action='modify' visible='true' lat='48.33880783395' lon='-4.43802596211' />
+  <node id='-194134' action='modify' visible='true' lat='48.34267510401' lon='-4.43550725999' />
+  <node id='-194136' action='modify' visible='true' lat='48.34261302345' lon='-4.43390078098' />
+  <way id='-194077' action='modify' visible='true'>
+    <nd ref='-194075' />
+    <nd ref='-194076' />
+    <nd ref='-194078' />
+    <nd ref='-194080' />
+    <tag k='highway' v='primary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-194089' action='modify' visible='true'>
+    <nd ref='-194076' />
+    <nd ref='-194088' />
+    <nd ref='-194090' />
+    <nd ref='-194092' />
+    <tag k='highway' v='secondary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-194102' action='modify' visible='true'>
+    <nd ref='-194101' />
+    <nd ref='-194075' />
+    <nd ref='-194103' />
+    <tag k='highway' v='trunk' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-194113' action='modify' visible='true'>
+    <nd ref='-194112' />
+    <nd ref='-194080' />
+    <nd ref='-194114' />
+    <tag k='highway' v='residential' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-194124' action='modify' visible='true'>
+    <nd ref='-194122' />
+    <nd ref='-194123' />
+    <nd ref='-194125' />
+    <nd ref='-194092' />
+    <tag k='highway' v='unclassified' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-194135' action='modify' visible='true'>
+    <nd ref='-194134' />
+    <nd ref='-194122' />
+    <nd ref='-194136' />
+    <tag k='highway' v='track' />
+    <tag k='oneway' v='yes' />
+  </way>
+</osm>


### PR DESCRIPTION
### Description:

Create an atlas command which provides an easy way to change the sharding in which a folder of atlas files is described.

For example, the geohash folder:
```
path/to/input
  ABC_cefd.atlas
  ABC_cefg.atlas
```

can be translated into:

```
path/to/output
  ABC_10-115-116.atlas
  ABC_10-115-117.atlas
  ABC_11-224-222.atlas
```

### Potential Impact:

new command

### Unit Test Approach:

Added multiple unit tests

### Test Results:

unit tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)