### PR TITLE
Added CountryShard string constructor

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/sharding/CountryShard.java
@@ -38,6 +38,17 @@ public class CountryShard implements Shard
         this.country = country;
     }
 
+    public CountryShard(final String country, final String shardString)
+    {
+        if (shardString == null || country == null)
+        {
+            throw new CoreException("Cannot have null parameters: Country = {} and Shard = {}",
+                    country, shardString);
+        }
+        this.country = country;
+        this.shard = new StringToShardConverter().convert(shardString);
+    }
+
     @Override
     public JsonObject asGeoJson()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/sharding/CountryShardTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/sharding/CountryShardTest.java
@@ -15,5 +15,10 @@ public class CountryShardTest
         final SlippyTile tile = SlippyTile.forName("1-2-3");
         Assert.assertEquals(tile.bounds(), countryShard.bounds());
         Assert.assertEquals("ABC", countryShard.getCountry());
+
+        final CountryShard countryShard2 = new CountryShard("ABC", "4-5-6");
+        final SlippyTile tile2 = SlippyTile.forName("4-5-6");
+        Assert.assertEquals(tile2.bounds(), countryShard2.bounds());
+        Assert.assertEquals("ABC", countryShard2.getCountry());
     }
 }


### PR DESCRIPTION
### Description:
`CountryShard` now has a constructor that can take a string version of a shard. This is simply for QoL and ease of use.

### Potential Impact:
Users have a new constructor!

### Unit Test Approach:
Added a test case. See diff.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)