### PR TITLE
Allow Namespace caching implementations to validate local file

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasSerializer.java
@@ -109,7 +109,7 @@ public final class PackedAtlasSerializer
         final AtlasSerializationFormat[] possibleFormats = AtlasSerializationFormat.values();
         for (final AtlasSerializationFormat candidateFormat : possibleFormats)
         {
-            logger.debug("Trying load format {}", candidateFormat);
+            logger.trace("Trying load format {} for atlas {}", candidateFormat, atlas.getName());
             atlas.setLoadSerializationFormat(candidateFormat);
             try
             {
@@ -117,15 +117,17 @@ public final class PackedAtlasSerializer
             }
             catch (final CoreException exception)
             {
-                logger.debug("Load format {} invalid", candidateFormat, exception);
+                logger.debug("Load format {} invalid for atlas {}", candidateFormat,
+                        atlas.getName(), exception);
                 continue;
             }
             // If we make it here, then we found the appropriate format and we can bail out
-            logger.debug("Using load format {}", candidateFormat);
+            logger.trace("Using load format {} for atlas {}", candidateFormat, atlas.getName());
             return;
         }
 
-        throw new CoreException("Could not determine a valid load format for atlas");
+        throw new CoreException("Could not determine a valid load format for atlas {}",
+                atlas.getName());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -124,6 +124,11 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
         }
     }
 
+    protected void validateLocalFile(final File localFile)
+    {
+        // Do nothing here, leave to extensions to decide.
+    }
+
     private void attemptToCacheFileLocally(final File cachedFile,
             final Function<URI, Optional<Resource>> defaultFetcher, final URI resourceURI)
     {
@@ -147,6 +152,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
                 try
                 {
                     resourceFromDefaultFetcher.get().copyTo(temporaryLocalFile);
+                    validateLocalFile(temporaryLocalFile);
                 }
                 catch (final Exception exception)
                 {

--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -173,6 +173,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
                     final Path cachedFilePath = Paths.get(cachedFile.getPath());
                     Files.move(temporaryLocalFilePath, cachedFilePath,
                             StandardCopyOption.ATOMIC_MOVE);
+                    validateLocalFile(cachedFile);
                 }
                 catch (final FileAlreadyExistsException exception)
                 {


### PR DESCRIPTION
### Description:

The Namespace caching strategy stores cached resources in local temporary files. This PR creates an empty method that would allow extensions to validate the copied local files.

Also: Improved logging in `PackedAtlasSerializer`

### Potential Impact:

No change, except for extensions that choose to extend this function.

### Unit Test Approach:

Use existing tests

### Test Results:

Use existing tests

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)