### PR TITLE
Revert partial naming change inadvertently included in PR 522

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -345,12 +345,6 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this.location.toWkt();
     }
 
-    public CompleteNode withAddedOutEdgeIdentifier(final Long extraOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.add(extraOutEdgeIdentifier);
-        return this;
-    }
-
     @Override
     public CompleteNode withAddedRelationIdentifier(final Long relationIdentifier)
     {
@@ -448,11 +442,24 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this;
     }
 
+    public CompleteNode withOutEdgeIdentifierExtra(final Long extraOutEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.add(extraOutEdgeIdentifier);
+        return this;
+    }
+
+    public CompleteNode withOutEdgeIdentifierLess(final Long lessOutEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.remove(lessOutEdgeIdentifier);
+        this.explicitlyExcludedOutEdgeIdentifiers.add(lessOutEdgeIdentifier);
+        return this;
+    }
+
     public CompleteNode withOutEdgeIdentifierReplaced(final Long beforeOutEdgeIdentifier,
             final Long afterOutEdgeIdentifier)
     {
-        return this.withRemovedOutEdgeIdentifier(beforeOutEdgeIdentifier)
-                .withAddedOutEdgeIdentifier(afterOutEdgeIdentifier);
+        return this.withOutEdgeIdentifierLess(beforeOutEdgeIdentifier)
+                .withOutEdgeIdentifierExtra(afterOutEdgeIdentifier);
     }
 
     public CompleteNode withOutEdgeIdentifiers(final SortedSet<Long> outEdgeIdentifiers)
@@ -498,13 +505,6 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     {
         this.relationIdentifiers = relations.stream().map(Relation::getIdentifier)
                 .collect(Collectors.toSet());
-        return this;
-    }
-
-    public CompleteNode withRemovedOutEdgeIdentifier(final Long lessOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.remove(lessOutEdgeIdentifier);
-        this.explicitlyExcludedOutEdgeIdentifiers.add(lessOutEdgeIdentifier);
         return this;
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -332,7 +332,7 @@ public class ChangeAtlasTest
         node2FromFullAtlas
                 .withOutEdgeIdentifiers(fullSizedAtlas.node(2L).outEdges().stream()
                         .map(Edge::getIdentifier).collect(Collectors.toCollection(TreeSet::new)))
-                .withRemovedOutEdgeIdentifier(-1L);
+                .withOutEdgeIdentifierLess(-1L);
         changeBuilder.add(FeatureChange.add(node2FromFullAtlas, fullSizedAtlas));
 
         // change a tag in node 2, but use a different atlas context that cannot see edge -1

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -679,8 +679,8 @@ public class FeatureChangeMergerTest
         final CompleteNode afterNode1 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(1L, 2L), Sets.treeSet(10L, 11L, 12L, 13L), null);
         afterNode1.withInEdgeIdentifierLess(1L);
-        afterNode1.withRemovedOutEdgeIdentifier(12L);
-        afterNode1.withRemovedOutEdgeIdentifier(13L);
+        afterNode1.withOutEdgeIdentifierLess(12L);
+        afterNode1.withOutEdgeIdentifierLess(13L);
 
         final CompleteNode afterNode2 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(2L, 3L), Sets.treeSet(11L), null);


### PR DESCRIPTION
### Description:

Revert partial naming change inadvertently included in #522: `CompleteNode`'s `withOutEdgeIdentifierLess` and `withOutEdgeIdentifierExtra` were renamed. 

### Potential Impact:

Consistent naming

### Unit Test Approach:

Use existing tests

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)