### PR TITLE
Refactored Shard string parsing to handle arbitrary shard types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=5.7.8-SNAPSHOT
+version=5.7.8.0.LUCAS
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=5.7.8.0.LUCAS
+version=5.7.8-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonType;
+import org.openstreetmap.atlas.geography.sharding.converters.StringToShardConverter;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
 import com.google.gson.JsonObject;
@@ -22,8 +23,8 @@ public class CountryShard implements Shard
 
     public static CountryShard forName(final String name)
     {
-        final StringList split = StringList.split(name, Shard.SHARD_DATA_SEPARATOR);
-        return new CountryShard(split.get(0), SlippyTile.forName(split.get(1)));
+        final StringList split = StringList.split(name, Shard.SHARD_DATA_SEPARATOR, 2);
+        return new CountryShard(split.get(0), new StringToShardConverter().convert(split.get(1)));
     }
 
     public CountryShard(final String country, final Shard shard)

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
@@ -17,16 +17,12 @@ public class CountryShard implements Shard
 {
     private static final long serialVersionUID = -4158215940506552768L;
 
-    // This is the separator between the country code and the shard name: COUNTRY_Z-X-Y in case of a
-    // SlippyTile for a Shard.
-    public static final String COUNTRY_SHARD_SEPARATOR = "_";
-
     private final Shard shard;
     private final String country;
 
     public static CountryShard forName(final String name)
     {
-        final StringList split = StringList.split(name, COUNTRY_SHARD_SEPARATOR);
+        final StringList split = StringList.split(name, Shard.SHARD_DATA_SEPARATOR);
         return new CountryShard(split.get(0), SlippyTile.forName(split.get(1)));
     }
 
@@ -79,7 +75,7 @@ public class CountryShard implements Shard
     @Override
     public String getName()
     {
-        return this.country + COUNTRY_SHARD_SEPARATOR + this.shard.getName();
+        return this.country + Shard.SHARD_DATA_SEPARATOR + this.shard.getName();
     }
 
     public Shard getShard()
@@ -96,7 +92,8 @@ public class CountryShard implements Shard
     @Override
     public String toString()
     {
-        return getName();
+        return "[CountryShard: country = " + this.country + ", shard = " + this.shard.toString()
+                + "]";
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/GeoHashTile.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/GeoHashTile.java
@@ -19,14 +19,16 @@ import com.google.gson.JsonObject;
  */
 public class GeoHashTile implements Shard
 {
-    private static final long serialVersionUID = 525101912087621541L;
-    private static final RectangleToSpatial4JRectangleConverter RECTANGLE_TO_SPATIAL_4_J_RECTANGLE_CONVERTER = new RectangleToSpatial4JRectangleConverter();
     public static final int MAXIMUM_PRECISION = 12;
+    public static final GeoHashTile ROOT = new GeoHashTile("");
+
     static final char[] GEOHASH_CHARACTERS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
             'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r', 's', 't', 'u',
             'v', 'w', 'x', 'y', 'z' };
     static final BiMap<Integer, Character> GEOHASH_CHARACTER_MAP = HashBiMap.create();
-    public static final GeoHashTile ROOT = new GeoHashTile("");
+
+    private static final long serialVersionUID = 525101912087621541L;
+    private static final RectangleToSpatial4JRectangleConverter RECTANGLE_TO_SPATIAL_4_J_RECTANGLE_CONVERTER = new RectangleToSpatial4JRectangleConverter();
 
     static
     {
@@ -169,7 +171,7 @@ public class GeoHashTile implements Shard
     @Override
     public String toString()
     {
-        return getName();
+        return "[GeoHashTile: value = " + this.value + "]";
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/Shard.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/Shard.java
@@ -4,13 +4,27 @@ import java.io.Serializable;
 
 import org.openstreetmap.atlas.geography.GeometryPrintable;
 import org.openstreetmap.atlas.geography.Located;
+import org.openstreetmap.atlas.geography.sharding.converters.StringToShardConverter;
 
 /**
  * A {@link Sharding} shard.
  *
  * @author matthieun
  */
-public interface Shard extends Located, Serializable, GeometryPrintable
+public interface Shard extends Located, Serializable, GeometryPrintable // NOSONAR
 {
+    /**
+     * The separator character for data within a shard string. For example, this character should be
+     * used to separate the country code from the shard name: USA_1-2-3. It should also be used to
+     * separate metadata from the shard name: USA_4-5-6_zz/xx/yy
+     */
+    String SHARD_DATA_SEPARATOR = "_";
+
+    /**
+     * Get the name of this {@link Shard}. The result of this method should be parsable by
+     * {@link StringToShardConverter}.
+     * 
+     * @return the parsable name of this {@link Shard}
+     */
     String getName();
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/SlippyTile.java
@@ -30,6 +30,8 @@ public class SlippyTile implements Shard, Comparable<SlippyTile>
 {
     public static final SlippyTile ROOT = new SlippyTile(0, 0, 0);
     public static final int MAX_ZOOM = 30;
+    public static final String COORDINATE_SEPARATOR = "-";
+
     private static final long serialVersionUID = -3752920878013084039L;
     private static final SlippyTileConverter CONVERTER = new SlippyTileConverter();
     private static final double CIRCULAR_MULTIPLIER = 2.0;

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/converters/SlippyTileConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/converters/SlippyTileConverter.java
@@ -12,26 +12,27 @@ import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
  */
 public class SlippyTileConverter implements TwoWayConverter<SlippyTile, String>
 {
-    private static final String SEPARATOR = "-";
     private static final int TILE_DIMENSIONS = 3;
 
     @Override
     public SlippyTile backwardConvert(final String slippyTileParameters)
     {
-        final StringList splits = StringList.split(slippyTileParameters, SEPARATOR);
+        final StringList splits = StringList.split(slippyTileParameters,
+                SlippyTile.COORDINATE_SEPARATOR);
         if (splits.size() != TILE_DIMENSIONS)
         {
             throw new CoreException("Wrong format of input string {}", slippyTileParameters);
         }
-        final int zoom = Integer.valueOf(splits.get(0));
-        final int xAxis = Integer.valueOf(splits.get(1));
-        final int yAxis = Integer.valueOf(splits.get(2));
+        final int zoom = Integer.parseInt(splits.get(0));
+        final int xAxis = Integer.parseInt(splits.get(1));
+        final int yAxis = Integer.parseInt(splits.get(2));
         return new SlippyTile(xAxis, yAxis, zoom);
     }
 
     @Override
     public String convert(final SlippyTile slippyTile)
     {
-        return slippyTile.getZoom() + SEPARATOR + slippyTile.getX() + SEPARATOR + slippyTile.getY();
+        return slippyTile.getZoom() + SlippyTile.COORDINATE_SEPARATOR + slippyTile.getX()
+                + SlippyTile.COORDINATE_SEPARATOR + slippyTile.getY();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverter.java
@@ -1,0 +1,150 @@
+package org.openstreetmap.atlas.geography.sharding.converters;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.sharding.CountryShard;
+import org.openstreetmap.atlas.geography.sharding.GeoHashTile;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.conversion.Converter;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/*
+ * TODO debug and comment, also perhaps add in special code to Shard implementations so that this
+ * class can automatically handle new implementations. This means we need to add methods to the
+ * Shard interface.
+ */
+/**
+ * Convert a string representation of a {@link Shard} to a concrete {@link Shard} object. Any time a
+ * new {@link Shard} implementation is added, this class needs to be updated. See the Javadoc for
+ * the {@link StringToShardConverter#convert(String)} method for more information.
+ *
+ * @author lcram
+ */
+public class StringToShardConverter implements Converter<String, Shard>
+{
+    private static final String COUNTRY_CODE_REGEX = "^[A-Z][A-Z0-9][A-Z0-9]$";
+    private static final String SLIPPY_TILE_REGEX = "^[0-9]+\\-[0-9]+\\-[0-9]+$";
+    private static final String GEOHASH_TILE_REGEX = "^[0-9b|c|d|e|f|g|h|j|k|m|n|o|p|q|r|s|t|u|v|w|x|y|z]+$";
+
+    /**
+     * Convert a string into a concrete {@link Shard} object. This method attempts to handle all
+     * possible shard strings that exist in the wild. Note that this method will correctly handle
+     * country shards in the form "ABC_1-2-3", where "_" is the declared country-shard separator. To
+     * extract metadata from the shard string (e.g. ABC_1-2-3_xx/yy/zz), see
+     * {@link StringToShardConverter#convertWithMetadata}.
+     * 
+     * @param shardString
+     *            the shard in string format
+     * @return the constructed {@link Shard}
+     */
+    @Override
+    public Shard convert(final String shardString)
+    {
+        return convertWithMetadata(shardString).getFirst();
+    }
+
+    /**
+     * Convert the shard string, and also get any metadata appended to the end of the string.
+     * 
+     * @param shardString
+     *            the shard in string format
+     * @return a {@link Tuple} containing the constructed {@link Shard} as well as the metadata.
+     */
+    public Tuple<Shard, Optional<String>> convertWithMetadata(final String shardString)
+    {
+        final StringList shardSplit = StringList.split(shardString,
+                CountryShard.COUNTRY_SHARD_SEPARATOR, 2);
+
+        try
+        {
+            return convertHelper(shardSplit);
+        }
+        catch (final Exception exception)
+        {
+            throw new CoreException("Could not parse shard string: {}", shardString, exception);
+        }
+    }
+
+    private Tuple<Shard, Optional<String>> convertHelper(final StringList shardSplit)
+    {
+        /*
+         * In this case, the shardSplit should contain just the shard string. For e.g. "1-2-3" for
+         * SlippyTile or "bb2r5" for GeoHashTile.
+         */
+        if (shardSplit.size() == 1)
+        {
+            return nonCountryShardFromSplit(shardSplit);
+        }
+        /*
+         * In this case, the shardSplit should contain a country code, a shard string, and
+         * optionally some additional metadata introduced by downstream client code. For e.g. we may
+         * have "ABC_1-2-2" or "DEF_bb2r5" or "GHI_1-2-3_additionalmetadata". For the purposes of
+         * shard parsing, we ignore the additional metadata. Note that we use a recursive call to
+         * recover the subshard, in the case of a nested CountryShard (e.g.
+         * ABC_DEF_1-2-3_somemetadata). It is also possible the the shardSplit is just a shard
+         * string and some metadata. In that case, we ignore country code parsing.
+         */
+        else if (shardSplit.size() > 1)
+        {
+            if (shardSplit.get(0).matches(COUNTRY_CODE_REGEX))
+            {
+                final StringList newListWithoutCountryCode = StringList.split(shardSplit.get(1),
+                        CountryShard.COUNTRY_SHARD_SEPARATOR, 2);
+                final Tuple<Shard, Optional<String>> conversionResult = convertHelper(
+                        newListWithoutCountryCode);
+                return new Tuple<>(new CountryShard(shardSplit.get(0), conversionResult.getFirst()),
+                        conversionResult.getSecond());
+            }
+            return nonCountryShardFromSplit(shardSplit);
+        }
+        /*
+         * Otherwise we have to fail.
+         */
+        else
+        {
+            throw new CoreException("Split list {} had invalid size {}, must be at least 1",
+                    shardSplit, shardSplit.size());
+        }
+    }
+
+    /**
+     * A helper to convert a {@link StringList} into a {@link Shard} object, but excluding the
+     * {@link CountryShard} implementation. This method will ignore any trailing metadata.
+     * 
+     * @param shardSplit
+     *            the {@link StringList} containing the shard info
+     * @return the constructed {@link Shard}
+     */
+    private Tuple<Shard, Optional<String>> nonCountryShardFromSplit(final StringList shardSplit)
+    {
+        if (shardSplit.size() < 1)
+        {
+            throw new CoreException("Split list {} had invalid size {}, must be at least 1",
+                    shardSplit, shardSplit.size());
+        }
+
+        final Shard shard;
+        final String shardString = shardSplit.get(0);
+        if (shardString.matches(SLIPPY_TILE_REGEX))
+        {
+            shard = SlippyTile.forName(shardString);
+        }
+        else if (shardString.matches(GEOHASH_TILE_REGEX))
+        {
+            shard = GeoHashTile.forName(shardString);
+        }
+        else
+        {
+            throw new CoreException("Unrecognized shard component: {}", shardString);
+        }
+
+        if (shardSplit.size() > 1)
+        {
+            return new Tuple<>(shard, Optional.of(shardSplit.get(1)));
+        }
+        return new Tuple<>(shard, Optional.empty());
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/collections/StringList.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/collections/StringList.java
@@ -173,6 +173,11 @@ public class StringList implements Iterable<String>, Serializable
         return Optional.of(this.get(size() - 1));
     }
 
+    public void remove(final int index)
+    {
+        this.list.remove(index);
+    }
+
     public int size()
     {
         return this.list.size();

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PbfToAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PbfToAtlasCommand.java
@@ -12,7 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas.AtlasSerializa
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.creation.RawAtlasGenerator;
 import org.openstreetmap.atlas.geography.atlas.raw.sectioning.WaySectionProcessor;
-import org.openstreetmap.atlas.geography.sharding.CountryShard;
+import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
@@ -82,7 +82,7 @@ public class PbfToAtlasCommand extends MultipleOutputCommand
                     AtlasLoadingOption.createOptionWithOnlySectioning(), getBounds()).build();
             final String pbfName = pbf.getName().replace(FileSuffix.PBF.toString(), "");
             final String rawAtlasFilename = String.format("%s%s%s%s", countryName,
-                    CountryShard.COUNTRY_SHARD_SEPARATOR, pbfName, FileSuffix.ATLAS);
+                    Shard.SHARD_DATA_SEPARATOR, pbfName, FileSuffix.ATLAS);
             if (!stopAtRaw())
             {
                 final WaySectionProcessor waySectionProcessor = new WaySectionProcessor(atlas,

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommand.java
@@ -2,7 +2,8 @@ package org.openstreetmap.atlas.utilities.command.subcommands;
 
 import java.util.List;
 
-import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.converters.StringToShardConverter;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
@@ -84,19 +85,19 @@ public class ShardToBoundsCommand extends AbstractAtlasShellToolsCommand
         super.registerOptionsAndArguments();
     }
 
-    private void parseShardAndPrintOutput(final String shard)
+    private void parseShardAndPrintOutput(final String shardName)
     {
-        this.outputDelegate.printlnStdout(shard + " bounds: ", TTYAttribute.BOLD);
-        final SlippyTile tile;
+        this.outputDelegate.printlnStdout(shardName + " bounds: ", TTYAttribute.BOLD);
+        final Shard shard;
         try
         {
-            tile = SlippyTile.forName(shard);
+            shard = new StringToShardConverter().convert(shardName);
         }
         catch (final Exception exception)
         {
-            logger.error("unable to parse {}", shard, exception);
+            logger.error("unable to parse {}", shardName, exception);
             return;
         }
-        this.outputDelegate.printlnStdout(tile.bounds().toWkt(), TTYAttribute.GREEN);
+        this.outputDelegate.printlnStdout(shard.bounds().toWkt(), TTYAttribute.GREEN);
     }
 }

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandDescriptionSection.txt
@@ -1,3 +1,3 @@
-Given a shard (or multiple shards), output the WKT of the shard's boundary. This
-boundary will always be a rectangle. The shards should be specified using their string
-format, e.g. the shard for [Zoom: 9, X: 168, Y: 233] would be specified as '9-168-233'.
+Given a shard (or multiple shards) in any format, output the WKT of the shard's boundary. This
+boundary will always be a rectangle. The shards should be specified using their getName() string
+format, e.g. the SlippyTile shard for [Zoom: 9, X: 168, Y: 233] would be specified as '9-168-233'.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandExamplesSection.txt
@@ -1,2 +1,6 @@
-Get the boundaries of some shards:
+Get the boundaries of some SlippyTile shards:
 #$ shard-bounds 9-168-233 9-168-234
+Get the boundary of a GeoHashTile shard:
+#$ shard-bounds dd4fb
+Get the boundaries of an assortment of shards:
+#$ shard-bounds DMA_9-168-233 1-2-3 f45tkp8n

--- a/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListCacheTest.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
-import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -24,13 +24,13 @@ public class CountryToShardListCacheTest
     {
         final CountryToShardListCache cache = new CountryToShardListCache(this.countryToShardList);
         // test that the right DMA shards are returned
-        final List<SlippyTile> dMAShards = cache.getShardsForCountry("DMA");
+        final List<Shard> dMAShards = cache.getShardsForCountry("DMA");
         Assert.assertEquals(
                 "[[SlippyTile: zoom = 9, x = 168, y = 233], [SlippyTile: zoom = 9, x = 169, y = 233], "
                         + "[SlippyTile: zoom = 9, x = 168, y = 234], [SlippyTile: zoom = 10, x = 338, y = 468]]",
                 dMAShards.toString());
         // test that asking for an invalid country code doesn't break anything
-        final List<SlippyTile> noShards = cache.getShardsForCountry("XXX");
+        final List<Shard> noShards = cache.getShardsForCountry("XXX");
         Assert.assertTrue(noShards.isEmpty());
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
@@ -1,0 +1,52 @@
+package org.openstreetmap.atlas.geography.sharding.converters;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.sharding.CountryShard;
+import org.openstreetmap.atlas.geography.sharding.GeoHashTile;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/**
+ * @author lcram
+ */
+public class StringToShardConverterTest
+{
+    @Test
+    public void testConverter()
+    {
+        Assert.fail("TODO fill in rest");
+    }
+
+    @Test
+    public void testConverterWithMetadata()
+    {
+        final Tuple<Shard, Optional<String>> tuple1 = new StringToShardConverter()
+                .convertWithMetadata("ABC_1-2-3");
+        final Tuple<Shard, Optional<String>> tuple2 = new StringToShardConverter()
+                .convertWithMetadata("ABC_bb54tp9");
+        final Tuple<Shard, Optional<String>> tuple3 = new StringToShardConverter()
+                .convertWithMetadata("ABC_1-2-3_zz/xx/yy");
+        final Tuple<Shard, Optional<String>> tuple4 = new StringToShardConverter()
+                .convertWithMetadata("1-2-3");
+        final Tuple<Shard, Optional<String>> tuple5 = new StringToShardConverter()
+                .convertWithMetadata("1-2-3_zz/_moremetadata");
+
+        Assert.assertTrue(tuple1.getFirst() instanceof CountryShard);
+        Assert.assertEquals("ABC", ((CountryShard) tuple1.getFirst()).getCountry());
+        Assert.assertTrue(((CountryShard) tuple1.getFirst()).getShard() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]",
+                ((CountryShard) tuple1.getFirst()).getShard().toString());
+
+        Assert.assertTrue(tuple2.getFirst() instanceof CountryShard);
+        Assert.assertEquals("ABC", ((CountryShard) tuple2.getFirst()).getCountry());
+        Assert.assertTrue(((CountryShard) tuple2.getFirst()).getShard() instanceof GeoHashTile);
+        Assert.assertEquals("[GeoHashTile: value = bb54tp9]",
+                ((CountryShard) tuple2.getFirst()).getShard().toString());
+
+        Assert.fail("TODO fill in rest");
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
@@ -18,7 +18,12 @@ public class StringToShardConverterTest
     @Test
     public void testConverter()
     {
-        Assert.fail("TODO fill in rest");
+        final Shard shard1 = new StringToShardConverter().convert("ABC_1-2-3");
+        Assert.assertTrue(shard1 instanceof CountryShard);
+        Assert.assertEquals("ABC", ((CountryShard) shard1).getCountry());
+        Assert.assertTrue(((CountryShard) shard1).getShard() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]",
+                ((CountryShard) shard1).getShard().toString());
     }
 
     @Test
@@ -34,6 +39,8 @@ public class StringToShardConverterTest
                 .convertWithMetadata("1-2-3");
         final Tuple<Shard, Optional<String>> tuple5 = new StringToShardConverter()
                 .convertWithMetadata("1-2-3_zz/_moremetadata");
+        final Tuple<Shard, Optional<String>> tuple6 = new StringToShardConverter()
+                .convertWithMetadata("ABC_DEF_1-2-3_zz/xx/yy");
 
         Assert.assertTrue(tuple1.getFirst() instanceof CountryShard);
         Assert.assertEquals("ABC", ((CountryShard) tuple1.getFirst()).getCountry());
@@ -47,6 +54,34 @@ public class StringToShardConverterTest
         Assert.assertEquals("[GeoHashTile: value = bb54tp9]",
                 ((CountryShard) tuple2.getFirst()).getShard().toString());
 
-        Assert.fail("TODO fill in rest");
+        Assert.assertTrue(tuple3.getFirst() instanceof CountryShard);
+        Assert.assertEquals("ABC", ((CountryShard) tuple3.getFirst()).getCountry());
+        Assert.assertTrue(((CountryShard) tuple3.getFirst()).getShard() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]",
+                ((CountryShard) tuple3.getFirst()).getShard().toString());
+        Assert.assertTrue(tuple3.getSecond().isPresent());
+        Assert.assertEquals("zz/xx/yy", tuple3.getSecond().get());
+
+        Assert.assertTrue(tuple4.getFirst() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]", tuple4.getFirst().toString());
+        Assert.assertFalse(tuple4.getSecond().isPresent());
+
+        Assert.assertTrue(tuple5.getFirst() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]", tuple5.getFirst().toString());
+        Assert.assertTrue(tuple5.getSecond().isPresent());
+        Assert.assertEquals("zz/_moremetadata", tuple5.getSecond().get());
+
+        Assert.assertTrue(tuple6.getFirst() instanceof CountryShard);
+        Assert.assertEquals("ABC", ((CountryShard) tuple6.getFirst()).getCountry());
+        Assert.assertTrue(((CountryShard) tuple6.getFirst()).getShard() instanceof CountryShard);
+        Assert.assertEquals("DEF",
+                ((CountryShard) ((CountryShard) tuple6.getFirst()).getShard()).getCountry());
+        Assert.assertTrue(((CountryShard) ((CountryShard) tuple6.getFirst()).getShard())
+                .getShard() instanceof SlippyTile);
+        Assert.assertEquals("[SlippyTile: zoom = 1, x = 2, y = 3]",
+                ((CountryShard) ((CountryShard) tuple6.getFirst()).getShard()).getShard()
+                        .toString());
+        Assert.assertTrue(tuple6.getSecond().isPresent());
+        Assert.assertEquals("zz/xx/yy", tuple6.getSecond().get());
     }
 }


### PR DESCRIPTION
### Description:

A new class called `StringToShardConverter` can now accept any type of `Shard` name, and from it return an instance of a concrete `Shard` implementation, as well as any metadata.

### Potential Impact:

There may be downstream code (e.g. `atlas-generator`) that needs upgrading. Some of it uses `SlippyTile.forName` when it should be using `StringToShardConverter#convert`, in order to handle various `Shard` implementations.

### Unit Test Approach:

Added unit test for new class

### Test Results:

Test pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)