### PR TITLE
EntityIdentifierGenerator no longer relies on external toString methods

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
@@ -133,7 +134,19 @@ public class EntityIdentifierGenerator
                 final CompleteRelation relation = (CompleteRelation) entity;
                 if (relation.members() != null)
                 {
-                    builder.append(relation.members().asBean().toString());
+                    final RelationBean bean = relation.members().asBean();
+                    builder.append("RelationBean[");
+                    for (final RelationBean.RelationBeanItem beanItem : bean)
+                    {
+                        builder.append("(");
+                        builder.append(beanItem.getType());
+                        builder.append(",");
+                        builder.append(beanItem.getIdentifier());
+                        builder.append(",");
+                        builder.append(beanItem.getRole());
+                        builder.append(")");
+                    }
+                    builder.append("]");
                 }
                 return builder.toString();
             default:

--- a/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
@@ -76,7 +76,7 @@ public class EntityIdentifierGeneratorTest
         final CompleteRelation relation = new CompleteRelation(1L, Maps.hashMap("a", "b", "c", "d"),
                 Rectangle.MINIMUM, bean, null, null, null, Sets.hashSet());
 
-        final String goldenPropertyString = ";RelationBean [[[POINT, 1, role], [AREA, 10, role]]]";
+        final String goldenPropertyString = ";RelationBean[(POINT,1,role)(AREA,10,role)]";
         Assert.assertEquals(goldenPropertyString,
                 new EntityIdentifierGenerator().getTypeSpecificPropertyString(relation));
     }


### PR DESCRIPTION
### Description:
Removed instance where the generator relied on the `toString` implementation of `RelationBean` to help create the hash string.

### Potential Impact:
Downstream code using `EntityIdentifierGenerator` may see different IDs for `Relation`s.

### Unit Test Approach:
Relevant unit test updated

### Test Results:
Test pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)