### PR TITLE
Some QoL updates to Atlas Shell Tools

### DIFF
--- a/atlas-shell-tools/ast_completions.bash
+++ b/atlas-shell-tools/ast_completions.bash
@@ -26,7 +26,7 @@ is_bash_at_least_version_4 ()
     fi
 }
 
-_complete ()
+_complete_atlas_shell_tools ()
 {
     local completion_mode="default";
     if [ "$1" = "atlas" ];
@@ -74,5 +74,5 @@ _complete ()
     fi
 }
 
-complete -o filenames -o bashdefault -F _complete atlas
-complete -o filenames -o bashdefault -F _complete atlas-config
+complete -o filenames -o bashdefault -F _complete_atlas_shell_tools atlas
+complete -o filenames -o bashdefault -F _complete_atlas_shell_tools atlas-config

--- a/atlas-shell-tools/man/man1/atlas-config-activate.1
+++ b/atlas-shell-tools/man/man1/atlas-config-activate.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-activate \-- Activate an installed Atlas Shell Tools module
+atlas\-config\-activate \-\- Activate an installed Atlas Shell Tools module
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-deactivate.1
+++ b/atlas-shell-tools/man/man1/atlas-config-deactivate.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-deactivate \-- Deactivate an installed Atlas Shell Tools module
+atlas\-config\-deactivate \-\- Deactivate an installed Atlas Shell Tools module
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-install.1
+++ b/atlas-shell-tools/man/man1/atlas-config-install.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-install \-- Install a new Atlas Shell Tools module from a local JAR
+atlas\-config\-install \-\- Install a new Atlas Shell Tools module from a local JAR
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-install.1
+++ b/atlas-shell-tools/man/man1/atlas-config-install.1
@@ -22,24 +22,21 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-install \-- Install a new Atlas Shell Tools module
+atlas\-config\-install \-- Install a new Atlas Shell Tools module from a local JAR
 
 .SH "SYNOPSIS"
 .sp
 .nf
 \fIatlas\-config\fR \fIinstall\fR \-\-help
-\fIatlas\-config\fR \fIinstall\fR \-\-repo=<repo>
 \fIatlas\-config\fR \fIinstall\fR [\-\-symlink] [\-\-force] [\-\-skip] [\-\-deactivated]
                      [\-\-name=<\fIname\fR>] <\fIJARfile\fR>
 .fi
 
 .SH "DESCRIPTION"
 .sp
-Installs and activates a given <\fIJARfile\fR> as a new \fBatlas\fR module, or installs
-a module from the repo specified by \fB\-\-repo\fR. This will deactivate any currently
-activated module. When the \fB\-\-repo\fR option is specified, \fBatlas-config-install\fR(1)
-ignores all other command line options and installs the repo using its repo
-configuration.
+Installs and activates a given <\fIJARfile\fR> as a new \fBatlas\fR module.
+This will deactivate any currently activated module. If you are trying to install
+a module from a specific repo, please see \fBatlas-config-repo\fR(1) for more information.
 
 When installing directly from a <\fIJARfile\fR>, the \fB\-\-symlink\fR option
 can be enabled to install using a symbolic link. This is great for cases where
@@ -86,13 +83,6 @@ Install a module using a custom name.
 .RE
 
 .PP
-\fB\-\-repo\fR=<repo>
-.RS 4
-Install a module from a repo. This is equivalent to the 'install' directive of
-\fBatlas\-config\-repo\fR(1).
-.RE
-
-.PP
 \fB\-\-skip\fR
 .RS 4
 Skip installation when re-installing an existing module.
@@ -117,12 +107,6 @@ Install a symlinked module but do not activate it:
 .sp
 .RS 4
 $ atlas\-config install \-\-symlink \-\-deactivated ~/example.jar
-.RE
-.sp
-Install a module from a repo called 'MyRepo':
-.sp
-.RS 4
-$ atlas\-config install \-\-repo MyRepo
 .RE
 
 .SH "SEE ALSO"

--- a/atlas-shell-tools/man/man1/atlas-config-list.1
+++ b/atlas-shell-tools/man/man1/atlas-config-list.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-list \-- List installed Atlas Shell Tools modules and module statuses
+atlas\-config\-list \-\- List installed Atlas Shell Tools modules and module statuses
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-list.1
+++ b/atlas-shell-tools/man/man1/atlas-config-list.1
@@ -22,19 +22,21 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-list \-- List all installed Atlas Shell Tools modules and module statuses
+atlas\-config\-list \-- List installed Atlas Shell Tools modules and module statuses
 
 .SH "SYNOPSIS"
 .sp
 .nf
 \fIatlas\-config\fR \fIlist\fR \-\-help
-\fIatlas\-config\fR \fIlist\fR
+\fIatlas\-config\fR \fIlist\fR [\-\-current] [\-\-verbose]
 .fi
 
 .SH "DESCRIPTION"
 .sp
-List all installed modules with additional contextual information. This listing
-is also known as the module workspace.
+List installed modules with additional contextual information. This listing
+is also known as the module workspace. The \fB\-\-verbose\fR option can be used to
+display module metadata if present. The \fB\-\-current\fR option can be used to view
+only the current activated module, if there is one.
 
 A \fB*\fR next to a module denotes that the module is activated. Symlinked
 modules display their targets using the familiar arrow notation (\fB\->\fR). If a
@@ -45,9 +47,21 @@ module name.
 .sp
 
 .PP
+\fB\-\-current\fR, \fB-c\fR
+.RS 4
+Show only the currently activated module, if one is activated.
+.RE
+
+.PP
 \fB\-\-help\fR
 .RS 4
 Show this help menu.
+.RE
+
+.PP
+\fB\-\-verbose\fR, \fB-v\fR
+.RS 4
+Show module metadata information below each module listing.
 .RE
 
 .SH "SEE ALSO"

--- a/atlas-shell-tools/man/man1/atlas-config-log.1
+++ b/atlas-shell-tools/man/man1/atlas-config-log.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-log \-- Check or set Atlas Shell Tools log parameters
+atlas\-config\-log \-\- Check or set Atlas Shell Tools log parameters
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-preset.1
+++ b/atlas-shell-tools/man/man1/atlas-config-preset.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-preset \-- Create and manage Atlas Shell Tools command presets
+atlas\-config\-preset \-\- Create and manage Atlas Shell Tools command presets
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-preset.1
+++ b/atlas-shell-tools/man/man1/atlas-config-preset.1
@@ -41,7 +41,7 @@ atlas\-config\-preset \-- Create and manage Atlas Shell Tools command presets
 \fBatlas\-config\-preset\fR(1) provides a more granular preset management interface
 than the basic \fBatlas\fR(1) options (\fB\-\-preset\fR, \fB\-\-save\-preset\fR).
 It can handle more complex tasks like editing a preset in place, or managing the
-preset namespaces. For full details on the workings on \fBatlas\-config\-preset\fR(1),
+preset namespaces. For full details on the workings of \fBatlas\-config\-preset\fR(1),
 see the \fBTier 2\fR and \fBTier 3\fR sections in \fBatlas\-presets\fR(7).
 
 .SH "OPTIONS"

--- a/atlas-shell-tools/man/man1/atlas-config-preset.1
+++ b/atlas-shell-tools/man/man1/atlas-config-preset.1
@@ -70,7 +70,7 @@ exist, else the copy will fail.
 .RS 4
 Edit preset <name> for <command>. If <name> does not exist, then it will be
 created when the edit is successfully saved. The default preset editor is \fBvim\fR,
-but this can be changed by setting the \fBEDITOR\fR environment variable.
+but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environment variable.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -70,7 +70,8 @@ Add a new repo object with a given <repo\-name>, \fBgit\fR(1) remote <URL>, and 
 optional default [ref]. Here, [ref] is a \fBgit\fR(1) ref (e.g. a branch name, a tag, or
 even a commit hash). If no explicit [ref] is provided, \fIadd\fR defaults to 'master'. The ref
 associated with a repo object is used by \fIinstall\fR as the default. See \fIinstall\fR for more
-information.
+information. Note that for <URL>, you can use any git\-clonable URL, i.e. an https:// URL, a file://
+URL, or even a local path like /Users/you/somerepo.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -39,7 +39,121 @@ atlas\-config\-repo \-- Register and manage Atlas Shell Tools repositories
 
 .SH "DESCRIPTION"
 .sp
