### PR TITLE
Shard listing now uses getName instead of toString

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryToShardListing.java
@@ -58,8 +58,8 @@ public class CountryToShardListing extends Command
         try (SafeBufferedWriter writer = output.writer())
         {
             CountryShardListing.countryToShardList(countries, boundaries, sharding)
-                    .forEach((country, shardSet) -> shardSet.forEach(shard -> writer
-                            .writeLine(new CountryShard(country, shard).toString())));
+                    .forEach((country, shardSet) -> shardSet.forEach(
+                            shard -> writer.writeLine(new CountryShard(country, shard).getName())));
         }
         catch (final Exception e)
         {

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/converters/StringToShardConverterTest.java
@@ -84,4 +84,28 @@ public class StringToShardConverterTest
         Assert.assertTrue(tuple6.getSecond().isPresent());
         Assert.assertEquals("zz/xx/yy", tuple6.getSecond().get());
     }
+
+    @Test
+    public void testIfGetNameIsParsable()
+    {
+        final StringToShardConverter converter = new StringToShardConverter();
+
+        final SlippyTile slippyTile = new SlippyTile(9, 12, 8);
+        final GeoHashTile geoHashTile = new GeoHashTile("3ghv");
+        final CountryShard countryShard1 = new CountryShard("DMA", slippyTile);
+        final CountryShard countryShard2 = new CountryShard("AIA", geoHashTile);
+
+        Assert.assertEquals(slippyTile, converter.convert(slippyTile.getName()));
+        Assert.assertEquals(slippyTile.toString(),
+                converter.convert(slippyTile.getName()).toString());
+        Assert.assertEquals(geoHashTile, converter.convert(geoHashTile.getName()));
+        Assert.assertEquals(geoHashTile.toString(),
+                converter.convert(geoHashTile.getName()).toString());
+        Assert.assertEquals(countryShard1, converter.convert(countryShard1.getName()));
+        Assert.assertEquals(countryShard1.toString(),
+                converter.convert(countryShard1.getName()).toString());
+        Assert.assertEquals(countryShard2, converter.convert(countryShard2.getName()));
+        Assert.assertEquals(countryShard2.toString(),
+                converter.convert(countryShard2.getName()).toString());
+    }
 }


### PR DESCRIPTION
### Description:
Now that the `Shard#getName` method has been standardized, any code attempting to write a parsable shard string should be using this method.

See: https://github.com/osmlab/atlas-generator/pull/122

### Potential Impact:
Parsing code expecting `toString` to give parsable output may be broken. This fixes that issue.

### Unit Test Approach:

Added a test that should catch any future getName issues

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)