### PR TITLE
FeatureChangeMergeException:Truncate after message re-construction

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/exception/CoreException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/CoreException.java
@@ -1,7 +1,9 @@
 package org.openstreetmap.atlas.exception;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import org.slf4j.helpers.MessageFormatter;
 
@@ -29,7 +31,7 @@ public class CoreException extends RuntimeException
 {
     public static final String TOKEN = CoreException.class.getSimpleName();
     private static final long serialVersionUID = 5019327451085548495L;
-    private static final Function<Object[], Object[]> refineArguments = arguments ->
+    protected static final UnaryOperator<Object[]> REFINE_ARGUMENTS = arguments ->
     {
         if (arguments.length > 0 && arguments[arguments.length - 1] instanceof Throwable)
         {
@@ -45,6 +47,9 @@ public class CoreException extends RuntimeException
             return arguments;
         }
     };
+    protected static final Function<Object[], Optional<Throwable>> CAUSE_FROM = arguments -> arguments.length != REFINE_ARGUMENTS
+            .apply(arguments).length ? Optional.of((Throwable) arguments[arguments.length - 1])
+                    : Optional.empty();
 
     public static Supplier<CoreException> supplier(final String message)
     {
@@ -75,10 +80,8 @@ public class CoreException extends RuntimeException
 
     public CoreException(final String message, final Object... arguments)
     {
-        super(MessageFormatter.arrayFormat(message, refineArguments.apply(arguments)).getMessage(),
-                arguments.length != refineArguments.apply(arguments).length
-                        ? (Throwable) arguments[arguments.length - 1]
-                        : null);
+        super(MessageFormatter.arrayFormat(message, REFINE_ARGUMENTS.apply(arguments)).getMessage(),
+                CAUSE_FROM.apply(arguments).orElse(null));
     }
 
     public CoreException(final String message, final Throwable cause)

--- a/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
+++ b/src/main/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeException.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.slf4j.helpers.MessageFormatter;
 
 /**
  * A special exception for {@link FeatureChange} merge errors.
@@ -37,7 +38,8 @@ public class FeatureChangeMergeException extends CoreException
     public FeatureChangeMergeException(final List<MergeFailureType> failureTypeTrace,
             final String message, final Object... arguments)
     {
-        super(truncate(message), arguments);
+        super(truncate(MessageFormatter.arrayFormat(message, REFINE_ARGUMENTS.apply(arguments))
+                .getMessage()), CAUSE_FROM.apply(arguments).orElse(null));
         this.failureTypeTrace = failureTypeTrace;
         if (this.failureTypeTrace == null || this.failureTypeTrace.isEmpty())
         {
@@ -48,7 +50,8 @@ public class FeatureChangeMergeException extends CoreException
     public FeatureChangeMergeException(final MergeFailureType rootLevelFailure,
             final String message, final Object... arguments)
     {
-        super(truncate(message), arguments);
+        super(truncate(MessageFormatter.arrayFormat(message, REFINE_ARGUMENTS.apply(arguments))
+                .getMessage()), CAUSE_FROM.apply(arguments).orElse(null));
         if (rootLevelFailure == null)
         {
             throw new CoreException("rootLevelFailure cannot be null");

--- a/src/test/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeExceptionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/exception/change/FeatureChangeMergeExceptionTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.exception.change;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 
 /**
  * @author matthieun
@@ -23,5 +24,24 @@ public class FeatureChangeMergeExceptionTest
         Assert.assertEquals(2100, two.length());
         Assert.assertEquals(FeatureChangeMergeException.MAXIMUM_MESSAGE_SIZE,
                 FeatureChangeMergeException.truncate(two).length());
+    }
+
+    @Test
+    public void testTruncateInConstructor()
+    {
+        final String one = "abc{}d";
+        final StringBuilder twoBuilder = new StringBuilder();
+        for (int index = 0; index < 2100; index++)
+        {
+            twoBuilder.append("a");
+        }
+        final String two = twoBuilder.toString();
+
+        final FeatureChangeMergeException fcme = new FeatureChangeMergeException(
+                MergeFailureType.HIGHEST_LEVEL_MERGE_FAILURE, one, two,
+                new CoreException("I am the cause"));
+        Assert.assertEquals(FeatureChangeMergeException.MAXIMUM_MESSAGE_SIZE,
+                fcme.getMessage().length());
+        Assert.assertEquals(CoreException.class, fcme.getCause().getClass());
     }
 }


### PR DESCRIPTION
### Description:

In some cases, the `FeatureChangeMergeException` message was small, but the injected features (through the `{}`) would be large. This fixes the issue to make truncation of message universal.

### Potential Impact:

Smaller error messages

### Unit Test Approach:

Added a test

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)