-TODO
+\fBatlas\-config\-repo\fR(1) provides an interface for managing repo objects (By repo,
+we simply mean any \fBgit\fR(1) repository that contains Atlas Shell Tools command
+implementations). Once a new repo object has been registered using \fIadd\fR,
+new modules can be installed from the repo using the \fIinstall\fR directive.
+This makes it easy to fetch the newest versions of Atlas Shell Tools commands and
+manage their multiple sources. Additional directives facilitate more advanced use
+cases. See the \fBDIRECTIVES\fR section for details.
+.sp
+For module installation, \fBatlas\-config\-repo\fR(1) uses the default \fBbuild.gradle\fR
+of the referenced repo, but with a special injected configuration designed to build a fat
+JAR that will work with Atlas Shell Tools. See the \fIinstall\fR directive for more details
+on this process. Additionally, \fBatlas\-config\-repo\fR(1) provides some other directives to
+manipulate this configuration.
+.sp
+Also note that registering new repos with \fIadd\fR does not actually save the referenced
+repository on your machine. Rather it simply stores some metadata (which we refer to as a repo
+object) that is used to clone the referenced repo at install\-time. The clone is saved in
+a temporary location and is removed when module installation completes.
+
+.SH "DIRECTIVES"
+\fBatlas\-config\-repo\fR(1) exposes its interface through various directives,
+detailed below.
+.sp
+
+.PP
+\fIadd\fR
+.RS 4
+Add a new repo object with a given <repo\-name>, \fBgit\fR(1) remote <URL>, and an
+optional default [ref]. Here, [ref] is a \fBgit\fR(1) ref (e.g. a branch name, a tag, or
+even a commit hash). If no explicit [ref] is provided, \fIadd\fR defaults to 'master'. The ref
+associated with a repo object is used by \fIinstall\fR as the default. See \fIinstall\fR for more
+information.
+.RE
+
+.PP
+\fIadd\-gradle\-exclude\fR
+.RS 4
+Add an excluded <package> to repo <repo\-name>. When the \fIinstall\fR directive
+builds a module, it is using Gradle (with a custom Atlas Shell Tools configuration) to create a
+fat JAR file for that module. Excluded packages are removed from the Atlas Shell Tools Gradle
+configuration using Gradle's 'exclude group:' directive. The 'exclude module:' directive is
+not currently supported.
+.RE
+
+.PP
+\fIadd\-gradle\-skip\fR
+.RS 4
+Add an skipped <task> to repo <repo\-name>. When the \fIinstall\fR directive
+builds a module, it is using Gradle (with a custom Atlas Shell Tools configuration) to create a
+fat JAR file for that module. By default, \fIinstall\fR is running a \fB./gradlew clean build\fR.
+Adding skipped tasks effectively adds \fB\-x <task>\fR arguments to the above command.
+.RE
+
+.PP
+\fIedit\fR
+.RS 4
+Edit the configuration for repo <repo\-name> if it exists. The default repo editor
+is \fBvim\fR, but this can be changed by setting the \fBEDITOR\fR environment variable.
+.RE
+
+.PP
+\fIinstall\fR
+.RS 4
+Install a module from a repo object with name <repo\-name>. This command will clone
+the repo referenced by <repo\-name>'s URL to a temporary location. Next, it will check
+out the ref specified in <repo\-name>'s config or use the override provided by \-\-ref
+if present. It will then initiate a Gradle build, using the repo's \fBbuild.gradle\fR
+file with a custom injected Atlas Shell Tools configuration. Finally, it will install
+and activate the freshly built module. When the install finishes, the cloned repo will
+be removed.
+.RE
+
+.PP
+\fIlist\fR
+.RS 4
+Display all registered repo objects, along with their URLs and default refs. If a [repo\-name]
+is provided, then display the full configuration of the given repo object.
+.RE
+
+.PP
+\fIremove\fR
+.RS 4
+Remove the registration for repo object <repo\-name>, if it exists.
+.RE
+
+.SH "EXAMPLES"
+.sp
+Register a new repo object with name \fBmy\-repo\fR and default branch \fBmaster\fR:
+.sp
+.RS 4
+$ atlas\-config repo add my\-repo https://github.com/me/my\-repo.git
+.RE
+.sp
+Register a new repo object with name \fBmy\-repo\fR and default branch \fBmy\-branch\fR:
+.sp
+.RS 4
+$ atlas\-config repo add my\-repo https://github.com/me/my\-repo.git my\-branch
+.RE
+.sp
+Skip Gradle task 'integrationTest' when installing from \fBmy\-repo\fR:
+.sp
+.RS 4
+$ atlas\-config repo add\-gradle\-skip my\-repo integrationTest
+.RE
+.sp
+Install a new module from repo \fBmy\-repo\fR, but override the default ref with a specific release:
+.sp
+.RS 4
+$ atlas\-config repo install my\-repo \-\-ref=1.3.9
+.RE
+.sp
+
+.SH "SEE ALSO"
+.sp
+\fBatlas\-config\fR(1), \fBatlas\-glossary\fR(7)
 
 .SH "ATLAS SHELL TOOLS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -86,7 +86,7 @@ not currently supported.
 .PP
 \fIadd\-gradle\-skip\fR
 .RS 4
-Add an skipped <task> to repo <repo\-name>. When the \fIinstall\fR directive
+Add a skipped <task> to repo <repo\-name>. When the \fIinstall\fR directive
 builds a module, it is using Gradle (with a custom Atlas Shell Tools configuration) to create a
 fat JAR file for that module. By default, \fIinstall\fR is running a \fB./gradlew clean build\fR.
 Adding skipped tasks effectively adds \fB\-x <task>\fR arguments to the above command.

--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -96,7 +96,8 @@ Adding skipped tasks effectively adds \fB\-x <task>\fR arguments to the above co
 \fIedit\fR
 .RS 4
 Edit the configuration for repo <repo\-name> if it exists. The default repo editor
-is \fBvim\fR, but this can be changed by setting the \fBEDITOR\fR environment variable.
+is \fBvim\fR, but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR
+environment variable.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man1/atlas-config-repo.1
+++ b/atlas-shell-tools/man/man1/atlas-config-repo.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-repo \-- Register and manage Atlas Shell Tools repositories
+atlas\-config\-repo \-\- Register and manage Atlas Shell Tools repositories
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-reset.1
+++ b/atlas-shell-tools/man/man1/atlas-config-reset.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-reset \-- Reset the Atlas Shell Tools installation
+atlas\-config\-reset \-\- Reset the Atlas Shell Tools installation
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-sync.1
+++ b/atlas-shell-tools/man/man1/atlas-config-sync.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-sync \-- Refresh the Atlas Shell Tools installation based on the active module
+atlas\-config\-sync \-\- Refresh the Atlas Shell Tools installation based on the active module
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-uninstall.1
+++ b/atlas-shell-tools/man/man1/atlas-config-uninstall.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-uninstall \-- Uninstall an Atlas Shell Tools module
+atlas\-config\-uninstall \-\- Uninstall an Atlas Shell Tools module
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config-update.1
+++ b/atlas-shell-tools/man/man1/atlas-config-update.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-update \-- Update Atlas Shell Tools core toolset
+atlas\-config\-update \-\- Update Atlas Shell Tools core toolset
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas-config.1
+++ b/atlas-shell-tools/man/man1/atlas-config.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config \-- Configure the Atlas Shell Tools installation
+atlas\-config \-\- Configure the Atlas Shell Tools installation
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas.1
+++ b/atlas-shell-tools/man/man1/atlas.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas \-- Run an Atlas Shell Tools command
+atlas \-\- Run an Atlas Shell Tools command
 
 .SH "SYNOPSIS"
 .sp

--- a/atlas-shell-tools/man/man1/atlas.1
+++ b/atlas-shell-tools/man/man1/atlas.1
@@ -181,7 +181,7 @@ $ atlas \-\-preset p1 \-\-save\-preset p2 MyCommand arg1 \-\-opt2=overrideOpt2Ar
 .sp
 \fBatlas\fR pages the output of the various help messages using a combination of
 \fBless\fR and \fBman\fR. Subcommand help pages are piped through \fBless\fR
-by default, but this can be overridden with the \fBPAGER\fR environment variable.
+by default, but this can be overridden with the \fBATLAS_SHELL_TOOLS_PAGER\fR environment variable.
 The actual \fBatlas\fR manual page (which you are currently reading) is displayed
 using \fBman\fR. To disable paged output for all documentation, try the
 \fB\-\-no\-pager\fR option.

--- a/atlas-shell-tools/man/man5/atlas-plumbing.5
+++ b/atlas-shell-tools/man/man5/atlas-plumbing.5
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-plumbing \-- Details about how Atlas Shell Tools stores program data
+atlas\-plumbing \-\- Details about how Atlas Shell Tools stores program data
 
 .SH "SYNOPSIS"
 $HOME/.local/share/atlas-shell-tools

--- a/atlas-shell-tools/man/man7/atlas-cli.7
+++ b/atlas-shell-tools/man/man7/atlas-cli.7
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-cli \-- Atlas Shell Tools command line interface and conventions
+atlas\-cli \-\- Atlas Shell Tools command line interface and conventions
 
 .SH "SYNOPSIS"
 *

