### PR TITLE
Extend FC bounds expansion to relation members

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeBoundsExpander.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeBoundsExpander.java
@@ -1,7 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -30,52 +29,6 @@ import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
  */
 public class FeatureChangeBoundsExpander
 {
-    /**
-     * @author matthieun
-     */
-    private static final class TypeAndIdentifier
-    {
-        private final ItemType itemType;
-        private final long identifier;
-
-        TypeAndIdentifier(final ItemType itemType, final long identifier)
-        {
-            this.itemType = itemType;
-            this.identifier = identifier;
-        }
-
-        @Override
-        public boolean equals(final Object other)
-        {
-            if (this == other)
-            {
-                return true;
-            }
-            if (other == null || getClass() != other.getClass())
-            {
-                return false;
-            }
-            final TypeAndIdentifier that = (TypeAndIdentifier) other;
-            return getIdentifier() == that.getIdentifier() && getItemType() == that.getItemType();
-        }
-
-        public long getIdentifier()
-        {
-            return this.identifier;
-        }
-
-        public ItemType getItemType()
-        {
-            return this.itemType;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(getItemType(), getIdentifier());
-        }
-    }
-
     private final Set<FeatureChange> featureChanges;
     private Atlas atlas;
     private final Predicate<FeatureChange> needsUpdate = featureChange ->
@@ -104,7 +57,7 @@ public class FeatureChangeBoundsExpander
     };
     private final Set<FeatureChange> result = new HashSet<>();
     private final Set<FeatureChange> featureChangesToUpdate = new HashSet<>();
