### PR TITLE
Fixed some inefficient resizing in one of the serialization adapters

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/proto/adapters/ProtoByteArrayOfArraysAdapter.java
+++ b/src/main/java/org/openstreetmap/atlas/proto/adapters/ProtoByteArrayOfArraysAdapter.java
@@ -32,6 +32,7 @@ public class ProtoByteArrayOfArraysAdapter implements ProtoAdapter
         }
 
         final ByteArrayOfArrays byteArrayOfArrays = new ByteArrayOfArrays(
+                protoByteArrayOfArrays.getArraysCount(), protoByteArrayOfArrays.getArraysCount(),
                 protoByteArrayOfArrays.getArraysCount());
         if (protoByteArrayOfArrays.hasName())
         {

--- a/src/test/java/org/openstreetmap/atlas/proto/adapters/ProtoByteArrayOfArraysAdapterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/proto/adapters/ProtoByteArrayOfArraysAdapterTest.java
@@ -15,8 +15,7 @@ public class ProtoByteArrayOfArraysAdapterTest
 {
     private static final Logger logger = LoggerFactory
             .getLogger(ProtoByteArrayOfArraysAdapterTest.class);
-    private static final int TEST_ARRAY_SIZE = 2000;
-    private static final int TEST_SUBARRAY_SIZE = 10_000;
+    private static final int TEST_ARRAY_SIZE = 5000;
     private static final String TEST_NAME = "testarray";
     private final ProtoByteArrayOfArraysAdapter adapter = new ProtoByteArrayOfArraysAdapter();
 
@@ -24,11 +23,11 @@ public class ProtoByteArrayOfArraysAdapterTest
     public void testConsistency()
     {
         final ByteArrayOfArrays byteArrayOfArrays = new ByteArrayOfArrays(TEST_ARRAY_SIZE,
-                TEST_SUBARRAY_SIZE, TEST_SUBARRAY_SIZE);
+                TEST_ARRAY_SIZE, TEST_ARRAY_SIZE);
         for (int index = 0; index < TEST_ARRAY_SIZE; index++)
         {
-            final byte[] items = new byte[TEST_SUBARRAY_SIZE];
-            for (int subIndex = 0; subIndex < TEST_SUBARRAY_SIZE; subIndex++)
+            final byte[] items = new byte[TEST_ARRAY_SIZE];
+            for (int subIndex = 0; subIndex < TEST_ARRAY_SIZE; subIndex++)
             {
                 items[subIndex] = 1;
             }


### PR DESCRIPTION
### Description:
The `ProtoByteArrayOfArraysAdapter` was not properly initializing the `LargeArray` memory block size, which was causing unnecessary resizes.

### Potential Impact:
N/A

### Unit Test Approach:
Unit test in `ProtoByteArrayOfArraysAdapterTest`

### Test Results:
Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)