--- a/atlas-shell-tools/man/man7/atlas-cookbook.7
+++ b/atlas-shell-tools/man/man7/atlas-cookbook.7
@@ -1,0 +1,85 @@
+.\"     Title: atlas-cookbook
+.\"    Author: Lucas Cram
+.\"    Source: atlas-shell-tools 0.0.1
+.\"  Language: English
+.\"
+.TH "ATLAS-GLOSSARY" "7" "1 December 2018" "atlas\-shell\-tools 0\&.0\&.1" "Atlas Shell Tools Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+
+.SH "NAME"
+.sp
+atlas\-cookbook \-- Atlas Shell Tools command cookbook
+
+.SH "SYNOPSIS"
+*
+
+.SH "RECIPES"
+
+.sp
+See a list of all commands in the current module:
+.RS 4
+.sp
+$ atlas \-\-list
+.sp
+# You can also use the abbreviated -l flag
+.sp
+$ atlas \-l
+.RE
+
+.sp
+See a list of all installed modules and then change the current module:
+.RS 4
+.sp
+$ atlas\-config list
+.sp
+$ atlas\-config activate <MODULE>
+.RE
+
+.sp
+Add a new repo, check your registered repos, and then install a module from one:
+.sp
+.RS 4
+.sp
+$ atlas\-config repo add my\-new\-repo https://github.com/me/my\-repo.git
+.sp
+$ atlas\-config repo list
+.sp
+$ atlas\-config repo install <REPO>
+.RE
+
+.sp
+Build a fat JAR and then symlink install for local testing:
+.sp
+.RS 4
+.sp
+$ cd /path/to/my/project
+.sp
+$ ./gradlew clean fat -x check
+.sp
+$ atlas\-config install --symlink <path/to/wherever/gradle/puts/jar>
+.sp
+# Now you can make some changes in your code, then simply rebuild to test them!
+.sp
+$ vim src/MySourceFile.java
+.sp
+$ ./gradlew clean fat -x check
+.RE
+
+
+.SH "ATLAS SHELL TOOLS"
+.sp
+Part of the \fBatlas\-shell\-tools\fR(7) suite

--- a/atlas-shell-tools/man/man7/atlas-cookbook.7
+++ b/atlas-shell-tools/man/man7/atlas-cookbook.7
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-cookbook \-- Atlas Shell Tools command cookbook
+atlas\-cookbook \-\- Atlas Shell Tools command cookbook
 
 .SH "SYNOPSIS"
 *

--- a/atlas-shell-tools/man/man7/atlas-glossary.7
+++ b/atlas-shell-tools/man/man7/atlas-glossary.7
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-glossary \-- A glossary of Atlas Shell Tools terms and concepts
+atlas\-glossary \-\- A glossary of Atlas Shell Tools terms and concepts
 
 .SH "SYNOPSIS"
 *

--- a/atlas-shell-tools/man/man7/atlas-presets.7
+++ b/atlas-shell-tools/man/man7/atlas-presets.7
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-presets \-- Atlas Shell Tools preset interface
+atlas\-presets \-\- Atlas Shell Tools preset interface
 
 .SH "SYNOPSIS"
 *

--- a/atlas-shell-tools/man/man7/atlas-presets.7
+++ b/atlas-shell-tools/man/man7/atlas-presets.7
@@ -151,8 +151,8 @@ when you want to make multiple versions of a long preset, each with some minor d
 .RS 4
 Edit preset <name> for \fIcommand\fR. If <name> does not exist, then it will be
 created when the edit is successfully saved. The default preset editor is \fBvim\fR,
-but this can be changed by setting the \fBEDITOR\fR environment variable. The following
-example will edit preset "p1" for command "MyCommand":
+but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environment variable.
+The following example will edit preset "p1" for command "MyCommand":
 .sp
 .RS 4
 $ atlas\-config preset edit MyCommand p1

--- a/atlas-shell-tools/man/man7/atlas-shell-tools.7
+++ b/atlas-shell-tools/man/man7/atlas-shell-tools.7
@@ -111,6 +111,11 @@ Details about how Atlas Shell Tools stores program data
 Atlas Shell Tools command line interface and conventions
 .RE
 
+\fBatlas\-cookbook\fR(7)
+.RS 4
+Atlas Shell Tools command cookbook
+.RE
+
 \fBatlas\-glossary\fR(7)
 .RS 4
 A glossary of Atlas Shell Tools terms and concepts

--- a/atlas-shell-tools/man/man7/atlas-shell-tools.7
+++ b/atlas-shell-tools/man/man7/atlas-shell-tools.7
@@ -58,7 +58,7 @@ Deactivate an installed module
 
 \fBatlas\-config\-install\fR(1)
 .RS 4
-Install a new module
+Install a new Atlas Shell Tools module from a local JAR
 .RE
 
 \fBatlas\-config\-list\fR(1)

--- a/atlas-shell-tools/man/man7/atlas-shell-tools.7
+++ b/atlas-shell-tools/man/man7/atlas-shell-tools.7
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-shell\-tools \-- A command line toolset for Atlas and related projects
+atlas\-shell\-tools \-\- A command line toolset for Atlas and related projects
 
 .SH "SYNOPSIS"
 *

--- a/atlas-shell-tools/man/man7/atlas-shell-tools.7
+++ b/atlas-shell-tools/man/man7/atlas-shell-tools.7
@@ -63,7 +63,7 @@ Install a new Atlas Shell Tools module from a local JAR
 
 \fBatlas\-config\-list\fR(1)
 .RS 4
-List all installed modules and module statuses
+List installed modules and module statuses
 .RE
 
 \fBatlas\-config\-log\fR(1)

