### PR TITLE
Add Utility Methods in LevelTag and LayerTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
@@ -22,6 +22,22 @@ public interface LayerTag
     @TagKey
     String KEY = "layer";
 
+    /**
+     * Checks if two Taggable objects are on the same layer or not. According to OSM wiki, objects
+     * with no explicit LayerTag are assumed to have layer 0.
+     *
+     * @param taggableOne
+     *            first object to compare
+     * @param taggableTwo
+     *            second object to compare
+     * @return true if the two objects have same layer tag, false otherwise
+     */
+    static boolean areOnSameLayer(final Taggable taggableOne, final Taggable taggableTwo)
+    {
+        return LayerTag.getTaggedOrImpliedValue(taggableOne, ZERO)
+                .equals(LayerTag.getTaggedOrImpliedValue(taggableTwo, ZERO));
+    }
+
     static long getMaxValue()
     {
         return LayerTag.class.getDeclaredAnnotation(Tag.class).range().max();
@@ -48,21 +64,5 @@ public interface LayerTag
                     LayerTag.class.getDeclaredAnnotation(Tag.class));
         }
         return Optional.empty();
-    }
-
-    /**
-     * Checks if two Taggable objects are on the same layer or not. According to OSM wiki, objects
-     * with no explicit LayerTag are assumed to have layer 0.
-     *
-     * @param taggableOne
-     *            first object to compare
-     * @param taggableTwo
-     *            second object to compare
-     * @return true if the two objects have same layer tag, false otherwise
-     */
-    static boolean areOnSameLayer(final Taggable taggableOne, final Taggable taggableTwo)
-    {
-        return LayerTag.getTaggedOrImpliedValue(taggableOne, ZERO)
-                .equals(LayerTag.getTaggedOrImpliedValue(taggableTwo, ZERO));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
@@ -60,7 +60,7 @@ public interface LayerTag
      *            second object to compare
      * @return true if the two objects have same layer tag, false otherwise
      */
-    static boolean isOnSameLayer(final Taggable taggableOne, final Taggable taggableTwo)
+    static boolean areOnSameLayer(final Taggable taggableOne, final Taggable taggableTwo)
     {
         return LayerTag.getTaggedOrImpliedValue(taggableOne, ZERO)
                 .equals(LayerTag.getTaggedOrImpliedValue(taggableTwo, ZERO));

--- a/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java
@@ -18,6 +18,7 @@ import org.openstreetmap.atlas.tags.annotations.extraction.LongExtractor;
         0 }), taginfo = "http://taginfo.openstreetmap.org/keys/layer#values", osm = "http://wiki.openstreetmap.org/wiki/Layer")
 public interface LayerTag
 {
+    Long ZERO = 0L;
     @TagKey
     String KEY = "layer";
 
@@ -47,5 +48,21 @@ public interface LayerTag
                     LayerTag.class.getDeclaredAnnotation(Tag.class));
         }
         return Optional.empty();