-    private final MultiMapWithSet<TypeAndIdentifier, Rectangle> typeIdentifiToEextensionBounds = new MultiMapWithSet<>();
+    private final MultiMapWithSet<AtlasEntityKey, Rectangle> typeIdentifiToEextensionBounds = new MultiMapWithSet<>();
 
     public FeatureChangeBoundsExpander(final Set<FeatureChange> featureChanges, final Atlas atlas)
     {
@@ -122,7 +75,7 @@ public class FeatureChangeBoundsExpander
         for (final FeatureChange featureChange : this.featureChangesToUpdate)
         {
             final Set<Rectangle> expansionRectangles = this.typeIdentifiToEextensionBounds
-                    .get(new TypeAndIdentifier(featureChange.getItemType(),
+                    .get(AtlasEntityKey.from(featureChange.getItemType(),
                             featureChange.getIdentifier()));
             FeatureChange newFeatureChange = featureChange;
             if (expansionRectangles != null)
@@ -212,12 +165,12 @@ public class FeatureChangeBoundsExpander
         if (start != null)
         {
             this.typeIdentifiToEextensionBounds
-                    .add(new TypeAndIdentifier(ItemType.NODE, start.getIdentifier()), bounds);
+                    .add(AtlasEntityKey.from(ItemType.NODE, start.getIdentifier()), bounds);
         }
         if (end != null)
         {
             this.typeIdentifiToEextensionBounds
-                    .add(new TypeAndIdentifier(ItemType.NODE, end.getIdentifier()), bounds);
+                    .add(AtlasEntityKey.from(ItemType.NODE, end.getIdentifier()), bounds);
         }
     }
 
@@ -230,8 +183,8 @@ public class FeatureChangeBoundsExpander
             members.forEach(relationMember ->
             {
                 final AtlasEntity entity = relationMember.getEntity();
-                this.typeIdentifiToEextensionBounds.add(
-                        new TypeAndIdentifier(entity.getType(), entity.getIdentifier()), bounds);
+                this.typeIdentifiToEextensionBounds
+                        .add(AtlasEntityKey.from(entity.getType(), entity.getIdentifier()), bounds);
             });
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeBoundsExpander.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeBoundsExpander.java
@@ -51,11 +51,7 @@ public class FeatureChangeBoundsExpander
         }
         final AtlasEntity entity = this.atlas.entity(featureChange.getIdentifier(),
                 featureChange.getItemType());
-        if (entity != null && !entity.relations().isEmpty())
-        {
-            return true;
-        }
-        return false;
+        return entity != null && !entity.relations().isEmpty();
     };
     private final Set<FeatureChange> result = new HashSet<>();
     private final Set<FeatureChange> featureChangesToUpdate = new HashSet<>();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -41,7 +41,7 @@ public class AtlasChangeGeneratorTest
         final Set<FeatureChange> changes = new FeatureChangeBoundsExpander(result, source).apply();
         for (final FeatureChange featureChange : changes)
         {
-            if (featureChange.getIdentifier() == 250641000000L)
+            if (featureChange.getIdentifier() == 177633000000L)
             {
                 Assert.assertEquals(Location.forWkt("POINT (4.2194855 38.8231656)"),
                         ((CompleteNode) featureChange.getAfterView()).getLocation());
@@ -90,6 +90,25 @@ public class AtlasChangeGeneratorTest
                 Assert.assertEquals(
                         "POLYGON ((4.2177433 38.8228217, 4.2177433 38.8235147, 4.2202479 38.8235147,"
                                 + " 4.2202479 38.8228217, 4.2177433 38.8228217))",
+                        featureChange.bounds().toWkt());
+            }
+        }
+    }
+
+    @Test
+    public void testExpandRelation()
+    {
+        final Atlas source = this.rule.getNodeBoundsExpansionAtlas();
+        final Set<FeatureChange> result = new HashSet<>();
+        result.add(FeatureChange.add(CompleteEdge.from(source.edge(177630000000L))));
+        final Set<FeatureChange> changes = new FeatureChangeBoundsExpander(result, source).apply();
+        for (final FeatureChange featureChange : changes)
+        {
+            if (featureChange.getIdentifier() == 177763000000L)
+            {
+                Assert.assertEquals(
+                        "POLYGON ((4.2177433 38.8228217, 4.2177433 38.8235147, 4.2197697 38.8235147,"
+                                + " 4.2197697 38.8228217, 4.2177433 38.8228217))",
                         featureChange.bounds().toWkt());
             }
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/AtlasChangeGeneratorTest.java
@@ -35,13 +35,13 @@ public class AtlasChangeGeneratorTest
         for (final Node node : source.nodes())
         {
             final CompleteNode completeNode = CompleteNode.shallowFrom(node)
-                    .withTags(node.getTags());
+                    .withLocation(node.getLocation()).withTags(node.getTags());
             result.add(FeatureChange.add(completeNode));
         }
-        final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
+        final Set<FeatureChange> changes = new FeatureChangeBoundsExpander(result, source).apply();
         for (final FeatureChange featureChange : changes)
         {
-            if (featureChange.getIdentifier() == 177633000000L)
+            if (featureChange.getIdentifier() == 250641000000L)
             {
                 Assert.assertEquals(Location.forWkt("POINT (4.2194855 38.8231656)"),
                         ((CompleteNode) featureChange.getAfterView()).getLocation());
@@ -82,7 +82,7 @@ public class AtlasChangeGeneratorTest
         result.add(FeatureChange.add(new CompleteNode(456L,
                 Location.forWkt("POINT (4.2200000 38.8235147)"), Maps.hashMap(HIGHWAY, "primary"),
                 Sets.treeSet(), Sets.treeSet(123L), Sets.hashSet())));
-        final Set<FeatureChange> changes = AtlasChangeGenerator.expandNodeBounds(source, result);
+        final Set<FeatureChange> changes = new FeatureChangeBoundsExpander(result, source).apply();
         for (final FeatureChange featureChange : changes)
         {
             if (featureChange.getIdentifier() == 177633000000L)

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/nodeBoundsExpansionAtlas.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/nodeBoundsExpansionAtlas.josm.osm
@@ -20,4 +20,9 @@
     <nd ref='-177649' />
     <tag k='highway' v='footway' />
   </way>
+  <relation id='-250654' action='modify' visible='true'>
+    <member type='way' ref='-177648' role='one' />
+    <member type='way' ref='-177630' role='two' />
+    <tag k='type' v='test' />
+  </relation>
 </osm>


### PR DESCRIPTION
### Description:

Extend `FeatureChange` bounds expansion to relation members, the same way it was done for `Node`s connected to `Edge`s.
Also cleanup the code and move it away from a default method to a legitimate class.

### Potential Impact:

Some `FeatureChange` bounds will be larger

### Unit Test Approach:

Updated existing test and added new one.

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)