### PR TITLE
Cache: Retry downloading the file from the fetcher

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -10,9 +10,12 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
+import org.openstreetmap.atlas.utilities.runtime.Retry;
+import org.openstreetmap.atlas.utilities.scalars.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +39,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
     private static final String PROPERTY_LOCAL_TEMPORARY_DIRECTORY = "java.io.tmpdir";
     private static final String TEMPORARY_DIRECTORY_STRING = System
             .getProperty(PROPERTY_LOCAL_TEMPORARY_DIRECTORY);
+    private static final Retry RETRY = new Retry(5, Duration.ONE_SECOND);
 
     private final String namespace;
 
@@ -126,7 +130,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
         if (!cachedFile.exists())
         {
             logger.trace("StrategyID {}: attempting to cache resource {} in temporary file {}",
-                    this.getStrategyID(), resourceURI, cachedFile.toString());
+                    this.getStrategyID(), resourceURI, cachedFile);
 
             final Optional<Resource> resourceFromDefaultFetcher = defaultFetcher.apply(resourceURI);
             if (!resourceFromDefaultFetcher.isPresent())
@@ -138,18 +142,20 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
             }
 
             final File temporaryLocalFile = File.temporary();
-            try
+            RETRY.run(() ->
             {
-                resourceFromDefaultFetcher.get().copyTo(temporaryLocalFile);
-            }
-            catch (final Exception exception)
-            {
-                logger.error(
-                        "StrategyID {}: something went wrong copying {} to temporary local file {}",
-                        this.getStrategyID(), resourceFromDefaultFetcher.toString(),
-                        temporaryLocalFile.toString(), exception);
-                return;
-            }
+                try
+                {
+                    resourceFromDefaultFetcher.get().copyTo(temporaryLocalFile);
+                }
+                catch (final Exception exception)
+                {
+                    throw new CoreException(
+                            "StrategyID {}: something went wrong copying {} to temporary local file {}",
+                            this.getStrategyID(), resourceFromDefaultFetcher.toString(),
+                            temporaryLocalFile.toString(), exception);
+                }
+            });
 
             // now that we have pulled down the file to a unique temporary location, attempt to
             // atomically move it to the cache after re-checking for existence
@@ -165,12 +171,11 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
                 catch (final FileAlreadyExistsException exception)
                 {
                     logger.trace("StrategyID {}: file {} is already cached", this.getStrategyID(),
-                            cachedFile.toString());
-                    return;
+                            cachedFile);
                 }
                 catch (final Exception exception)
                 {
-                    logger.error("StrategyID {}: something went wrong moving {} to {}",
+                    throw new CoreException("StrategyID {}: something went wrong moving {} to {}",
                             this.getStrategyID(), temporaryLocalFile.toString(),
                             cachedFile.toString(), exception);
                 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -152,8 +152,8 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
                 {
                     throw new CoreException(
                             "StrategyID {}: something went wrong copying {} to temporary local file {}",
-                            this.getStrategyID(), resourceFromDefaultFetcher.toString(),
-                            temporaryLocalFile.toString(), exception);
+                            this.getStrategyID(), resourceFromDefaultFetcher, temporaryLocalFile,
+                            exception);
                 }
             });
 
@@ -176,8 +176,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
                 catch (final Exception exception)
                 {
                     throw new CoreException("StrategyID {}: something went wrong moving {} to {}",
-                            this.getStrategyID(), temporaryLocalFile.toString(),
-                            cachedFile.toString(), exception);
+                            this.getStrategyID(), temporaryLocalFile, cachedFile, exception);
                 }
             }
         }


### PR DESCRIPTION
### Description:

When a namespace caching strategy relies on a fetcher that is unreliable (reading files from a network storage for example) we should attempt multiple retries. Also if all retries fail, the error should be thrown, and not just logged.

This is in line with #529 

### Potential Impact:

**Breaking Change**: This might break any workflows expecting an exception to be handled here. Those workflows will have to be updated to handle the errors upstream.

### Unit Test Approach:

Use existing tests in Retry and NamespaceCachingStrategy

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
