### PR TITLE
Refactored CompleteEntity method names for consistency

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/testing/AtlasChangeGeneratorSplitRoundabout.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/testing/AtlasChangeGeneratorSplitRoundabout.java
@@ -65,7 +65,7 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
                     return CompleteRelation.shallowFrom(relation)
                             .withMembersAndSource(newMembers, relation)
                             // With the new relation members
-                            .withExtraMember(firstEdge, edge).withExtraMember(secondEdge, edge);
+                            .withAddedMember(firstEdge, edge).withAddedMember(secondEdge, edge);
                 }).map(relation -> FeatureChange.add(relation, atlas)).forEach(result::add);
 
                 // Add the two new edges.
@@ -80,12 +80,12 @@ public class AtlasChangeGeneratorSplitRoundabout implements AtlasChangeGenerator
 
                 // End node has a replaced start edge identifier
                 result.add(FeatureChange.add(CompleteNode.shallowFrom(edge.end())
-                        .withInEdges(edge.end().inEdges()).withInEdgeIdentifierReplaced(
+                        .withInEdges(edge.end().inEdges()).withReplacedInEdgeIdentifier(
                                 oldEdgeIdentifier, newEdgeIdentifier2),
                         atlas));
                 // Start node has a replaced end edge identifier
                 result.add(FeatureChange.add(CompleteNode.shallowFrom(edge.start())
-                        .withOutEdges(edge.start().outEdges()).withOutEdgeIdentifierReplaced(
+                        .withOutEdges(edge.start().outEdges()).withReplacedOutEdgeIdentifier(
                                 oldEdgeIdentifier, newEdgeIdentifier1),
                         atlas));
             }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteEntity.java
@@ -26,7 +26,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
  * (Node, Edge, Area, ...) this cannot be an abstract class.
  *
  * @param <C>
- *            - the {@link CompleteEntity} implementation.
+ *            the {@link CompleteEntity} implementation
  * @author matthieun
  * @author Yazad Khambata
  */

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteNode.java
@@ -345,6 +345,18 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this.location.toWkt();
     }
 
+    public CompleteNode withAddedInEdgeIdentifier(final Long inEdgeIdentifier)
+    {
+        this.inEdgeIdentifiers.add(inEdgeIdentifier);
+        return this;
+    }
+
+    public CompleteNode withAddedOutEdgeIdentifier(final Long inEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.add(inEdgeIdentifier);
+        return this;
+    }
+
     @Override
     public CompleteNode withAddedRelationIdentifier(final Long relationIdentifier)
     {
@@ -378,26 +390,6 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
     {
         this.identifier = identifier;
         return this;
-    }
-
-    public CompleteNode withInEdgeIdentifierExtra(final Long extraInEdgeIdentifier)
-    {
-        this.inEdgeIdentifiers.add(extraInEdgeIdentifier);
-        return this;
-    }
-
-    public CompleteNode withInEdgeIdentifierLess(final Long lessInEdgeIdentifier)
-    {
-        this.inEdgeIdentifiers.remove(lessInEdgeIdentifier);
-        this.explicitlyExcludedInEdgeIdentifiers.add(lessInEdgeIdentifier);
-        return this;
-    }
-
-    public CompleteNode withInEdgeIdentifierReplaced(final Long beforeInEdgeIdentifier,
-            final Long afterInEdgeIdentifier)
-    {
-        return this.withInEdgeIdentifierLess(beforeInEdgeIdentifier)
-                .withInEdgeIdentifierExtra(afterInEdgeIdentifier);
     }
 
     public CompleteNode withInEdgeIdentifiers(final SortedSet<Long> inEdgeIdentifiers)
@@ -440,26 +432,6 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
             this.bounds = location.bounds();
         }
         return this;
-    }
-
-    public CompleteNode withOutEdgeIdentifierExtra(final Long extraOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.add(extraOutEdgeIdentifier);
-        return this;
-    }
-
-    public CompleteNode withOutEdgeIdentifierLess(final Long lessOutEdgeIdentifier)
-    {
-        this.outEdgeIdentifiers.remove(lessOutEdgeIdentifier);
-        this.explicitlyExcludedOutEdgeIdentifiers.add(lessOutEdgeIdentifier);
-        return this;
-    }
-
-    public CompleteNode withOutEdgeIdentifierReplaced(final Long beforeOutEdgeIdentifier,
-            final Long afterOutEdgeIdentifier)
-    {
-        return this.withOutEdgeIdentifierLess(beforeOutEdgeIdentifier)
-                .withOutEdgeIdentifierExtra(afterOutEdgeIdentifier);
     }
 
     public CompleteNode withOutEdgeIdentifiers(final SortedSet<Long> outEdgeIdentifiers)
@@ -508,6 +480,20 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
         return this;
     }
 