+    }
+
+    /**
+     * Checks if two Taggable objects are on the same layer or not. According to OSM wiki, objects
+     * with no explicit LayerTag are assumed to have layer 0.
+     *
+     * @param taggableOne
+     *            first object to compare
+     * @param taggableTwo
+     *            second object to compare
+     * @return true if the two objects have same layer tag, false otherwise
+     */
+    static boolean isOnSameLayer(final Taggable taggableOne, final Taggable taggableTwo)
+    {
+        return LayerTag.getTaggedOrImpliedValue(taggableOne, ZERO)
+                .equals(LayerTag.getTaggedOrImpliedValue(taggableTwo, ZERO));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
@@ -20,11 +20,34 @@ public interface LevelTag
     static String getTaggedOrImpliedValue(final Taggable taggable, final String impliedValue)
     {
         final Optional<String> taggedValue = getTaggedValue(taggable);
-        return taggedValue.isPresent() ? taggedValue.get() : impliedValue;
+        return taggedValue.orElse(impliedValue);
     }
 
     static Optional<String> getTaggedValue(final Taggable taggable)
     {
         return taggable.getTag(KEY);
+    }
+
+    /**
+     * Checks if two Taggable objects are on the same level or not. As per
+     * https://wiki.openstreetmap.org/wiki/Key:level, level=0 is not always at street level and so
+     * unlike LayerTag, if the LevelTag is not explicitly given, we cannot imply that the object is
+     * at level 0.
+     *
+     * @param taggableOne
+     *            first object to compare
+     * @param taggableTwo
+     *            second object to compare
+     * @return true if object one and object two are on the same level
+     */
+    static boolean isOnSameLevel(final Taggable taggableOne, final Taggable taggableTwo)
+    {
+        final Optional<String> levelTagEdgeOne = LevelTag.getTaggedValue(taggableOne);
+        final Optional<String> levelTagEdgeTwo = LevelTag.getTaggedValue(taggableTwo);
+        if (levelTagEdgeOne.isPresent() && levelTagEdgeTwo.isPresent())
+        {
+            return levelTagEdgeOne.get().equals(levelTagEdgeTwo.get());
+        }
+        return !levelTagEdgeOne.isPresent() && !levelTagEdgeTwo.isPresent();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
@@ -17,17 +17,6 @@ public interface LevelTag
     @TagKey
     String KEY = "level";
 
-    static String getTaggedOrImpliedValue(final Taggable taggable, final String impliedValue)
-    {
-        final Optional<String> taggedValue = getTaggedValue(taggable);
-        return taggedValue.isPresent() ? taggedValue.get() : impliedValue;
-    }
-
-    static Optional<String> getTaggedValue(final Taggable taggable)
-    {
-        return taggable.getTag(KEY);
-    }
-
     /**
      * Checks if two Taggable objects are on the same level or not. As per
      * https://wiki.openstreetmap.org/wiki/Key:level, level=0 is not always at street level and so
@@ -49,5 +38,16 @@ public interface LevelTag
             return levelTagEdgeOne.get().equals(levelTagEdgeTwo.get());
         }
         return !levelTagEdgeOne.isPresent() && !levelTagEdgeTwo.isPresent();
+    }
+
+    static String getTaggedOrImpliedValue(final Taggable taggable, final String impliedValue)
+    {
+        final Optional<String> taggedValue = getTaggedValue(taggable);
+        return taggedValue.isPresent() ? taggedValue.get() : impliedValue;
+    }
+
+    static Optional<String> getTaggedValue(final Taggable taggable)
+    {
+        return taggable.getTag(KEY);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
@@ -20,7 +20,7 @@ public interface LevelTag
     static String getTaggedOrImpliedValue(final Taggable taggable, final String impliedValue)
     {
         final Optional<String> taggedValue = getTaggedValue(taggable);
-        return taggedValue.orElse(impliedValue);
+        return taggedValue.isPresent() ? taggedValue.get() : impliedValue;
     }
 
     static Optional<String> getTaggedValue(final Taggable taggable)

--- a/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/LevelTag.java
@@ -40,7 +40,7 @@ public interface LevelTag
      *            second object to compare
      * @return true if object one and object two are on the same level
      */
-    static boolean isOnSameLevel(final Taggable taggableOne, final Taggable taggableTwo)
+    static boolean areOnSameLevel(final Taggable taggableOne, final Taggable taggableTwo)
     {
         final Optional<String> levelTagEdgeOne = LevelTag.getTaggedValue(taggableOne);
         final Optional<String> levelTagEdgeTwo = LevelTag.getTaggedValue(taggableTwo);

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LayerTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LayerTagTestCase.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.tags.annotations.validation;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.Taggable;
 
 /**
  * Test case for the LayerTag class
@@ -11,6 +12,13 @@ import org.openstreetmap.atlas.tags.LayerTag;
  */
 public class LayerTagTestCase extends BaseTagTestCase
 {
+    @Test
+    public void layerMaxValue()
+    {
+        Assert.assertEquals(LayerTag.getMaxValue(), 5);
+        Assert.assertEquals(LayerTag.getMinValue(), -5);
+    }
+
     @Test
     public void layerNotZero()
     {
@@ -41,5 +49,24 @@ public class LayerTagTestCase extends BaseTagTestCase
         {
             Assert.assertTrue(validators().isValidFor(LayerTag.KEY, String.valueOf(loop)));
         }
+    }
+
+    @Test
+    public void taggablesOnDifferentLayer()
+    {
+        final Taggable taggableOne = Taggable.with("layer", "1");
+        final Taggable taggableTwo = Taggable.with("layer", "2");
+        Assert.assertFalse(LayerTag.areOnSameLayer(taggableOne, taggableTwo));
+    }
+
+    @Test
+    public void taggablesOnSameLayer()
+    {
+        final Taggable taggableOne = Taggable.with("layer", "1");
+        final Taggable taggableTwo = Taggable.with("layer", "2");
+        final Taggable taggableThree = Taggable.with("layer", "0");
+        final Taggable taggableFour = Taggable.with("highway", "primary");
+        Assert.assertFalse(LayerTag.areOnSameLayer(taggableOne, taggableTwo));
+        Assert.assertTrue(LayerTag.areOnSameLayer(taggableThree, taggableFour));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LevelTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/LevelTagTestCase.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.tags.annotations.validation;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.LevelTag;
+import org.openstreetmap.atlas.tags.Taggable;
+
+/**
+ * Test case for the {@link LevelTag} class
+ *
+ * @author sayas01
+ */
+public class LevelTagTestCase extends BaseTagTestCase
+{
+    @Test
+    public void taggablesOnDifferentLevel()
+    {
+        final Taggable taggableOne = Taggable.with("level", "1");
+        final Taggable taggableTwo = Taggable.with("level", "2");
+        final Taggable taggableThree = Taggable.with("level", "0");
+        final Taggable taggableFour = Taggable.with("highway", "primary");
+        Assert.assertFalse(LevelTag.areOnSameLevel(taggableOne, taggableTwo));
+        Assert.assertFalse(LevelTag.areOnSameLevel(taggableThree, taggableFour));
+    }
+
+    @Test
+    public void taggablesOnSameLevel()
+    {
+        final Taggable taggableOne = Taggable.with("level", "1");
+        final Taggable taggableTwo = Taggable.with("level", "1");
+        Assert.assertTrue(LevelTag.areOnSameLevel(taggableOne, taggableTwo));
+    }
+}


### PR DESCRIPTION
### Description:

This PR adds two methods, areOnSameLevel(in LevelTag class) and areOnSameLayer(in LayerTag class). These methods can be used to check if two Taggable objects are on the same level or on the same layer. 
Note: According to OSM wiki, if Layer tag is not explicitly given, we can assume the object to be on layer 0 but in case of LevelTag, we cannot imply that an absent LevelTag means the object is at Level 0. The methods are implemented likewise.

### Potential Impact:

Nothing, just two additional helper methods which can be used.

### Unit Test Approach:

Added new unit tests to test the updates.

### Test Results:

All test passing.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
