### PR TITLE
Included more points during point and line slicing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -818,14 +818,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                 final CompletePoint afterPoint = CompletePoint.shallowFrom(point)
                         .withTags(point.getTags());
                 createPointTags(point.getLocation(), true).forEach(afterPoint::withAddedTag);
-                if (isInsideWorkingBound(afterPoint))
-                {
-                    pointChanges.add(FeatureChange.add(afterPoint, lineSlicedAtlas));
-                }
-                else
-                {
-                    pointChanges.add(FeatureChange.remove(CompletePoint.shallowFrom(point)));
-                }
+                pointChanges.add(FeatureChange.add(afterPoint, lineSlicedAtlas));
             }
         });
         if (pointChanges.peekNumberOfChanges() == 0)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/command/OsmPbfToAtlasSubCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/command/OsmPbfToAtlasSubCommandTest.java
@@ -100,7 +100,7 @@ public class OsmPbfToAtlasSubCommandTest
             Assert.assertTrue(atlas.edge(87185039000000L).containsValue("iso_country_code",
                     Collections.singleton("NAM")));
             // Test for country codes
-            Assert.assertNull(atlas.point(1013787604000000L));
+            Assert.assertNotNull(atlas.point(1013787604000000L));
             // Test edge filter
             Assert.assertNull(atlas.edge(87186304000001L));
             // Test node filter


### PR DESCRIPTION
### Description:
During the original refactor of point and line slicing, points were aggressively excluded based on shard boundaries. This PR eliminates that in favor of including them under the assumption that they will be filtered out explicitly later in a separate process.

### Potential Impact:
More points included, slightly larger size for the resulting point-and-line sliced Atlases.

### Unit Test Approach:
One change to an existing test to assert that a point does in fact exist where previously it was filtered out.

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)