--- a/atlas-shell-tools/scripts/atlas
+++ b/atlas-shell-tools/scripts/atlas
@@ -158,7 +158,7 @@ sub atlas_show_contextual_help_menu_and_exit {
     # command array contain only one element.
     open JAVA, "-|", @java_command or die $!;
     my $output = '';
-    while(<JAVA>) {
+    while (<JAVA>) {
         # Not the most efficient way to do things.
         # Perhaps some kind of slurp is needed. File::Slurp could work but does
         # have an outstanding Unicode bug. Need to investigate more.
@@ -257,21 +257,24 @@ my $cfg_preset;
 my $allow_run_as_root;
 Getopt::Long::Configure(qw(no_ignore_case_always));
 GetOptions(
-    "no-pager" => \$skip_paging,
-    "memory|m=s" => \$memory,
-    "help|h:s" => \$help_argument,
-    "version|V" => sub { print "$program_version\n"; exit 0; },
-    "quiet|q" => \$quiet,
-    "list|l" => \$show_list,
-    "class-of=s" => \$class_of,
-    "preset|p=s" => \$use_preset,
-    "save-preset=s" => \$save_preset,
-    "debug" => \$debug_flag,
+    "no-pager"          => \$skip_paging,
+    "memory|m=s"        => \$memory,
+    "help|h:s"          => \$help_argument,
+    "version|V"         => sub {
+        print "$program_version\n";
+        exit 0;
+    },
+    "quiet|q"           => \$quiet,
+    "list|l"            => \$show_list,
+    "class-of=s"        => \$class_of,
+    "preset|p=s"        => \$use_preset,
+    "save-preset=s"     => \$save_preset,
+    "debug"             => \$debug_flag,
     "allow-run-as-root" => \$allow_run_as_root,
     # This callback occurs the first time we see a non-option argument.
     # In our case, this will be the subcommand.
-    "<>" => sub {
-        my($arg) = @_;
+    "<>"                => sub {
+        my ($arg) = @_;
         if ($arg =~ m{^-}) {
             unless ($arg eq '-') {
                 die "FATAL error: unhandled global option $arg";
@@ -308,7 +311,7 @@ if (defined $help_argument) {
         my @command = ();
         push @command, @man_command;
         push @command, "$program_name";
-        system { $command[0] } @command;
+        system {$command[0]} @command;
         my $exitcode = $? >> 8;
         if ($exitcode != 0) {
             exit 1;
@@ -489,7 +492,7 @@ if ($debug_flag) {
 # Here we use system's indirect object syntax to correctly handle all possible
 # edge cases regarding the configuration of @java_command.
 # See bottom of page: http://perldoc.perl.org/functions/exec.html
-system { $java_command[0] } @java_command;
+system {$java_command[0]} @java_command;
 my $exitcode = $? >> 8;
 exit $exitcode;
 

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -249,7 +249,7 @@ sub execute_command_install {
     my $force_install = 0;
     my $skip_install = 0;
     my $install_deactivated = 0;
-    my $alternate_name;
+    my $alternate_name = "";
     my $help_flag;
     my $repo;
     GetOptions(
@@ -281,111 +281,11 @@ sub execute_command_install {
         ast_utilities::getopt_failure_and_exit($program_name, "install");
     }
 
-    unless (-f $module_to_install || -l $module_to_install) {
-        ast_utilities::error_output($program_name . ": install", "no such file ${bold_stderr}${module_to_install}${reset_stderr}");
+    my $success = ast_module_subsystem::perform_install($module_to_install, $ast_path, $program_name,
+                                                        $alternate_name, $syminstall, $skip_install,
+                                                        $force_install, $install_deactivated, $quiet);
+    unless ($success) {
         return 0;
-    }
-
-    my $modules_folder = File::Spec->catfile($ast_path, $ast_module_subsystem::MODULES_FOLDER);
-
-    # Create the module name, respecting the --name flag if present.
-    my $module_basename;
-    if (defined $alternate_name) {
-        $module_basename = $alternate_name . $ast_module_subsystem::MODULE_SUFFIX;
-    }
-    else {
-        $module_basename = basename($module_to_install);
-    }
-    # TODO: figure out how to interpolate $MODULE_SUFFIX into this regex
-    unless ($module_basename =~ /.*\.jar$/) {
-        ast_utilities::error_output($program_name . ": install", "module must end with '.jar' extension");
-        return 0;
-    }
-    $module_basename =~ s{$ast_module_subsystem::MODULE_SUFFIX}{};
-
-    # Handle the case where the module is already installed
-    my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
-    if (defined $modules{$module_basename}) {
-        ast_utilities::warn_output($program_name . ": install", "module ${bold_stderr}${module_basename}${reset_stderr} is already installed");
-        if ($skip_install) {
-            print STDERR "Skipping installation.\n";
-            return 0;
-        }
-        unless ($force_install) {
-            my $overwrite = ast_utilities::prompt_yn("Overwrite?");
-            unless ($overwrite) {
-                print STDERR "Skipping installation.\n";
-                return 0;
-            }
-        }
-        ast_utilities::warn_output($program_name . ": install", "overwriting ${bold_stderr}${module_basename}${reset_stderr}");
-    }
-
-    # Construct the new module paths.
-    # We create a path for both an activated and deactivated version.
-    my $module_new_path =
-        File::Spec->catfile($modules_folder, $module_basename . $ast_module_subsystem::MODULE_SUFFIX);
-    my $module_new_path_deactivated =
-        File::Spec->catfile($modules_folder, $module_basename . $ast_module_subsystem::DEACTIVATED_MODULE_SUFFIX);
-
-    # If we made it here we are go to overwrite, so clean up any matching existing modules.
-    unlink $module_new_path;
-    unlink $module_new_path_deactivated;
-
-    my $exitcode;
-    if ($syminstall) {
-        my $module_to_install_abs = Cwd::realpath($module_to_install);
-        my $module_to_install_rel = File::Spec->abs2rel($module_to_install_abs, $modules_folder);
-
-        if ($install_deactivated) {
-            symlink($module_to_install_rel, $module_new_path_deactivated);
-        }
-        else {
-            symlink($module_to_install_rel, $module_new_path);
-        }
-        $exitcode = $? >> 8;
-    }
-    else {
-        my @command = ();
-        push @command, "cp";
-        push @command, "$module_to_install";
-        if ($install_deactivated) {
-            push @command, "$module_new_path_deactivated";
-            system { $command[0] } @command;
-        }
-        else {
-            push @command, "$module_new_path";
-            system { $command[0] } @command;
-        }
-        $exitcode = $? >> 8;
-    }
-
-    if ($exitcode) {
-        print STDERR "${red_stderr}${bold_stderr}Installation failed.${reset_stderr} Operation exited with $exitcode.\n";
-        return 0;
-    }
-    else {
-        unless ($install_deactivated) {
-            my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
-            foreach my $module (keys %modules) {
-                if ($modules{$module} == $ast_module_subsystem::ACTIVATED
-                    && $module ne $module_basename) {
-                    ast_module_subsystem::perform_deactivate($module, $ast_path, $program_name, $quiet);
-                }
-            }
-        }
-
-        unless($install_deactivated) {
-            ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
-            my $success = ast_module_subsystem::generate_active_module_index($ast_path, $program_name, $quiet, 0);
-            unless ($success) {
-                ast_utilities::warn_output($program_name . ": install", "partial installation may not function properly");
-            }
-        }
-
-        unless ($quiet) {
-            print "Module ${green_stdout}${bold_stdout}${module_basename}${reset_stdout} installed.\n";
-        }
     }
 
     return 1;

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -251,28 +251,17 @@ sub execute_command_install {
     my $install_deactivated = 0;
     my $alternate_name = "";
     my $help_flag;
-    my $repo;
     GetOptions(
         'symlink|s' => \$syminstall,
         'deactivated' => \$install_deactivated,
         'force' => \$force_install,
         'skip' => \$skip_install,
         'name=s' => \$alternate_name,
-        'repo=s' => \$repo,
         'help|h' => \$help_flag
     ) or ast_utilities::getopt_failure_and_exit($program_name, "install");
 
     if (defined $help_flag) {
         show_submanpage_and_exit('install');
-    }
-
-    if (defined $repo) {
-        my $success = ast_repo_subsystem::install_repo($ast_path, $program_name, $quiet, $repo, '');
-        unless ($success) {
-            ast_utilities::error_output($program_name . ": install", "could not install repo ${bold_stderr}${repo}${reset_stderr}");
-            return 0;
-        }
-        return 1;
     }
 
     my $module_to_install = shift @ARGV;
@@ -281,9 +270,18 @@ sub execute_command_install {
         ast_utilities::getopt_failure_and_exit($program_name, "install");
     }
 
+    my %metadata;
+    if ($syminstall) {
+        $metadata{$ast_module_subsystem::SOURCE_KEY} = "symlink";
+    }
+    else {
+        $metadata{$ast_module_subsystem::SOURCE_KEY} = "local_file";
+    }
+    my $uri_abs = Cwd::realpath($module_to_install);
+    $metadata{$ast_module_subsystem::URI_KEY} = "file://" . $uri_abs;
     my $success = ast_module_subsystem::perform_install($module_to_install, $ast_path, $program_name,
                                                         $alternate_name, $syminstall, $skip_install,
-                                                        $force_install, $install_deactivated, $quiet);
+                                                        $force_install, $install_deactivated, \%metadata, $quiet);
     unless ($success) {
         return 0;
     }

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -279,6 +279,7 @@ sub execute_command_install {
     }
     my $uri_abs = Cwd::realpath($module_to_install);
     $metadata{$ast_module_subsystem::URI_KEY} = "file://" . $uri_abs;
+    $metadata{$ast_module_subsystem::DATE_TIME_KEY} = POSIX::strftime("%Y-%m-%d %H:%M:%S", localtime time);
     my $success = ast_module_subsystem::perform_install($module_to_install, $ast_path, $program_name,
                                                         $alternate_name, $syminstall, $skip_install,
                                                         $force_install, $install_deactivated, \%metadata, $quiet);

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -68,14 +68,14 @@ my $program_version = "$ast_utilities::ATLAS_SHELL_TOOLS_VERSION ($program_name 
 
 # logging definitions
 my %valid_levels = (
-    "ALL" => 1,
+    "ALL"   => 1,
     "TRACE" => 1,
     "DEBUG" => 1,
-    "INFO" => 1,
-    "WARN" => 1,
+    "INFO"  => 1,
+    "WARN"  => 1,
     "ERROR" => 1,
     "FATAL" => 1,
-    "OFF" => 1
+    "OFF"   => 1
 );
 my @valid_level_keys = keys %valid_levels;
 
@@ -108,7 +108,7 @@ sub show_submanpage_and_exit {
     else {
         push @command, "$program_name-$subpage";
     }
-    system { $command[0] } @command;
+    system {$command[0]} @command;
     exit 0;
 }
 
@@ -252,12 +252,12 @@ sub execute_command_install {
     my $alternate_name = "";
     my $help_flag;
     GetOptions(
-        'symlink|s' => \$syminstall,
+        'symlink|s'   => \$syminstall,
         'deactivated' => \$install_deactivated,
-        'force' => \$force_install,
-        'skip' => \$skip_install,
-        'name=s' => \$alternate_name,
-        'help|h' => \$help_flag
+        'force'       => \$force_install,
+        'skip'        => \$skip_install,
+        'name=s'      => \$alternate_name,
+        'help|h'      => \$help_flag
     ) or ast_utilities::getopt_failure_and_exit($program_name, "install");
 
     if (defined $help_flag) {
@@ -279,10 +279,11 @@ sub execute_command_install {
     }
     my $uri_abs = Cwd::realpath($module_to_install);
     $metadata{$ast_module_subsystem::URI_KEY} = "file://" . $uri_abs;
-    $metadata{$ast_module_subsystem::DATE_TIME_KEY} = POSIX::strftime("%Y-%m-%d %H:%M:%S", localtime time);
+    $metadata{$ast_module_subsystem::DATE_TIME_KEY} = POSIX::strftime("%Y-%m-%d %H:%M:%S UTC", gmtime(time));
     my $success = ast_module_subsystem::perform_install($module_to_install, $ast_path, $program_name,
-                                                        $alternate_name, $syminstall, $skip_install,
-                                                        $force_install, $install_deactivated, \%metadata, $quiet);
+        $alternate_name, $syminstall, $skip_install,
+        $force_install, $install_deactivated, \%metadata, $quiet);
+
     unless ($success) {
         return 0;
     }
@@ -291,18 +292,25 @@ sub execute_command_install {
 }
 
 sub execute_command_list {
+    my $current = 0;
     my $help_flag;
+    my $verbose = 0;
     GetOptions(
-        'help|h' => \$help_flag
+        'current|c' => \$current,
+        'help|h'    => \$help_flag,
+        'verbose|v' => \$verbose
     ) or ast_utilities::getopt_failure_and_exit($program_name, "list");
 
     if (defined $help_flag) {
         show_submanpage_and_exit('list');
     }
 
+    my $modules_folder = File::Spec->catfile($ast_path, $ast_module_subsystem::MODULES_FOLDER);
+
     my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
     my %symlinks = ast_module_subsystem::get_module_to_symlink_hash($ast_path);
     my %targets = ast_module_subsystem::get_module_to_target_hash($ast_path);
+    my %metadata = ast_module_subsystem::get_module_to_metadata_hash($ast_path);
 
     unless (keys %modules) {
         ast_utilities::error_output($program_name . ": list", "found no installed modules");
@@ -310,14 +318,30 @@ sub execute_command_list {
         return 0;
     }
 
-    print "${bold_stdout}Installed modules:${reset_stdout}\n\n";
+    if ($current) {
+        print "${bold_stdout}Currently active module:${reset_stdout}\n\n";
+    }
+    else {
+        print "${bold_stdout}Installed modules:${reset_stdout}\n\n";
+    }
     # Sort the module names alphabetically. We use 'lc' to convert them to
     # lowercase, since by default 'sort' uses ASCII ordering.
     foreach my $module (sort {lc $a cmp lc $b} keys %modules) {
         my $status = $modules{$module};
         my $symlink = $symlinks{$module};
         my $target = $targets{$module};
+        my %module_metadata;
+        if (defined $metadata{$module}) {
+            %module_metadata = %{$metadata{$module}};
+        }
+        else {
+            %module_metadata = ();
+        }
         my $display = '    ';
+
+        if ($current && $status != 1) {
+            next;
+        }
 
         # if activated, place a star next to the name
         if ($status == 1) {
@@ -337,7 +361,7 @@ sub execute_command_list {
         }
 
         # show the module name!
-        $display = $display . " ${module}${reset_stdout}";
+        $display = $display . " ${bold_stdout}${module}${reset_stdout}";
 
         # show a big message if the symlink is broken, blink if also activated
         if ($symlink == $ast_module_subsystem::BROKEN_SYMLINK) {
@@ -355,8 +379,19 @@ sub execute_command_list {
         }
 
         print "$display\n";
+
+        if ($verbose) {
+            if (%module_metadata) {
+                foreach my $metadata_key (sort {lc $a cmp lc $b} keys %module_metadata) {
+                    print "          ${metadata_key}: $module_metadata{$metadata_key}\n";
+                }
+            }
+            print "\n";
+        }
     }
-    print "\n";
+    unless ($verbose) {
+        print "\n";
+    }
 
     return 1;
 }
@@ -446,8 +481,8 @@ sub execute_command_preset {
         'help|h' => \$help_flag,
         # This callback occurs the first time we see a non-option argument.
         # In our case, this will be the subcommand.
-        "<>" => sub {
-            my($arg) = @_;
+        "<>"     => sub {
+            my ($arg) = @_;
             if ($arg =~ m{^-}) {
                 unless ($arg eq '-') {
                     die "FATAL error: unhandled global option $arg";
@@ -618,7 +653,7 @@ sub execute_command_repo {
     my $ref_flag = '';
     GetOptions(
         'help|h' => \$help_flag,
-        'ref=s' => \$ref_flag
+        'ref=s'  => \$ref_flag
     ) or ast_utilities::getopt_failure_and_exit($program_name, "repo");
 
     if (defined $help_flag) {
@@ -866,8 +901,8 @@ sub execute_command_uninstall {
     my $forceflag = 0;
     my $help_flag;
     GetOptions(
-        'all|a' => \$allflag,
-        'force' => \$forceflag,
+        'all|a'  => \$allflag,
+        'force'  => \$forceflag,
         'help|h' => \$help_flag
     ) or ast_utilities::getopt_failure_and_exit($program_name, "uninstall");
 
@@ -954,15 +989,18 @@ my $help_argument;
 my $allow_run_as_root;
 Getopt::Long::Configure(qw(no_ignore_case_always));
 GetOptions(
-    "no-pager" => \$skip_paging,
-    "help|h:s" => \$help_argument,
-    "version|V" => sub { print "$program_version\n"; exit 0; },
-    "quiet|q" => \$quiet,
+    "no-pager"          => \$skip_paging,
+    "help|h:s"          => \$help_argument,
+    "version|V"         => sub {
+        print "$program_version\n";
+        exit 0;
+    },
+    "quiet|q"           => \$quiet,
     "allow-run-as-root" => \$allow_run_as_root,
     # This callback occurs the first time we see a non-option argument.
     # In our case, this will be the subcommand.
-    "<>" => sub {
-        my($arg) = @_;
+    "<>"                => sub {
+        my ($arg) = @_;
         if ($arg =~ m{^-}) {
             unless ($arg eq '-') {
                 die "FATAL error: unhandled global option $arg";

--- a/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
     remove_active_module_index
 );
 
+our $METADATA_SUFFIX = '.metadata';
 our $MODULE_SUFFIX = '.jar';
 our $DEACTIVATED_SUFFIX = '.deactivated';
 our $DEACTIVATED_MODULE_SUFFIX = $MODULE_SUFFIX . $DEACTIVATED_SUFFIX;

--- a/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
@@ -101,7 +101,7 @@ sub get_subcommand_to_class_hash {
     my $ast_path = shift;
 
     my $index_path = File::Spec->catfile($ast_path, $ACTIVE_INDEX_PATH);
-    open my $index_fileIN, '<', $index_path or return ();
+    open my $index_fileIN, '<', $index_path or return();
     my %subcommand_to_class = ();
 
     while (<$index_fileIN>) {
@@ -123,7 +123,7 @@ sub get_subcommand_to_description_hash {
     my $ast_path = shift;
 
     my $index_path = File::Spec->catfile($ast_path, $ACTIVE_INDEX_PATH);
-    open my $index_fileIN, '<', $index_path or return ();
+    open my $index_fileIN, '<', $index_path or return();
     my %subcommand_to_description = ();
 
     while (<$index_fileIN>) {
@@ -145,7 +145,7 @@ sub get_subcommand_to_description_hash {
 sub get_module_to_status_hash {
     my $ast_path = shift;
 
-    my @find_command=(
+    my @find_command = (
         "find", "${ast_path}/${MODULES_FOLDER}",
         "-maxdepth", "1",
         "(", "-name", "*$MODULE_SUFFIX", "-o", "-name", "*$DEACTIVATED_SUFFIX", ")",
@@ -191,7 +191,7 @@ sub get_module_to_status_hash {
 sub get_module_to_symlink_hash {
     my $ast_path = shift;
 
-    my @find_command=(
+    my @find_command = (
         "find", "${ast_path}/${MODULES_FOLDER}",
         "-maxdepth", "1",
         "(", "-name", "*$MODULE_SUFFIX", "-o", "-name", "*$DEACTIVATED_SUFFIX", ")",
@@ -238,7 +238,7 @@ sub get_module_to_symlink_hash {
 sub get_module_to_target_hash {
     my $ast_path = shift;
 
-    my @find_command=(
+    my @find_command = (
         "find", "${ast_path}/${MODULES_FOLDER}",
         "-maxdepth", "1",
         "(", "-name", "*$MODULE_SUFFIX", "-o", "-name", "*$DEACTIVATED_SUFFIX", ")",
@@ -279,7 +279,7 @@ sub get_module_to_target_hash {
 sub get_module_to_metadata_hash {
     my $ast_path = shift;
 
-    my @find_command=(
+    my @find_command = (
         "find", "${ast_path}/${MODULES_FOLDER}",
         "-maxdepth", "1",
         "-name", "*$METADATA_SUFFIX",
@@ -466,11 +466,11 @@ sub perform_install {
         push @command, "$module_to_install";
         if ($install_deactivated) {
             push @command, "$module_new_path_deactivated";
-            system { $command[0] } @command;
+            system {$command[0]} @command;
         }
         else {
             push @command, "$module_new_path";
-            system { $command[0] } @command;
+            system {$command[0]} @command;
         }
         $exitcode = $? >> 8;
     }
@@ -507,66 +507,6 @@ sub perform_install {
             print "Module ${green_stdout}${bold_stdout}${module_basename}${reset_stdout} installed.\n";
         }
     }
-
-    return 1;
-}
-
-# Write a metadata hash for a module.
-# Params:
-#   $modules_folder: the path to the module folder
-#   $module_basename: the module basename
-#   $metadata_ref: a reference to the metadata hash
-#   $program_name: the name of the calling program
-# Return: 1 on success, 0 on failure
-sub write_module_metadata {
-    my $modules_folder = shift;
-    my $module_basename = shift;
-    my $metadata_ref = shift;
-    my $program_name = shift;
-
-    my %metadata = %{$metadata_ref};
-
-    my $module_new_path_metadata =
-        File::Spec->catfile($modules_folder, $module_basename . $METADATA_SUFFIX);
-
-    open my $metadata_handle, '>', "$module_new_path_metadata";
-    if (defined $metadata{$SOURCE_KEY}) {
-        print $metadata_handle $SOURCE_KEY . $METADATA_SEPARATOR . $metadata{$SOURCE_KEY} . "\n";
-    }
-    else {
-        ast_utilities::warn_output($program_name, "bad metadata: missing SOURCE_KEY");
-        close $metadata_handle;
-        unlink $module_new_path_metadata;
-        return 0;
-    }
-    if (defined $metadata{$URI_KEY}) {
-        print $metadata_handle $URI_KEY . $METADATA_SEPARATOR . $metadata{$URI_KEY} . "\n";
-    }
-    else {
-        ast_utilities::warn_output($program_name, "bad metadata: missing URI_KEY");
-        close $metadata_handle;
-        unlink $module_new_path_metadata;
-        return 0;
-    }
-    if (defined $metadata{$DATE_TIME_KEY}) {
-        print $metadata_handle $DATE_TIME_KEY . $METADATA_SEPARATOR . $metadata{$DATE_TIME_KEY} . "\n";
-    }
-    else {
-        ast_utilities::warn_output($program_name, "bad metadata: missing DATE_TIME_KEY");
-        close $metadata_handle;
-        unlink $module_new_path_metadata;
-        return 0;
-    }
-    if (defined $metadata{$REPO_NAME_KEY}) {
-        print $metadata_handle $REPO_NAME_KEY . $METADATA_SEPARATOR . $metadata{$REPO_NAME_KEY} . "\n";
-    }
-    if (defined $metadata{$REPO_REF_KEY}) {
-        print $metadata_handle $REPO_REF_KEY . $METADATA_SEPARATOR . $metadata{$REPO_REF_KEY} . "\n";
-    }
-    if (defined $metadata{$REPO_COMMIT_KEY}) {
-        print $metadata_handle $REPO_COMMIT_KEY . $METADATA_SEPARATOR . $metadata{$REPO_COMMIT_KEY} . "\n";
-    }
-    close $metadata_handle;
 
     return 1;
 }
@@ -759,7 +699,7 @@ sub generate_active_module_index {
         print "Generating new index...\n";
     }
 
-    system { $java_command[0] } @java_command;
+    system {$java_command[0]} @java_command;
     my $exitcode = $? >> 8;
     unless ($exitcode == 0) {
         ast_utilities::error_output($program_name, 'could not generate index');
@@ -790,6 +730,66 @@ sub remove_active_module_index {
     unless ($quiet) {
         print "Cleared index.\n";
     }
+}
+
+# Write a metadata hash for a module.
+# Params:
+#   $modules_folder: the path to the module folder
+#   $module_basename: the module basename
+#   $metadata_ref: a reference to the metadata hash
+#   $program_name: the name of the calling program
+# Return: 1 on success, 0 on failure
+sub write_module_metadata {
+    my $modules_folder = shift;
+    my $module_basename = shift;
+    my $metadata_ref = shift;
+    my $program_name = shift;
+
+    my %metadata = %{$metadata_ref};
+
+    my $module_new_path_metadata =
+        File::Spec->catfile($modules_folder, $module_basename . $METADATA_SUFFIX);
+
+    open my $metadata_handle, '>', "$module_new_path_metadata";
+    if (defined $metadata{$SOURCE_KEY}) {
+        print $metadata_handle $SOURCE_KEY . $METADATA_SEPARATOR . $metadata{$SOURCE_KEY} . "\n";
+    }
+    else {
+        ast_utilities::warn_output($program_name, "bad metadata: missing SOURCE_KEY");
+        close $metadata_handle;
+        unlink $module_new_path_metadata;
+        return 0;
+    }
+    if (defined $metadata{$URI_KEY}) {
+        print $metadata_handle $URI_KEY . $METADATA_SEPARATOR . $metadata{$URI_KEY} . "\n";
+    }
+    else {
+        ast_utilities::warn_output($program_name, "bad metadata: missing URI_KEY");
+        close $metadata_handle;
+        unlink $module_new_path_metadata;
+        return 0;
+    }
+    if (defined $metadata{$DATE_TIME_KEY}) {
+        print $metadata_handle $DATE_TIME_KEY . $METADATA_SEPARATOR . $metadata{$DATE_TIME_KEY} . "\n";
+    }
+    else {
+        ast_utilities::warn_output($program_name, "bad metadata: missing DATE_TIME_KEY");
+        close $metadata_handle;
+        unlink $module_new_path_metadata;
+        return 0;
+    }
+    if (defined $metadata{$REPO_NAME_KEY}) {
+        print $metadata_handle $REPO_NAME_KEY . $METADATA_SEPARATOR . $metadata{$REPO_NAME_KEY} . "\n";
+    }
+    if (defined $metadata{$REPO_REF_KEY}) {
+        print $metadata_handle $REPO_REF_KEY . $METADATA_SEPARATOR . $metadata{$REPO_REF_KEY} . "\n";
+    }
+    if (defined $metadata{$REPO_COMMIT_KEY}) {
+        print $metadata_handle $REPO_COMMIT_KEY . $METADATA_SEPARATOR . $metadata{$REPO_COMMIT_KEY} . "\n";
+    }
+    close $metadata_handle;
+
+    return 1;
 }
 
 # Perl modules must return a value. Returning a value perl considers "truthy"

--- a/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_module_subsystem.pm
@@ -24,10 +24,11 @@ our @EXPORT = qw(
     BROKEN_SYMLINK
     REAL_FILE
     SOURCE_KEY
+    URI_KEY
+    DATE_TIME_KEY
     REPO_NAME_KEY
     REPO_REF_KEY
     REPO_COMMIT_KEY
-    URI_KEY
     METADATA_SEPARATOR
     get_subcommand_to_class_hash
     get_subcommand_to_description_hash
@@ -59,12 +60,13 @@ our $GOOD_SYMLINK = 1;
 our $BROKEN_SYMLINK = -1;
 our $REAL_FILE = 0;
 
-# Module metadata keys
-our $SOURCE_KEY = "source";
-our $REPO_NAME_KEY = "repo_name";
-our $REPO_REF_KEY = "repo_ref";
-our $REPO_COMMIT_KEY = "repo_commit";
+# Module metadata keys/data
+our $SOURCE_KEY = "source-type";
 our $URI_KEY = "URI";
+our $DATE_TIME_KEY = "date-time";
+our $REPO_NAME_KEY = "repo-name";
+our $REPO_REF_KEY = "repo-ref";
+our $REPO_COMMIT_KEY = "repo-commit";
 our $METADATA_SEPARATOR = ":";
 
 # Use ASCII record separator as delimiter.
@@ -546,8 +548,20 @@ sub write_module_metadata {
         unlink $module_new_path_metadata;
         return 0;
     }
+    if (defined $metadata{$DATE_TIME_KEY}) {
+        print $metadata_handle $DATE_TIME_KEY . $METADATA_SEPARATOR . $metadata{$DATE_TIME_KEY} . "\n";
+    }
+    else {
+        ast_utilities::warn_output($program_name, "bad metadata: missing DATE_TIME_KEY");
+        close $metadata_handle;
+        unlink $module_new_path_metadata;
+        return 0;
+    }
     if (defined $metadata{$REPO_NAME_KEY}) {
         print $metadata_handle $REPO_NAME_KEY . $METADATA_SEPARATOR . $metadata{$REPO_NAME_KEY} . "\n";
+    }
+    if (defined $metadata{$REPO_REF_KEY}) {
+        print $metadata_handle $REPO_REF_KEY . $METADATA_SEPARATOR . $metadata{$REPO_REF_KEY} . "\n";
     }
     if (defined $metadata{$REPO_COMMIT_KEY}) {
         print $metadata_handle $REPO_COMMIT_KEY . $METADATA_SEPARATOR . $metadata{$REPO_COMMIT_KEY} . "\n";

--- a/atlas-shell-tools/scripts/common/ast_preset_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_preset_subsystem.pm
@@ -128,7 +128,7 @@ sub save_preset {
     my $preset_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $command);
     make_path("$preset_subfolder", {
         verbose => 0,
-        mode => 0755
+        mode    => 0755
     });
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
@@ -399,7 +399,7 @@ sub edit_preset {
     my $preset_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $command);
     make_path("$preset_subfolder", {
         verbose => 0,
-        mode => 0755
+        mode    => 0755
     });
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
@@ -439,7 +439,7 @@ sub edit_preset {
     my @editor = ast_utilities::get_editor();
 
     push @editor, "$tmpfile";
-    system { $editor[0] } @editor;
+    system {$editor[0]} @editor;
 
     open $handle, '<', "$tmpfile";
     open $stage_handle, '>', "$preset_stage_file";
@@ -494,7 +494,7 @@ sub edit_preset {
     push @command, "cp";
     push @command, "$preset_stage_file";
     push @command, "$preset_file";
-    system { $command[0] } @command;
+    system {$command[0]} @command;
     close $tmpdir;
     show_preset($ast_path, $program_name, $quiet, $preset, $command, $namespace);
 
@@ -538,7 +538,7 @@ sub copy_preset {
     push @command, "cp";
     push @command, "$source_file";
     push @command, "$dest_file";
-    system { $command[0] } @command;
+    system {$command[0]} @command;
 
     unless ($quiet) {
         print "Copied contents of preset ${bold_stdout}${src_preset}${reset_stdout} into new preset ${bold_stdout}${dest_preset}${reset_stdout}.\n";
@@ -612,7 +612,7 @@ sub read_preset {
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
     unless (-f $preset_file) {
-        return ();
+        return();
     }
 
     my @options = ();
@@ -650,7 +650,7 @@ sub get_namespaces_array {
     my @filtered_namespaces = ();
     for my $found_namespace (@namespaces) {
         unless ($found_namespace eq '.' || $found_namespace eq '..'
-                || $found_namespace eq $CURRENT_NAMESPACE_FILE) {
+            || $found_namespace eq $CURRENT_NAMESPACE_FILE) {
             push @filtered_namespaces, $found_namespace;
         }
     }
@@ -719,7 +719,7 @@ sub create_namespace {
 
     make_path("$new_namespace_folder", {
         verbose => 0,
-        mode => 0755
+        mode    => 0755
     });
 
     unless ($quiet) {

--- a/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
@@ -91,7 +91,7 @@ sub create_repo {
 
     make_path("$repo_subfolder", {
         verbose => 0,
-        mode => 0755
+        mode    => 0755
     });
 
     my $repo_config_file = File::Spec->catfile($repo_subfolder, $REPO_CONFIG);
@@ -161,7 +161,7 @@ sub edit_repo {
     # open the staging file in the user's editor
     my @editor = ast_utilities::get_editor();
     push @editor, "$staging_file";
-    system { $editor[0] } @editor;
+    system {$editor[0]} @editor;
 
     # confirm that the staging file is not malformed, i.e. it must have a valid URL and ref
     $url = read_single_config_variable_from_arbitrary_file($staging_file, 'url');
@@ -424,7 +424,7 @@ sub install_repo {
         return 0;
     }
 
-    my @find_command=(
+    my @find_command = (
         "find", ".",
         "-type", "f",
         "-name", "*-AST.jar",
@@ -448,10 +448,10 @@ sub install_repo {
         $local_metadata{$ast_module_subsystem::REPO_NAME_KEY} = "${repo}";
         $local_metadata{$ast_module_subsystem::REPO_REF_KEY} = "${ref_to_use}";
         $local_metadata{$ast_module_subsystem::REPO_COMMIT_KEY} = "${installed_commit_hash}";
-        $local_metadata{$ast_module_subsystem::DATE_TIME_KEY} = strftime("%Y-%m-%d %H:%M:%S", localtime time);
+        $local_metadata{$ast_module_subsystem::DATE_TIME_KEY} = strftime("%Y-%m-%d %H:%M:%S UTC", gmtime(time));
         # install the module!
         my $success = ast_module_subsystem::perform_install($module, $ast_path, $program_name,
-                                              "${repo}-${installed_commit_hash_short}", 0, 0, 1, 0, \%local_metadata, 0);
+            "${repo}-${installed_commit_hash_short}", 0, 0, 1, 0, \%local_metadata, 0);
 
         unless ($success) {
             ast_utilities::error_output($program_name, "repo install operation failed");
@@ -545,13 +545,13 @@ sub get_repo_settings {
     my $repo_subfolder = File::Spec->catfile($ast_path, $REPOS_FOLDER, $repo);
     unless (-d $repo_subfolder) {
         ast_utilities::error_output($program_name, "repo ${bold_stderr}${repo}${reset_stderr} does not exist");
-        return ();
+        return();
     }
 
     my $repo_config_file = File::Spec->catfile($repo_subfolder, $REPO_CONFIG);
     unless (-f $repo_config_file) {
         ast_utilities::error_output($program_name, "could not find config file for repo ${bold_stderr}${repo}${reset_stderr}");
-        return ();
+        return();
     }
 
     my @settings = ();

--- a/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
@@ -313,8 +313,9 @@ sub install_repo {
             my $module_commit_hash = $metadata{$ast_module_subsystem::REPO_COMMIT_KEY};
             if (defined $module_commit_hash && $module_commit_hash eq $remote_commit_hash) {
                 ast_utilities::warn_output($program_name, "nothing to do");
-                print STDERR "Repo ${bold_stderr}${repo}${reset_stderr} ref ${bold_stderr}${ref_to_use}${reset_stderr} refers to commit ${bold_stderr}${remote_commit_hash}${reset_stderr}\n";
-                print STDERR "Installed module ${bold_stderr}${module_key}${reset_stderr} was already built from this commit.\n";
+                print STDERR "Ref ${bold_stderr}${ref_to_use}${reset_stderr} in repo ${bold_stderr}${repo}${reset_stderr} refers to commit ${bold_stderr}${remote_commit_hash}${reset_stderr}.\n";
+                print STDERR "Installed module ${bold_stderr}${module_key}${reset_stderr} was built from this commit.\n";
+                print STDERR "Try \'${bold_stderr}${ast_utilities::CONFIG_PROGRAM} activate ${module_key}${reset_stderr}\' to use this version.\n";
                 return 1;
             }
         }
@@ -354,8 +355,9 @@ sub install_repo {
         if ($tentative_module_name eq $module_name) {
             print STDERR "\n";
             ast_utilities::warn_output($program_name, "nothing to do");
-            print STDERR "Repo ${bold_stderr}${repo}${reset_stderr} ref ${bold_stderr}${ref_to_use}${reset_stderr} refers to commit ${bold_stderr}${installed_commit_hash}${reset_stderr}\n";
-            print STDERR "Installed module ${bold_stderr}${module_name}${reset_stderr} already was built from this commit.\n";
+            print STDERR "Ref ${bold_stderr}${ref_to_use}${reset_stderr} in repo ${bold_stderr}${repo}${reset_stderr} refers to commit ${bold_stderr}${installed_commit_hash}${reset_stderr}.\n";
+            print STDERR "Installed module ${bold_stderr}${module_name}${reset_stderr} was built from this commit.\n";
+            print STDERR "Try \'${bold_stderr}${ast_utilities::CONFIG_PROGRAM} activate ${module_name}${reset_stderr}\' to use this version.\n";
             return 1;
         }
     }

--- a/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
@@ -279,10 +279,32 @@ sub install_repo {
         ast_utilities::error_output($program_name, "repo install operation failed");
         return 0;
     }
+    my $ref_to_use;
+    if ($ref_override eq '') {
+        $ref_to_use = $ref;
+    }
+    else {
+        $ref_to_use = $ref_override;
+    }
 
     my $tmpdir = tempdir(CLEANUP => 1);
 
     my @command = ();
+    push @command, "git";
+    push @command, "ls-remote";
+    push @command, "${url}";
+    push @command, "${ref_to_use}";
+    my $lsremote_result = ast_utilities::read_command_output(\@command);
+    my @remote_ref = split /\s+/, $lsremote_result;
+    my $commit_hash;
+    if (scalar @remote_ref > 0) {
+        $commit_hash = $remote_ref[0];
+    }
+    # TODO debug remove this
+    print "TODO DEBUG hash: $commit_hash\n";
+    return 0;
+
+    @command = ();
     push @command, "git";
     push @command, "clone";
     push @command, "${url}";
@@ -295,13 +317,6 @@ sub install_repo {
 
     chdir $tmpdir or die "$!";
 
-    my $ref_to_use;
-    if ($ref_override eq '') {
-        $ref_to_use = $ref;
-    }
-    else {
-        $ref_to_use = $ref_override;
-    }
     @command = ();
     push @command, "git";
     push @command, "checkout";

--- a/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_repo_subsystem.pm
@@ -7,6 +7,7 @@ use Exporter qw(import);
 use File::Basename qw(basename);
 use File::Path qw(make_path rmtree);
 use File::Temp qw(tempdir tempfile);
+use POSIX qw(strftime);
 use ast_tty;
 use ast_module_subsystem;
 use ast_utilities;
@@ -445,7 +446,9 @@ sub install_repo {
         $local_metadata{$ast_module_subsystem::SOURCE_KEY} = "repo";
         $local_metadata{$ast_module_subsystem::URI_KEY} = "${url}";
         $local_metadata{$ast_module_subsystem::REPO_NAME_KEY} = "${repo}";
+        $local_metadata{$ast_module_subsystem::REPO_REF_KEY} = "${ref_to_use}";
         $local_metadata{$ast_module_subsystem::REPO_COMMIT_KEY} = "${installed_commit_hash}";
+        $local_metadata{$ast_module_subsystem::DATE_TIME_KEY} = strftime("%Y-%m-%d %H:%M:%S", localtime time);
         # install the module!
         my $success = ast_module_subsystem::perform_install($module, $ast_path, $program_name,
                                               "${repo}-${installed_commit_hash_short}", 0, 0, 1, 0, \%local_metadata, 0);

--- a/atlas-shell-tools/scripts/common/ast_utilities.pm
+++ b/atlas-shell-tools/scripts/common/ast_utilities.pm
@@ -125,10 +125,10 @@ sub create_data_directory {
     my $default_namespace_path = File::Spec->catfile($data_directory, $ast_preset_subsystem::PRESETS_FOLDER, $ast_preset_subsystem::DEFAULT_NAMESPACE);
     my $full_repos_path = File::Spec->catfile($data_directory, $ast_repo_subsystem::REPOS_FOLDER);
     make_path("$data_directory", "$full_module_path", "$full_log4j_path",
-              "$full_presets_path", "$default_namespace_path", "$full_repos_path", {
-        verbose => 0,
-        mode => 0755
-    });
+        "$full_presets_path", "$default_namespace_path", "$full_repos_path", {
+            verbose => 0,
+            mode    => 0755
+        });
 
     # reset the log4j file if it is missing
     my $log4j_file = File::Spec->catfile($data_directory, $ast_log_subsystem::LOG4J_FOLDER, $ast_log_subsystem::LOG4J_FILE);
@@ -236,7 +236,7 @@ sub warn_output {
 # Return: the input
 sub prompt {
     my $query = shift; # take a prompt string as argument
-    local $| = 1; # activate autoflush to immediately show the prompt
+    local $| = 1;      # activate autoflush to immediately show the prompt
     print $query;
     my $answer = <STDIN>;
     if (defined $answer) {
@@ -260,13 +260,17 @@ sub prompt_yn {
 }
 
 # Get a pager command capable of displaying formatting codes. Checks the value
-# of the PAGER env variable, and uses that instead if it is set.
+# of the ATLAS_SHELL_TOOLS_PAGER env variable, and uses that instead if it is set.
+# If that is unset, fall back to PAGER. If that is unset, try a default.
 # Params: none
 # Return: the pager command array
 sub get_pager {
     my @pager_command = ();
 
-    if (defined $ENV{PAGER} && $ENV{PAGER} ne '') {
+    if (defined $ENV{ATLAS_SHELL_TOOLS_PAGER} && $ENV{ATLAS_SHELL_TOOLS_PAGER} ne '') {
+        @pager_command = split /\s+/, $ENV{ATLAS_SHELL_TOOLS_PAGER};
+    }
+    elsif (defined $ENV{PAGER} && $ENV{PAGER} ne '') {
         @pager_command = split /\s+/, $ENV{PAGER};
     }
     else {
@@ -288,14 +292,17 @@ sub get_pager {
 }
 
 # Get an editor command capable of displaying and editing a text file. Checks
-# the value of the EDITOR env variable, and uses that instead if it points to an
-# editor.
+# the value of the ATLAS_SHELL_TOOLS_EDITOR env variable, and uses that instead if it points to an
+# editor. If that is unset, fall back to EDITOR. If that is unset, try a default.
 # Params: none
 # Return: the editor command
 sub get_editor {
     my @editor_command = ();
 
-    if (defined $ENV{EDITOR} && $ENV{EDITOR} ne '') {
+    if (defined $ENV{ATLAS_SHELL_TOOLS_EDITOR} && $ENV{ATLAS_SHELL_TOOLS_EDITOR} ne '') {
+        @editor_command = split /\s+/, $ENV{ATLAS_SHELL_TOOLS_EDITOR};
+    }
+    elsif (defined $ENV{EDITOR} && $ENV{EDITOR} ne '') {
         @editor_command = split /\s+/, $ENV{EDITOR};
     }
     else {

--- a/atlas-shell-tools/scripts/common/ast_utilities.pm
+++ b/atlas-shell-tools/scripts/common/ast_utilities.pm
@@ -37,6 +37,8 @@ our @EXPORT = qw(
     get_man
     string_starts_with
     is_dir_empty
+    levenshtein
+    read_command_output
 );
 
 our $ATLAS_SHELL_TOOLS_VERSION = "atlas-shell-tools version 0.0.1";
@@ -391,6 +393,27 @@ sub levenshtein {
     }
 
     return $distance[@letters1][@letters2];
+}
+
+# Read the output of a given command array.
+# Params:
+#   $command_ref: a reference to an array containing the command args
+# Return: the output of a given command array
+sub read_command_output {
+    my $command_ref = shift;
+
+    my @command = @{$command_ref};
+    open COMMAND, "-|", @command or die $!;
+    my $output = '';
+    while (<COMMAND>) {
+        # Not the most efficient way to do things.
+        # Perhaps some kind of slurp is needed. File::Slurp could work but does
+        # have an outstanding Unicode bug. Need to investigate more.
+        $output = $output . $_;
+    }
+    close COMMAND;
+
+    return $output;
 }
 
 # Perl modules must return a value. Returning a value perl considers "truthy"

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/documentation/PagerHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/documentation/PagerHelper.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.streaming.resource.File;
@@ -15,8 +16,8 @@ import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 public class PagerHelper
 {
     private static final String PAGER_ENVIRONMENT_VARIABLE = "ATLAS_SHELL_TOOLS_PAGER";
-    private static final String DEFAULT_PAGER = "less";
-    private static final String DEFAULT_PAGER_FLAGS = "-cSRMis";
+    private static final String PAGER_FALLBACK_VARIABLE = "PAGER";
+    private static final String DEFAULT_PAGER = "less -cSRMis";
 
     /**
      * Page a given string using the system paging program. Will check PAGER environment variable
@@ -28,13 +29,25 @@ public class PagerHelper
     public void pageString(final String string)
     {
         final String pagerVariable = System.getenv(PAGER_ENVIRONMENT_VARIABLE);
+        final String pagerFallbackVariable = System.getenv(PAGER_FALLBACK_VARIABLE);
+        final Optional<String> pagerProgram;
+        final String[] pagerFlags;
+
         if (pagerVariable != null && !pagerVariable.isEmpty())
         {
-            System.err.println( // NOSONAR
-                    "TODO: respect for ATLAS_SHELL_TOOLS_PAGER env var currently unimplemented!"); // NOSONAR
+            pagerProgram = callWhichOnPager(pagerVariable.split("\\s+")[0]);
+            pagerFlags = extractFlagsFromVariable(pagerVariable);
         }
-
-        final Optional<String> pagerProgram = callWhichOnPager(DEFAULT_PAGER);
+        else if (pagerFallbackVariable != null && !pagerFallbackVariable.isEmpty())
+        {
+            pagerProgram = callWhichOnPager(pagerFallbackVariable.split("\\s+")[0]);
+            pagerFlags = extractFlagsFromVariable(pagerFallbackVariable);
+        }
+        else
+        {
+            pagerProgram = callWhichOnPager(DEFAULT_PAGER.split("\\s+")[0]);
+            pagerFlags = extractFlagsFromVariable(DEFAULT_PAGER);
+        }
 
         File temporaryFile = null;
         try
@@ -57,9 +70,15 @@ public class PagerHelper
 
         try
         {
-            final ProcessBuilder processBuilder = new ProcessBuilder(
-                    pagerProgram.orElseThrow(AtlasShellToolsException::new), DEFAULT_PAGER_FLAGS,
-                    temporaryFile.getAbsolutePath());
+            final String[] processBuilderArguments = new String[1 + pagerFlags.length + 1];
+            processBuilderArguments[0] = pagerProgram.orElseThrow(AtlasShellToolsException::new);
+            if (pagerFlags.length > 0)
+            {
+                System.arraycopy(pagerFlags, 0, processBuilderArguments, 1, pagerFlags.length);
+            }
+            processBuilderArguments[processBuilderArguments.length - 1] = temporaryFile
+                    .getAbsolutePath();
+            final ProcessBuilder processBuilder = new ProcessBuilder(processBuilderArguments);
             processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
             processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
             processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT);
@@ -106,6 +125,12 @@ public class PagerHelper
         {
             return Optional.empty();
         }
-        return Optional.ofNullable(line);
+        return Optional.of(line);
+    }
+
+    private String[] extractFlagsFromVariable(final String variable)
+    {
+        final String[] flags = variable.split("\\s+");
+        return Arrays.copyOfRange(flags, 1, flags.length);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/documentation/PagerHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/documentation/PagerHelper.java
@@ -14,7 +14,7 @@ import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
  */
 public class PagerHelper
 {
-    private static final String PAGER_ENVIRONMENT_VARIABLE = "PAGER";
+    private static final String PAGER_ENVIRONMENT_VARIABLE = "ATLAS_SHELL_TOOLS_PAGER";
     private static final String DEFAULT_PAGER = "less";
     private static final String DEFAULT_PAGER_FLAGS = "-cSRMis";
 
@@ -30,7 +30,8 @@ public class PagerHelper
         final String pagerVariable = System.getenv(PAGER_ENVIRONMENT_VARIABLE);
         if (pagerVariable != null && !pagerVariable.isEmpty())
         {
-            System.err.println("TODO: respect for PAGER env var currently unimplemented!"); // NOSONAR
+            System.err.println( // NOSONAR
+                    "TODO: respect for ATLAS_SHELL_TOOLS_PAGER env var currently unimplemented!"); // NOSONAR
         }
 
         final Optional<String> pagerProgram = callWhichOnPager(DEFAULT_PAGER);


### PR DESCRIPTION
### Description:

Updates to the following:

1. Lots of man page updates. Some typos have been fixed. A new `atlas-cookbook(7)` page has been added containing some commonly used command sequences (recipes). A man page for `atlas-config-repo(1)` has also been added.
2. Module installation logic has been refactored into `ast_module_subsystem::perform_install`. This reduced code complexity in the repo installation code as well as in the `atlas-config install` implementation
3. Module installation now saves useful metadata (like source repo, install time, and more), which can be viewed using a new `--verbose|-v` flag for `atlas-config list`.
4. Commands now check `ATLAS_SHELL_TOOLS_{EDITOR|PAGER}` before checking the `{EDITOR|PAGER}` environment variables, allowing users to specify a custom editor or pager for Atlas Shell Tools only.

### Potential Impact:
Improved experience for Atlas Shell Tools users.

### Unit Test Approach:
Extensive command line testing.

### Test Results:
Testing looks good.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
