### PR TITLE
Cover additional edge cases in loxodromic midpoint

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Location.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Location.java
@@ -456,17 +456,12 @@ public class Location
         double lambda = ((lon2 - lon1) * Math.log(phi3) + lon1 * Math.log(phi2)
                 - lon2 * Math.log(phi1)) / Math.log(phi2 / phi1);
 
-        // Locations on the same circle of latitude
-        if (!Double.isFinite(lambda))
+        // Locations on the same circle of latitude do not produce a finite lambda value above.
+        // Locations at the same longitude (especially the antimeridian) should preserve their sign.
+        // All other locations should be be normalized within [-180, +180).
+        if (!Double.isFinite(lambda) || lon1 == lon2)
         {
             lambda = (lon1 + lon2) / 2;
-        }
-
-        // Normalize to [-180, +180), unless both input points are at +180, then return +180
-        if (this.getLongitude().equals(Longitude.MAXIMUM)
-                && that.getLongitude().equals(Longitude.MAXIMUM))
-        {
-            lambda = Longitude.MAXIMUM.asRadians();
         }
         else
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/LocationTest.java
@@ -151,6 +151,13 @@ public class LocationTest extends Command
 
         Assert.assertEquals(45.0, midpoint4.getLatitude().asDegrees(), DELTA);
         Assert.assertEquals(180.0, midpoint4.getLongitude().asDegrees(), DELTA);
+
+        final Location location9 = new Location(Latitude.degrees(-16.5), Longitude.degrees(-180));
+        final Location location10 = new Location(Latitude.degrees(-17.0), Longitude.degrees(-180));
+        final Location midpoint5 = location9.loxodromicMidPoint(location10);
+
+        Assert.assertEquals(-16.75, midpoint5.getLatitude().asDegrees(), DELTA);
+        Assert.assertEquals(-180.0, midpoint5.getLongitude().asDegrees(), DELTA);
     }
 
     @Test


### PR DESCRIPTION
### Description:

When both input `Location`s lie along the same longitude, the `loxodromicMidPoint()` can be calculated in a simpler way, since the midpoint's longitude will be the same as the input longitude.

This avoids issues primarily with the positive and negative antimeridian lines at +180 and -180, which might otherwise return a midpoint with the wrong sign after the trigonometric calculations take place.

### Potential Impact:

Downstream users who get the loxodromic midpoint for two `Location`s on the same line of longitude should find that their midpoint remains exactly at the same line of longitude as the input `Location`s, instead of wobbling in some cases. This should be most apparent if this method is applied to points along the antimeridian at -180˚. 

https://github.com/osmlab/atlas/pull/496 added special handling for the +180˚ meridian, but did not cover the special case where the calculated values at -180˚ drift just slightly over to the other side of the meridian, and end up rounding to a final value of +180˚, in spite of both inputs lying on the other side of the meridian.

### Unit Test Approach:

An example pair of points close to Fiji are added to the unit tests for `Location.loxodromicMidPoint()`. Prior to the code change, this midpoint is returned with a positive longitude, even though both input longitudes are negative.

### Test Results:

The updated `loxodromicMidPoint()` method was called on the start and end nodes of a sampling of real OSM ways, and returns the expected results.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
