### PR TITLE
Cap message size in FeatureChangeMergeException

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -14,11 +14,11 @@ import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 public class FeatureChangeMergeException extends CoreException
 {
     private static final long serialVersionUID = -3583945839922744755L;
-    private static final int MAXIMUM_MESSAGE_SIZE = 2000;
+    static final int MAXIMUM_MESSAGE_SIZE = 2000;
 
     private final List<MergeFailureType> failureTypeTrace;
 
-    private static String truncate(final String input)
+    static String truncate(final String input)
     {
         return input.substring(0, Math.min(input.length(), MAXIMUM_MESSAGE_SIZE));
     }

--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -14,13 +14,19 @@ import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 public class FeatureChangeMergeException extends CoreException
 {
     private static final long serialVersionUID = -3583945839922744755L;
+    private static final int MAXIMUM_MESSAGE_SIZE = 2000;
 
     private final List<MergeFailureType> failureTypeTrace;
+
+    private static String truncate(final String input)
+    {
+        return input.substring(0, Math.min(input.length(), MAXIMUM_MESSAGE_SIZE));
+    }
 
     public FeatureChangeMergeException(final List<MergeFailureType> failureTypeTrace,
             final String message)
     {
-        super(message);
+        super(truncate(message));
         this.failureTypeTrace = failureTypeTrace;
         if (this.failureTypeTrace == null || this.failureTypeTrace.isEmpty())
         {
@@ -31,7 +37,7 @@ public class FeatureChangeMergeException extends CoreException
     public FeatureChangeMergeException(final List<MergeFailureType> failureTypeTrace,
             final String message, final Object... arguments)
     {
-        super(message, arguments);
+        super(truncate(message), arguments);
         this.failureTypeTrace = failureTypeTrace;
         if (this.failureTypeTrace == null || this.failureTypeTrace.isEmpty())
         {
@@ -42,7 +48,7 @@ public class FeatureChangeMergeException extends CoreException
     public FeatureChangeMergeException(final MergeFailureType rootLevelFailure,
             final String message, final Object... arguments)
     {
-        super(message, arguments);
+        super(truncate(message), arguments);
         if (rootLevelFailure == null)
         {
             throw new CoreException("rootLevelFailure cannot be null");
@@ -54,7 +60,7 @@ public class FeatureChangeMergeException extends CoreException
     public FeatureChangeMergeException(final MergeFailureType rootLevelFailure,
             final String message)
     {
-        super(message);
+        super(truncate(message));
         if (rootLevelFailure == null)
         {
             throw new CoreException("rootLevelFailure cannot be null");

--- a/src/test/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeExceptionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeExceptionTest.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.exception.change;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author matthieun
+ */
+public class FeatureChangeMergeExceptionTest
+{
+    @Test
+    public void testTruncate()
+    {
+        final String one = "abc";
+        final StringBuilder twoBuilder = new StringBuilder();
+        for (int index = 0; index < 2100; index++)
+        {
+            twoBuilder.append("a");
+        }
+        final String two = twoBuilder.toString();
+
+        Assert.assertEquals(one, FeatureChangeMergeException.truncate(one));
+        Assert.assertEquals(2100, two.length());
+        Assert.assertEquals(FeatureChangeMergeException.MAXIMUM_MESSAGE_SIZE,
+                FeatureChangeMergeException.truncate(two).length());
+    }
+}


### PR DESCRIPTION
### Description:

`FeatureChangeMergeException` will often contain geometries in WKT in its message. When the geometries are too large, then the message should be capped in size.

### Potential Impact:

Some ends of messages might be missing, however the stack should be intact.

### Unit Test Approach:

Added one test

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
