### PR TITLE
Fixed an issue with duplicate points

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -309,22 +309,16 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                     }
                     else
                     {
-                        for (final Point rawAtlasPoint : rawAtlasPointsAtScaledCoordinate)
-                        {
-                            // Add all point identifiers to make up the new Line
-                            newLineShapePoints.add(rawAtlasPoint.getIdentifier());
-                        }
+                        newLineShapePoints.add(
+                                rawAtlasPointsAtScaledCoordinate.iterator().next().getIdentifier());
                     }
                 }
             }
 
             else
             {
-                for (final Point rawAtlasPoint : rawAtlasPointsAtCoordinate)
-                {
-                    // Add all point identifiers to make up the new Line
-                    newLineShapePoints.add(rawAtlasPoint.getIdentifier());
-                }
+                newLineShapePoints
+                        .add(rawAtlasPointsAtCoordinate.iterator().next().getIdentifier());
             }
         }
 
@@ -1047,10 +1041,13 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
             final boolean isNewPoint = this.slicedRelationChanges.getCreatedPoints()
                     .containsKey(identifier);
 
+            final boolean isPartOfRelation = !getStartingAtlas().point(identifier).relations()
+                    .isEmpty();
+
             final boolean newLineUsesExistingPoint = isPartOfNewLine && !isNewPoint;
 
             // All lines that contain this point have been deleted, delete the point
-            if (!partOfExistingNonDeletedLine && !newLineUsesExistingPoint)
+            if (!partOfExistingNonDeletedLine && !newLineUsesExistingPoint && !isPartOfRelation)
             {
                 this.slicedRelationChanges.deletePoint(identifier);
             }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
@@ -1,12 +1,14 @@
 package org.openstreetmap.atlas.geography.atlas.raw.slicing;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.complex.Finder;
@@ -245,6 +247,38 @@ public class RelationSlicingTest
         Assert.assertEquals(16, slicedAtlas.numberOfPoints());
         Assert.assertEquals(6, slicedAtlas.numberOfLines());
         Assert.assertEquals(2, slicedAtlas.numberOfRelations());
+
+        slicedAtlas.lines().forEach(System.out::println);
+    }
+
+    @Test
+    public void testSingleOuterMadeOfOpenLinesSpanningTwoCountriesWithDuplicatePoints()
+    {
+        // This relation is made up of two open lines, both crossing the country boundary and
+        // forming a multi-polygon with one outer.
+        final Atlas rawAtlas = this.setup
+                .getSingleOuterMadeOfOpenLinesSpanningTwoCountriesAtlasWithDuplicatePoints();
+        Assert.assertEquals(2, rawAtlas.numberOfLines());
+        Assert.assertEquals(11, rawAtlas.numberOfPoints());
+        Assert.assertEquals(1, rawAtlas.numberOfRelations());
+
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
+
+        Assert.assertEquals(17, slicedAtlas.numberOfPoints());
+        Assert.assertEquals(6, slicedAtlas.numberOfLines());
+        Assert.assertEquals(2, slicedAtlas.numberOfRelations());
+
+        slicedAtlas.lines().forEach(line ->
+        {
+            final Iterator<Location> lineLocations = line.iterator();
+            Location previous = lineLocations.next();
+            while (lineLocations.hasNext())
+            {
+                final Location current = lineLocations.next();
+                Assert.assertFalse(current.equals(previous));
+                previous = current;
+            }
+        });
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTestRule.java
@@ -58,6 +58,39 @@ public class RelationSlicingTestRule extends CoreTestRule
     private static final String LOCATION_37 = "6.87407883746,-8.34039743242";
     private static final String LOCATION_38 = "6.87822317845,-8.33993631058";
 
+    private static final String LOCATION_39 = "6.876712, -8.331375";
+
+    @TestAtlas(
+
+            points = { @Point(id = "214776000000", coordinates = @Loc(value = LOCATION_30)),
+                    @Point(id = "214775000000", coordinates = @Loc(value = LOCATION_31)),
+                    @Point(id = "214774000000", coordinates = @Loc(value = LOCATION_32)),
+                    @Point(id = "214773000000", coordinates = @Loc(value = LOCATION_33)),
+                    @Point(id = "214772000000", coordinates = @Loc(value = LOCATION_34)),
+                    @Point(id = "214771000000", coordinates = @Loc(value = LOCATION_35)),
+                    @Point(id = "214770000000", coordinates = @Loc(value = LOCATION_36)),
+                    @Point(id = "214769000000", coordinates = @Loc(value = LOCATION_37)),
+                    @Point(id = "214768000000", coordinates = @Loc(value = LOCATION_38)),
+                    @Point(id = "214708000000", coordinates = @Loc(value = LOCATION_39)),
+                    @Point(id = "214718000000", coordinates = @Loc(value = LOCATION_39)) },
+
+            lines = {
+                    @Line(id = "214778000000", coordinates = { @Loc(value = LOCATION_38),
+                            @Loc(value = LOCATION_31),
+                            @Loc(value = LOCATION_32) }, tags = { "highway=residential" }),
+                    @Line(id = "214777000000", coordinates = { @Loc(value = LOCATION_38),
+                            @Loc(value = LOCATION_37), @Loc(value = LOCATION_30),
+                            @Loc(value = LOCATION_34), @Loc(value = LOCATION_35),
+                            @Loc(value = LOCATION_32) }, tags = { "highway=primary" }) },
+
+            relations = {
+
+                    @Relation(id = "214805000000", tags = { "type=multipolygon",
+                            "leisure=park" }, members = {
+                                    @Member(id = "214777000000", role = "outer", type = "line"),
+                                    @Member(id = "214778000000", role = "outer", type = "line") }) })
+    private Atlas singleOuterMadeOfOpenLinesSpanningTwoCountriesWithDuplicatePoints;
+
     @TestAtlas(
 
             points = { @Point(id = "214776000000", coordinates = @Loc(value = LOCATION_30)),
@@ -334,6 +367,11 @@ public class RelationSlicingTestRule extends CoreTestRule
     public Atlas getSingleOuterMadeOfOpenLinesSpanningTwoCountriesAtlas()
     {
         return this.singleOuterMadeOfOpenLinesSpanningTwoCountries;
+    }
+
+    public Atlas getSingleOuterMadeOfOpenLinesSpanningTwoCountriesAtlasWithDuplicatePoints()
+    {
+        return this.singleOuterMadeOfOpenLinesSpanningTwoCountriesWithDuplicatePoints;
     }
 
     public Atlas getSingleOuterNonWaterSpanningTwoAtlases1()


### PR DESCRIPTION
### Description:
This PR addresses an issue in which occasionally, two consecutive Points would be inserted along a Line during Relation slicing. This issue was caused by using the full iterator of `atlas.pointsAt()`, which would occasionally return multiple Points for the same location. The intent behind the code was simply to leverage an existing Point's coordinates, not to add all Points at that location to the Line. Beyond being a minor bug, this logic sometimes introduced differences to the final Relation slicing result based on what Points were included in the Atlas-- this change now ensures the results should be identical.

### Potential Impact:
N/A
### Unit Test Approach:
N/A
### Test Results:
N/A
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)