+    public CompleteNode withRemovedInEdgeIdentifier(final Long inEdgeIdentifier)
+    {
+        this.inEdgeIdentifiers.remove(inEdgeIdentifier);
+        this.explicitlyExcludedInEdgeIdentifiers.add(inEdgeIdentifier);
+        return this;
+    }
+
+    public CompleteNode withRemovedOutEdgeIdentifier(final Long outEdgeIdentifier)
+    {
+        this.outEdgeIdentifiers.remove(outEdgeIdentifier);
+        this.explicitlyExcludedOutEdgeIdentifiers.add(outEdgeIdentifier);
+        return this;
+    }
+
     @Override
     public CompleteNode withRemovedRelationIdentifier(final Long relationIdentifier)
     {
@@ -515,5 +501,19 @@ public class CompleteNode extends Node implements CompleteLocationItem<CompleteN
                 .filter(keepId -> keepId != relationIdentifier.longValue())
                 .collect(Collectors.toSet());
         return this;
+    }
+
+    public CompleteNode withReplacedInEdgeIdentifier(final Long beforeInEdgeIdentifier,
+            final Long afterInEdgeIdentifier)
+    {
+        return this.withRemovedInEdgeIdentifier(beforeInEdgeIdentifier)
+                .withAddedInEdgeIdentifier(afterInEdgeIdentifier);
+    }
+
+    public CompleteNode withReplacedOutEdgeIdentifier(final Long beforeOutEdgeIdentifier,
+            final Long afterOutEdgeIdentifier)
+    {
+        return this.withRemovedOutEdgeIdentifier(beforeOutEdgeIdentifier)
+                .withAddedOutEdgeIdentifier(afterOutEdgeIdentifier);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -435,7 +435,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                     for (final Relation relation : line.relations())
                     {
                         final CompleteRelation updatedRelation = CompleteRelation.from(relation)
-                                .withExtraMember(newLineSlice, line);
+                                .withAddedMember(newLineSlice, line);
                         lineChanges.add(FeatureChange.add(updatedRelation, atlas));
                     }
                 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeAtlasTest.java
@@ -332,7 +332,7 @@ public class ChangeAtlasTest
         node2FromFullAtlas
                 .withOutEdgeIdentifiers(fullSizedAtlas.node(2L).outEdges().stream()
                         .map(Edge::getIdentifier).collect(Collectors.toCollection(TreeSet::new)))
-                .withOutEdgeIdentifierLess(-1L);
+                .withRemovedOutEdgeIdentifier(-1L);
         changeBuilder.add(FeatureChange.add(node2FromFullAtlas, fullSizedAtlas));
 
         // change a tag in node 2, but use a different atlas context that cannot see edge -1

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeMergerTest.java
@@ -678,14 +678,14 @@ public class FeatureChangeMergerTest
 
         final CompleteNode afterNode1 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(1L, 2L), Sets.treeSet(10L, 11L, 12L, 13L), null);
-        afterNode1.withInEdgeIdentifierLess(1L);
-        afterNode1.withOutEdgeIdentifierLess(12L);
-        afterNode1.withOutEdgeIdentifierLess(13L);
+        afterNode1.withRemovedInEdgeIdentifier(1L);
+        afterNode1.withRemovedOutEdgeIdentifier(12L);
+        afterNode1.withRemovedOutEdgeIdentifier(13L);
 
         final CompleteNode afterNode2 = new CompleteNode(123L, Location.COLOSSEUM, null,
                 Sets.treeSet(2L, 3L), Sets.treeSet(11L), null);
-        afterNode2.withInEdgeIdentifierLess(4L);
-        afterNode2.withInEdgeIdentifierExtra(100L);
+        afterNode2.withRemovedInEdgeIdentifier(4L);
+        afterNode2.withAddedInEdgeIdentifier(100L);
 
         final FeatureChange featureChange1 = new FeatureChange(ChangeType.ADD, afterNode1,
                 beforeNode1);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -232,7 +232,7 @@ public class CompleteRelationTest
 
         final CompleteRelation cRelation = CompleteRelation.from(atlas.relation(1L));
         Assert.assertEquals(atlas.relation(1L).bounds(), cRelation.bounds());
-        cRelation.withExtraMember(atlas.point(5L), "a");
+        cRelation.withAddedMember(atlas.point(5L), "a");
         Assert.assertEquals(Rectangle.forLocated(atlas.relation(1L).bounds(), atlas.point(5L)),
                 cRelation.bounds());
     }


### PR DESCRIPTION
### Description:
Many of the `with*` methods in the various `CompleteEntity` implementations had inconsistent names. This has been fixed.

E.g.
`withInEdgeIdentifierExtra` => `withAddedInEdgeIdentifier`
etc.

### Potential Impact:
Downstream dependencies may break.

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)