### PR TITLE
Truncate now shows a triple dot for clarity

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -296,7 +296,8 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
 
     default String truncate(final String input)
     {
-        return input.substring(0, Math.min(input.length(), PrettifyStringFormat.TRUNCATE_LENGTH));
+        return input.substring(0, Math.min(input.length(), PrettifyStringFormat.TRUNCATE_LENGTH))
+                + "...";
     }
 
     CompleteEntity withAddedRelationIdentifier(Long relationIdentifier);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -297,7 +297,7 @@ public interface CompleteEntity<C extends CompleteEntity<C>> extends TagChangeLi
     default String truncate(final String input)
     {
         return input.substring(0, Math.min(input.length(), PrettifyStringFormat.TRUNCATE_LENGTH))
-                + "...";
+                + PrettifyStringFormat.TRUNCATE_ELLIPSES;
     }
 
     CompleteEntity withAddedRelationIdentifier(Long relationIdentifier);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/PrettifyStringFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/PrettifyStringFormat.java
@@ -9,4 +9,5 @@ public enum PrettifyStringFormat
     MINIMAL_MULTI_LINE;
 
     public static final int TRUNCATE_LENGTH = 2000;
+    public static final String TRUNCATE_ELLIPSES = "...";
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntityTest.java
@@ -19,9 +19,12 @@ public class CompleteEntityTest
         }
         final String two = twoBuilder.toString();
 
-        Assert.assertEquals(one, new CompleteArea(1L, null, null, null).truncate(one));
+        Assert.assertEquals(one + PrettifyStringFormat.TRUNCATE_ELLIPSES,
+                new CompleteArea(1L, null, null, null).truncate(one));
         Assert.assertEquals(2100, two.length());
-        Assert.assertEquals(PrettifyStringFormat.TRUNCATE_LENGTH,
+        Assert.assertEquals(
+                PrettifyStringFormat.TRUNCATE_LENGTH
+                        + PrettifyStringFormat.TRUNCATE_ELLIPSES.length(),
                 new CompleteArea(1L, null, null, null).truncate(two).length());
     }
 }


### PR DESCRIPTION
### Description:
`CompleteEntity` uses a truncate method for pretty printing. It now adds a `...` when in truncates, so it is clear to users that this string has been truncated.

### Potential Impact:
N/A

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)