### PR TITLE
Fixed a bug with FeatureChange beforeView merging

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergingHelpers.java
@@ -304,6 +304,7 @@ public final class FeatureChangeMergingHelpers
         {
             mergedBeforeArea = CompleteArea.shallowFrom((Area) beforeEntityLeft)
                     .withTags(mergedTagsBean.getMergedBeforeMember())
+                    .withPolygon(mergedPolygonBean.getMergedBeforeMember())
                     .withRelationIdentifiers(mergedParentRelationsBean.getMergedBeforeMember());
         }
         else
@@ -380,6 +381,7 @@ public final class FeatureChangeMergingHelpers
                     .withStartNodeIdentifier(mergedStartNodeIdentifierBean.getMergedBeforeMember())
                     .withEndNodeIdentifier(mergedEndNodeIdentifierBean.getMergedBeforeMember())
                     .withTags(mergedTagsBean.getMergedBeforeMember())
+                    .withPolyLine(mergedPolyLineBean.getMergedBeforeMember())
                     .withRelationIdentifiers(mergedParentRelationsBean.getMergedBeforeMember());
         }
         else
@@ -478,6 +480,7 @@ public final class FeatureChangeMergingHelpers
         {
             mergedBeforeLine = CompleteLine.shallowFrom((Line) beforeEntityLeft)
                     .withTags(mergedTagsBean.getMergedBeforeMember())
+                    .withPolyLine(mergedPolyLineBean.getMergedBeforeMember())
                     .withRelationIdentifiers(mergedParentRelationsBean.getMergedBeforeMember());
         }
         else
@@ -628,6 +631,7 @@ public final class FeatureChangeMergingHelpers
                     .withInEdgeIdentifiers(mergedInEdgeIdentifiersBean.getMergedBeforeMember())
                     .withOutEdgeIdentifiers(mergedOutEdgeIdentifiersBean.getMergedBeforeMember())
                     .withTags(mergedTagsBean.getMergedBeforeMember())
+                    .withLocation(mergedLocationBean.getMergedBeforeMember())
                     .withRelationIdentifiers(mergedParentRelationsBean.getMergedBeforeMember());
         }
         else
