### PR TITLE
CompleteEntity: Truncate pretty strings for large geometries

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
@@ -194,7 +194,7 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
         builder.append(separator);
         if (this.polygon != null)
         {
-            builder.append("polygon: " + this.polygon + ", ");
+            builder.append("polygon: " + truncate(this.polygon.toString()) + ", ");
             builder.append(separator);
         }
         if (this.tags != null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
@@ -218,7 +218,7 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
         builder.append(separator);
         if (this.polyLine != null)
         {
-            builder.append("polyLine: " + this.polyLine + ", ");
+            builder.append("polyLine: " + truncate(this.polyLine.toString()) + ", ");
             builder.append(separator);
         }
         if (this.startNodeIdentifier != null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -32,8 +32,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
  */
 public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeListenable
 {
-    int TRUNCATE_LENGTH = 2000;
-
     static Map<String, String> addNewTag(final Map<String, String> tags, final String key,
             final String value)
     {
@@ -298,7 +296,7 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
 
     default String truncate(final String input)
     {
-        return input.substring(0, Math.min(input.length(), TRUNCATE_LENGTH));
+        return input.substring(0, Math.min(input.length(), PrettifyStringFormat.TRUNCATE_LENGTH));
     }
 
     CompleteEntity withAddedRelationIdentifier(Long relationIdentifier);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -32,6 +32,8 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
  */
 public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeListenable
 {
+    int TRUNCATE_LENGTH = 2000;
+
     static Map<String, String> addNewTag(final Map<String, String> tags, final String key,
             final String value)
     {
@@ -293,6 +295,11 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
      * @return the WKT of this entity's geometry, null if the geometry is null
      */
     String toWkt();
+
+    default String truncate(final String input)
+    {
+        return input.substring(0, Math.min(input.length(), TRUNCATE_LENGTH));
+    }
 
     CompleteEntity withAddedRelationIdentifier(Long relationIdentifier);
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
@@ -195,7 +195,7 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
         builder.append(separator);
         if (this.polyLine != null)
         {
-            builder.append("polyLine: " + this.polyLine + ", ");
+            builder.append("polyLine: " + truncate(this.polyLine.toString()) + ", ");
             builder.append(separator);
         }
         if (this.tags != null)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/PrettifyStringFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/PrettifyStringFormat.java
@@ -6,5 +6,7 @@ package org.openstreetmap.atlas.geography.atlas.complete;
 public enum PrettifyStringFormat
 {
     MINIMAL_SINGLE_LINE,
-    MINIMAL_MULTI_LINE
+    MINIMAL_MULTI_LINE;
+
+    public static final int TRUNCATE_LENGTH = 2000;
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
@@ -21,7 +21,7 @@ public class CompleteEntityTest
 
         Assert.assertEquals(one, new CompleteArea(1L, null, null, null).truncate(one));
         Assert.assertEquals(2100, two.length());
-        Assert.assertEquals(CompleteEntity.TRUNCATE_LENGTH,
+        Assert.assertEquals(PrettifyStringFormat.TRUNCATE_LENGTH,
                 new CompleteArea(1L, null, null, null).truncate(two).length());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
@@ -3,6 +3,9 @@ package org.openstreetmap.atlas.geography.atlas.complete;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * @author matthieun
+ */
 public class CompleteEntityTest
 {
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
@@ -1,0 +1,24 @@
+package org.openstreetmap.atlas.geography.atlas.complete;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CompleteEntityTest
+{
+    @Test
+    public void testTruncate()
+    {
+        final String one = "abc";
+        final StringBuilder twoBuilder = new StringBuilder();
+        for (int index = 0; index < 2100; index++)
+        {
+            twoBuilder.append("a");
+        }
+        final String two = twoBuilder.toString();
+
+        Assert.assertEquals(one, new CompleteArea(1L, null, null, null).truncate(one));
+        Assert.assertEquals(2100, two.length());
+        Assert.assertEquals(CompleteEntity.TRUNCATE_LENGTH,
+                new CompleteArea(1L, null, null, null).truncate(two).length());
+    }
+}


### PR DESCRIPTION
### Description:

Truncate pretty strings for large geometries when prettifying a CompleteEntity

### Potential Impact:

Less logs

### Unit Test Approach:

Added one unit test

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)