@@ -673,6 +677,7 @@ public final class FeatureChangeMergingHelpers
         {
             mergedBeforePoint = CompletePoint.shallowFrom((Point) beforeEntityLeft)
                     .withTags(mergedTagsBean.getMergedBeforeMember())
+                    .withLocation(mergedLocationBean.getMergedBeforeMember())
                     .withRelationIdentifiers(mergedParentRelationsBean.getMergedBeforeMember());
         }
         else

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteArea.java
@@ -288,7 +288,10 @@ public class CompleteArea extends Area implements CompleteEntity<CompleteArea>
     public CompleteArea withPolygon(final Polygon polygon)
     {
         this.polygon = polygon;
-        this.bounds = polygon.bounds();
+        if (this.polygon != null)
+        {
+            this.bounds = polygon.bounds();
+        }
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEdge.java
@@ -340,7 +340,10 @@ public class CompleteEdge extends Edge implements CompleteLineItem<CompleteEdge>
     public CompleteEdge withPolyLine(final PolyLine polyLine)
     {
         this.polyLine = polyLine;
-        this.bounds = polyLine.bounds();
+        if (this.polyLine != null)
+        {
+            this.bounds = polyLine.bounds();
+        }
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteLine.java
@@ -290,7 +290,10 @@ public class CompleteLine extends Line implements CompleteLineItem<CompleteLine>
     public CompleteLine withPolyLine(final PolyLine polyLine)
     {
         this.polyLine = polyLine;
-        this.bounds = polyLine.bounds();
+        if (this.polyLine != null)
+        {
+            this.bounds = polyLine.bounds();
+        }
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -345,6 +345,12 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this.location.toWkt();
     }
 
+    public CompleteNode withAddedOutEdgeIdentifier(final Long extraOutEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.add(extraOutEdgeIdentifier);
+        return this;
+    }
+
     @Override
     public CompleteNode withAddedRelationIdentifier(final Long relationIdentifier)
     {
@@ -425,32 +431,28 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this;
     }
 
+    public CompleteNode withInEdgesAndSource(final Set<Edge> inEdges, final Node source)
+    {
+        return withInEdgeIdentifiersAndSource(inEdges.stream().map(Edge::getIdentifier)
+                .collect(Collectors.toCollection(TreeSet::new)), source);
+    }
+
     @Override
     public CompleteNode withLocation(final Location location)
     {
         this.location = location;
-        this.bounds = location.bounds();
-        return this;
-    }
-
-    public CompleteNode withOutEdgeIdentifierExtra(final Long extraOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.add(extraOutEdgeIdentifier);
-        return this;
-    }
-
-    public CompleteNode withOutEdgeIdentifierLess(final Long lessOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.remove(lessOutEdgeIdentifier);
-        this.explicitlyExcludedOutEdgeIdentifiers.add(lessOutEdgeIdentifier);
+        if (this.location != null)
+        {
+            this.bounds = location.bounds();
+        }
         return this;
     }
 
     public CompleteNode withOutEdgeIdentifierReplaced(final Long beforeOutEdgeIdentifier,
             final Long afterOutEdgeIdentifier)
     {
-        return this.withOutEdgeIdentifierLess(beforeOutEdgeIdentifier)
-                .withOutEdgeIdentifierExtra(afterOutEdgeIdentifier);
+        return this.withRemovedOutEdgeIdentifier(beforeOutEdgeIdentifier)
+                .withAddedOutEdgeIdentifier(afterOutEdgeIdentifier);
     }
 
     public CompleteNode withOutEdgeIdentifiers(final SortedSet<Long> outEdgeIdentifiers)
@@ -478,6 +480,12 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this;
     }
 
+    public CompleteNode withOutEdgesAndSource(final Set<Edge> outEdges, final Node source)
+    {
+        return withOutEdgeIdentifiersAndSource(outEdges.stream().map(Edge::getIdentifier)
+                .collect(Collectors.toCollection(TreeSet::new)), source);
+    }
+
     @Override
     public CompleteNode withRelationIdentifiers(final Set<Long> relationIdentifiers)
     {
@@ -490,6 +498,13 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
                 .collect(Collectors.toSet());
+        return this;
+    }
+
+    public CompleteNode withRemovedOutEdgeIdentifier(final Long lessOutEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.remove(lessOutEdgeIdentifier);
+        this.explicitlyExcludedOutEdgeIdentifiers.add(lessOutEdgeIdentifier);
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompletePoint.java
@@ -293,7 +293,10 @@ public class CompletePoint extends Point implements CompleteLocationItem<Complet
     public CompletePoint withLocation(final Location location)
     {
         this.location = location;
-        this.bounds = location.bounds();
+        if (this.location != null)
+        {
+            this.bounds = location.bounds();
+        }
         return this;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -249,40 +249,44 @@ public abstract class AtlasEntity
      */
     public abstract LocationIterableProperties toGeoJsonBuildingBlock();
 
-    protected String parentRelationsAsDiffViewFriendlyString()
-    {
-        final StringList relationIds = new StringList();
-        for (final Relation relation : this.relations())
-        {
-            relationIds.add(relation.getIdentifier());
-        }
-        final String relationsString = relationIds.join(",");
-
-        return relationsString;
-    }
-
     protected String tagString()
     {
         final StringBuilder builder = new StringBuilder();
         final Map<String, String> tags = getTags();
         int index = 0;
         builder.append("[Tags: ");
-        for (final String key : tags.keySet())
+        if (tags != null)
         {
-            final String value = tags.get(key);
-            builder.append("[");
-            builder.append(key);
-            builder.append(" => ");
-            builder.append(value);
-            builder.append("]");
-            if (index < tags.size() - 1)
+            for (final String key : tags.keySet())
             {
-                builder.append(", ");
+                final String value = tags.get(key);
+                builder.append("[");
+                builder.append(key);
+                builder.append(" => ");
+                builder.append(value);
+                builder.append("]");
+                if (index < tags.size() - 1)
+                {
+                    builder.append(", ");
+                }
+                index++;
             }
-            index++;
         }
         builder.append("]");
         return builder.toString();
+    }
+
+    String parentRelationsAsDiffViewFriendlyString()
+    {
+        final StringList relationIds = new StringList();
+        if (this.relations() != null)
+        {
+            for (final Relation relation : this.relations())
+            {
+                relationIds.add(relation.getIdentifier());
+            }
+        }
+        return relationIds.join(",");
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
@@ -293,9 +293,15 @@ public abstract class Edge extends LineItem implements Comparable<Edge>
     {
         final String relationsString = this.parentRelationsAsDiffViewFriendlyString();
 
-        return "[Edge" + ": id=" + this.getIdentifier() + ", startNode=" + start().getIdentifier()
-                + ", endNode=" + end().getIdentifier() + ", polyLine=" + this.asPolyLine().toWkt()
-                + ", relations=(" + relationsString + "), " + tagString() + "]";
+        final String startNodeString = start() != null ? Long.toString(start().getIdentifier())
+                : "null";
+        final String endNodeString = start() != null ? Long.toString(end().getIdentifier())
+                : "null";
+        final String polyLineWkt = this.asPolyLine() != null ? this.asPolyLine().toWkt() : "null";
+
+        return "[Edge" + ": id=" + this.getIdentifier() + ", startNode=" + startNodeString
+                + ", endNode=" + endNodeString + ", polyLine=" + polyLineWkt + ", relations=("
+                + relationsString + "), " + tagString() + "]";
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommand.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.complete.PrettifyStringFormat;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
@@ -390,8 +392,8 @@ public class AtlasSearchCommand extends AtlasLoaderCommand
                 this.outputDelegate.printlnStdout(
                         "Found entity matching criteria in " + atlasResource.getPath() + ":",
                         TTYAttribute.BOLD);
-                this.outputDelegate.printlnStdout(entity.toDiffViewFriendlyString(),
-                        TTYAttribute.GREEN);
+                this.outputDelegate.printlnStdout(((CompleteEntity) CompleteEntity.from(entity))
+                        .prettify(PrettifyStringFormat.MINIMAL_MULTI_LINE), TTYAttribute.GREEN);
                 this.outputDelegate.printlnStdout("");
                 this.matchingAtlases.add(atlas);
                 if (this.unitTestMode)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -332,7 +332,7 @@ public class ChangeAtlasTest
         node2FromFullAtlas
                 .withOutEdgeIdentifiers(fullSizedAtlas.node(2L).outEdges().stream()
                         .map(Edge::getIdentifier).collect(Collectors.toCollection(TreeSet::new)))
-                .withOutEdgeIdentifierLess(-1L);
+                .withRemovedOutEdgeIdentifier(-1L);
         changeBuilder.add(FeatureChange.add(node2FromFullAtlas, fullSizedAtlas));
 
         // change a tag in node 2, but use a different atlas context that cannot see edge -1

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -41,9 +41,117 @@ public class FeatureChangeMergerTest
     private static final Logger logger = LoggerFactory.getLogger(FeatureChangeMergerTest.class);
 
     @Test
-    public void testBeforeViewMerge()
+    public void testBeforeViewAreaMerge()
     {
-        Assert.fail("TODO implement");
+        final CompleteArea before1 = new CompleteArea(123L, null, Maps.hashMap("a", "1", "b", "2"),
+                null).withBoundsExtendedBy(Polygon.SILICON_VALLEY.bounds());
+        final CompleteArea after1 = new CompleteArea(123L, null,
+                Maps.hashMap("a", "1", "b", "2", "c", "3"), null)
+                        .withBoundsExtendedBy(Polygon.SILICON_VALLEY.bounds());
+        final CompleteArea before2 = new CompleteArea(123L, Polygon.SILICON_VALLEY, null, null);
+        final CompleteArea after2 = new CompleteArea(123L, Polygon.SILICON_VALLEY_2, null, null);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, after1, before1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, after2, before2);
+        final FeatureChange mergedFeatureChange = featureChange1.merge(featureChange2);
+        final CompleteArea mergedBefore = (CompleteArea) mergedFeatureChange.getBeforeView();
+        final CompleteArea mergedAfter = (CompleteArea) mergedFeatureChange.getAfterView();
+        Assert.assertEquals(Polygon.SILICON_VALLEY, mergedBefore.asPolygon());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2"), mergedBefore.getTags());
+        Assert.assertEquals(Polygon.SILICON_VALLEY_2, mergedAfter.asPolygon());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2", "c", "3"), mergedAfter.getTags());
+    }
+
+    @Test
+    public void testBeforeViewEdgeMerge()
+    {
+        final CompleteEdge before1 = new CompleteEdge(123L, null, Maps.hashMap("a", "1", "b", "2"),
+                null, null, null).withBoundsExtendedBy(PolyLine.TEST_POLYLINE.bounds());
+        final CompleteEdge after1 = new CompleteEdge(123L, null,
+                Maps.hashMap("a", "1", "b", "2", "c", "3"), null, null, null)
+                        .withBoundsExtendedBy(PolyLine.TEST_POLYLINE.bounds());
+        final CompleteEdge before2 = new CompleteEdge(123L, PolyLine.TEST_POLYLINE, null, null,
+                null, null);
+        final CompleteEdge after2 = new CompleteEdge(123L, PolyLine.TEST_POLYLINE_2, null, null,
+                null, null);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, after1, before1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, after2, before2);
+        final FeatureChange mergedFeatureChange = featureChange1.merge(featureChange2);
+        final CompleteEdge mergedBefore = (CompleteEdge) mergedFeatureChange.getBeforeView();
+        final CompleteEdge mergedAfter = (CompleteEdge) mergedFeatureChange.getAfterView();
+        Assert.assertEquals(PolyLine.TEST_POLYLINE, mergedBefore.asPolyLine());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2"), mergedBefore.getTags());
+        Assert.assertEquals(PolyLine.TEST_POLYLINE_2, mergedAfter.asPolyLine());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2", "c", "3"), mergedAfter.getTags());
+    }
+
+    @Test
+    public void testBeforeViewLineMerge()
+    {
+        final CompleteLine before1 = new CompleteLine(123L, null, Maps.hashMap("a", "1", "b", "2"),
+                null).withBoundsExtendedBy(PolyLine.TEST_POLYLINE.bounds());
+        final CompleteLine after1 = new CompleteLine(123L, null,
+                Maps.hashMap("a", "1", "b", "2", "c", "3"), null)
+                        .withBoundsExtendedBy(PolyLine.TEST_POLYLINE.bounds());
+        final CompleteLine before2 = new CompleteLine(123L, PolyLine.TEST_POLYLINE, null, null);
+        final CompleteLine after2 = new CompleteLine(123L, PolyLine.TEST_POLYLINE_2, null, null);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, after1, before1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, after2, before2);
+        final FeatureChange mergedFeatureChange = featureChange1.merge(featureChange2);
+        final CompleteLine mergedBefore = (CompleteLine) mergedFeatureChange.getBeforeView();
+        final CompleteLine mergedAfter = (CompleteLine) mergedFeatureChange.getAfterView();
+        Assert.assertEquals(PolyLine.TEST_POLYLINE, mergedBefore.asPolyLine());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2"), mergedBefore.getTags());
+        Assert.assertEquals(PolyLine.TEST_POLYLINE_2, mergedAfter.asPolyLine());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2", "c", "3"), mergedAfter.getTags());
+    }
+
+    @Test
+    public void testBeforeViewNodeMerge()
+    {
+        final CompleteNode before1 = new CompleteNode(123L, null, Maps.hashMap("a", "1", "b", "2"),
+                null, null, null).withBoundsExtendedBy(Location.TEST_1.bounds());
+        final CompleteNode after1 = new CompleteNode(123L, null,
+                Maps.hashMap("a", "1", "b", "2", "c", "3"), null, null, null)
+                        .withBoundsExtendedBy(Location.TEST_1.bounds());
+        final CompleteNode before2 = new CompleteNode(123L, Location.TEST_1, null, null, null,
+                null);
+        final CompleteNode after2 = new CompleteNode(123L, Location.TEST_2, null, null, null, null);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, after1, before1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, after2, before2);
+        final FeatureChange mergedFeatureChange = featureChange1.merge(featureChange2);
+        final CompleteNode mergedBefore = (CompleteNode) mergedFeatureChange.getBeforeView();
+        final CompleteNode mergedAfter = (CompleteNode) mergedFeatureChange.getAfterView();
+        Assert.assertEquals(Location.TEST_1, mergedBefore.getLocation());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2"), mergedBefore.getTags());
+        Assert.assertEquals(Location.TEST_2, mergedAfter.getLocation());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2", "c", "3"), mergedAfter.getTags());
+    }
+
+    @Test
+    public void testBeforeViewPointMerge()
+    {
+        final CompletePoint before1 = new CompletePoint(123L, null,
+                Maps.hashMap("a", "1", "b", "2"), null)
+                        .withBoundsExtendedBy(Location.TEST_1.bounds());
+        final CompletePoint after1 = new CompletePoint(123L, null,
+                Maps.hashMap("a", "1", "b", "2", "c", "3"), null)
+                        .withBoundsExtendedBy(Location.TEST_1.bounds());
+        final CompletePoint before2 = new CompletePoint(123L, Location.TEST_1, null, null);
+        final CompletePoint after2 = new CompletePoint(123L, Location.TEST_2, null, null);
+
+        final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, after1, before1);
+        final FeatureChange featureChange2 = new FeatureChange(ChangeType.ADD, after2, before2);
+        final FeatureChange mergedFeatureChange = featureChange1.merge(featureChange2);
+        final CompletePoint mergedBefore = (CompletePoint) mergedFeatureChange.getBeforeView();
+        final CompletePoint mergedAfter = (CompletePoint) mergedFeatureChange.getAfterView();
+        Assert.assertEquals(Location.TEST_1, mergedBefore.getLocation());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2"), mergedBefore.getTags());
+        Assert.assertEquals(Location.TEST_2, mergedAfter.getLocation());
+        Assert.assertEquals(Maps.hashMap("a", "1", "b", "2", "c", "3"), mergedAfter.getTags());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -41,6 +41,12 @@ public class FeatureChangeMergerTest
     private static final Logger logger = LoggerFactory.getLogger(FeatureChangeMergerTest.class);
 
     @Test
+    public void testBeforeViewMerge()
+    {
+        Assert.fail("TODO implement");
+    }
+
+    @Test
     public void testMergeAreasFail()
     {
         final CompleteArea beforeArea1 = new CompleteArea(123L, Polygon.CENTER,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -679,8 +679,8 @@ public class FeatureChangeMergerTest
         final CompleteNode afterNode1 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(1L, 2L), Sets.treeSet(10L, 11L, 12L, 13L), null);
         afterNode1.withInEdgeIdentifierLess(1L);
-        afterNode1.withOutEdgeIdentifierLess(12L);
-        afterNode1.withOutEdgeIdentifierLess(13L);
+        afterNode1.withRemovedOutEdgeIdentifier(12L);
+        afterNode1.withRemovedOutEdgeIdentifier(13L);
 
         final CompleteNode afterNode2 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(2L, 3L), Sets.treeSet(11L), null);


### PR DESCRIPTION
### Description:
Previously, we had `FeatureChange` merging dropping the geometry of the beforeView when it performed a beforeView merge. This is obviously no bueno. It's now fixed.

I also changed the name of `Node#withIn(Out)EdgeIdentifierExtra(Less)` to `Node#withAdded(Removed)In(Out)EdgeIdentifier` to more closely match the names for the parent relation setter methods (`CompleteEntity#withAdded(Removed)RelationIdentifier`).

The rest of the changes are just a bunch of null checks that were needed to get this PR to work.

### Potential Impact:
Lots of strange downstream behavior may be resolved.

### Unit Test Approach:
Added tests that expose the bug.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)