### PR TITLE
ZSH support for Atlas Shell Tools

### DIFF
--- a/atlas-shell-tools/README.md
+++ b/atlas-shell-tools/README.md
@@ -27,7 +27,6 @@ $ sh quick_install_bash.sh
 ```
 
 #### For `zsh` users:
-**TODO actually implement zsh support**
 ```
 $ curl -O https://raw.githubusercontent.com/osmlab/atlas/master/atlas-shell-tools/quick_install_zsh.sh
 # Inspect the downloaded file and ensure you are satisfied it is safe to run:
@@ -53,7 +52,7 @@ $ ./atlas-shell-tools/scripts/atlas-config repo install atlas
 ##### Setting up your shell startup file
 Next, open whichever configuration file your shell uses to set environment variables (e.g. `~/.bash_profile` for `bash`, or `~/.zshenv` for `zsh`). Export the following environment variables using your shell's equivalent `export` statement.
 ```
-# In bash we can use 'export', other shells may use different syntax
+# In bash/zsh we can use 'export', other shells may use different syntax
 
 # Point ATLAS_SHELL_TOOLS_HOME at the 'atlas-shell-tools' subfolder within your 'atlas-shell-tools' installation
 export ATLAS_SHELL_TOOLS_HOME=/path/to/atlas-shell-tools/atlas-shell-tools
@@ -63,6 +62,7 @@ export PATH="$PATH:$ATLAS_SHELL_TOOLS_HOME/scripts"
 ```
 ##### Autocomplete support
 Additionally, `atlas-shell-tools` supports autocomplete for `bash` and `zsh` through [ast_completions.bash](https://github.com/osmlab/atlas/blob/master/atlas-shell-tools/ast_completions.bash) and [ast_completions.zsh](https://github.com/osmlab/atlas/blob/master/atlas-shell-tools/ast_completions.zsh), respectively. To get these set up, you'll need to source them in your shell's appropriate startup file (`~/.bashrc` for `bash` or `~/.zshrc` for `zsh`).
+
 An example for `bash`:
 ```
 ##### ~/.bashrc file #####
@@ -70,6 +70,15 @@ An example for `bash`:
 # other stuff here....
 #
 source "$ATLAS_SHELL_TOOLS_HOME/ast_completions.bash"
+```
+
+An example for `zsh`:
+```
+##### ~/.zshrc file #####
+#
+# other stuff here....
+#
+source "$ATLAS_SHELL_TOOLS_HOME/ast_completions.zsh"
 ```
 
 ## Creating A Command

--- a/atlas-shell-tools/ast_completions.bash
+++ b/atlas-shell-tools/ast_completions.bash
@@ -49,7 +49,7 @@ _complete_atlas_shell_tools ()
         compopt +o default
     fi
 
-    local reply=$(atlas-config "${completion_mode}" "${COMP_WORDS[@]}");
+    local reply=$(atlas-config "${completion_mode}" "${COMP_CWORD}" "${COMP_WORDS[@]}");
 
     if [ "$reply" = "__atlas-shell-tools_sentinel_complete_filenames__" ];
     then

--- a/atlas-shell-tools/ast_completions.zsh
+++ b/atlas-shell-tools/ast_completions.zsh
@@ -43,5 +43,5 @@ autoload compinit
 compinit
 autoload bashcompinit
 bashcompinit
-complete -o filenames -o default -F _complete_atlas_shell_tools_zsh atlas
-complete -o filenames -o default -F _complete_atlas_shell_tools_zsh atlas-config
+complete -o filenames -o bashdefault -F _complete_atlas_shell_tools_zsh atlas
+complete -o filenames -o bashdefault -F _complete_atlas_shell_tools_zsh atlas-config

--- a/atlas-shell-tools/ast_completions.zsh
+++ b/atlas-shell-tools/ast_completions.zsh
@@ -12,3 +12,38 @@
 # file to pick up the completions in every new shell!
 
 # TODO figure out how to do zsh completions
+
+_complete_atlas_shell_tools_zsh ()
+{
+    local completion_mode="default";
+    if [ "$1" = "atlas" ];
+    then
+        local completion_mode="__completion_atlas__"
+    elif [ "$1" = "atlas-config" ];
+    then
+        local completion_mode="__completion_atlascfg__"
+    fi
+
+    if [ "$completion_mode" = "default" ];
+    then
+        echo "complete error: ${completion_mode} was still default"
+        return 1
+    fi
+
+    local reply=$(atlas-config "${completion_mode}" "${COMP_WORDS[@]}");
+
+    if [ "$reply" = "__atlas-shell-tools_sentinel_complete_filenames__" ];
+    then
+        COMPREPLY=()
+        return 0
+    else
+        COMPREPLY=(${reply})
+    fi
+}
+
+autoload compinit
+compinit
+autoload bashcompinit
+bashcompinit
+complete -o filenames -o default -F _complete_atlas_shell_tools_zsh atlas
+complete -o filenames -o default -F _complete_atlas_shell_tools_zsh atlas-config

--- a/atlas-shell-tools/ast_completions.zsh
+++ b/atlas-shell-tools/ast_completions.zsh
@@ -28,11 +28,18 @@ _complete_atlas_shell_tools_zsh ()
         return 1
     fi
 
-    local reply=$(atlas-config "${completion_mode}" "${COMP_WORDS[@]}");
+    local reply=$(atlas-config "${completion_mode}" "${COMP_CWORD}" "${COMP_WORDS[@]}");
 
     if [ "$reply" = "__atlas-shell-tools_sentinel_complete_filenames__" ];
     then
-        COMPREPLY=()
+        local cur=${COMP_WORDS[COMP_CWORD]}
+
+        # We must locally set IFS to '\n' in case there are filenames with whitespace.
+        # Without this, a filename like "file with spaces" would present itself
+        # as 3 discrete completion options, "file", "with", and "spaces".
+        local IFS=$'\n'
+
+        COMPREPLY=($(compgen -o filenames -f -- "$cur"))
         return 0
     else
         COMPREPLY=(${reply})

--- a/atlas-shell-tools/ast_completions.zsh
+++ b/atlas-shell-tools/ast_completions.zsh
@@ -11,17 +11,15 @@
 # Then add 'source "$ATLAS_SHELL_TOOLS_HOME/ast_completions.zsh"' to your '~/.zshrc'
 # file to pick up the completions in every new shell!
 
-# TODO figure out how to do zsh completions
-
 _complete_atlas_shell_tools_zsh ()
 {
     local completion_mode="default";
     if [ "$1" = "atlas" ];
     then
-        local completion_mode="__completion_atlas__"
+        local completion_mode="__completion_atlas_zsh__"
     elif [ "$1" = "atlas-config" ];
     then
-        local completion_mode="__completion_atlascfg__"
+        local completion_mode="__completion_atlascfg_zsh__"
     fi
 
     if [ "$completion_mode" = "default" ];

--- a/atlas-shell-tools/quick_install_zsh.sh
+++ b/atlas-shell-tools/quick_install_zsh.sh
@@ -1,9 +1,160 @@
 #!/bin/sh
 
-echo "TODO: zsh install"
-echo "For now, please use quick_install_bash.sh."
-echo "You may still use zsh if you wish, but you"
-echo "must manually add the necessary export environment"
-echo "statements to your startup files. See the section"
-echo "in the README.md about manual installation for details."
+# Define a prompt function for re-use
+prompt_yn_was_yes() {
+    prompt=$1
+    while true;
+    do
+        echo "$prompt"
+        # handle EOF case
+        if ! read -r answer;
+        then
+            exit 0
+        fi
+        if [ "$answer" != "${answer#[Yy]}" ];
+        then
+            # case user entered 'y'
+            return 0
+        elif [ "$answer" != "${answer#[Nn]}" ];
+        then
+            # case user entered 'n'
+            return 1
+        fi
+        echo "Please enter 'y' or 'n'..."
+    done
+}
 
+# Utilize POSIX sh features ONLY for installation. Also, we exit the script
+# on any error.
+set -e
+
+# Grab the install location from first argument if present.
+install_location=$1
+
+# Verify that you have programs needed by atlas-shell-tools
+if ! command -v less > /dev/null;
+then
+    echo "Error: atlas-shell-tools requires the 'less' paging program."
+    # Unfortunately, we cannot use $LINENO in POSIX sh. Make sure to manually
+    # maintain this line number.
+    echo "To install anyway, open $0 and comment out check on lines 35-42."
+    exit 1
+fi
+
+if ! command -v man > /dev/null;
+then
+    echo "Error: atlas-shell-tools requires the 'man' program."
+    # Unfortunately, we cannot use $LINENO in POSIX sh. Make sure to manually
+    # maintain this line number.
+    echo "To install anyway, open $0 and comment out check on lines 44-51."
+    exit 1
+fi
+
+if ! command -v vim > /dev/null;
+then
+    echo "Error: atlas-shell-tools requires the 'vim' editor."
+    # Unfortunately, we cannot use $LINENO in POSIX sh. Make sure to manually
+    # maintain this line number.
+    echo "To install anyway, open $0 and comment out check on lines 53-60."
+    exit 1
+fi
+
+# Check the install location. If blank, we will use $HOME as default after
+# prompting the user for confirmation.
+if [ -z "$install_location" ];
+then
+    echo "Using the value of \$HOME ($HOME) as install location."
+    echo "If an alternative location is desired, select 'n' and try:"
+    echo
+    echo "    \$ sh quick_install_bash.sh /install/path"
+    echo
+    if prompt_yn_was_yes "OK to continue (y/n)?";
+    then
+        install_location="$HOME"
+    else
+        exit 0
+    fi
+fi
+
+if [ ! -d "$install_location" ];
+then
+    echo "Error: $install_location does not exist"
+    exit 1
+fi
+
+if [ ! -w "$install_location" ];
+then
+    echo "Error: you do not have write permissions for $install_location"
+    exit 1
+fi
+
+base_folder="atlas-shell-tools"
+full_installation_path="$install_location/$base_folder"
+
+if [ -e "$full_installation_path" ];
+then
+    echo "Error: $full_installation_path already exists"
+    exit 1
+fi
+
+git clone https://github.com/osmlab/atlas.git "$full_installation_path"
+cd "$full_installation_path"
+git checkout master
+chmod +x atlas-shell-tools/scripts/atlas atlas-shell-tools/scripts/atlas-config
+export ATLAS_SHELL_TOOLS_HOME="$full_installation_path/atlas-shell-tools"
+export PATH="$PATH:$ATLAS_SHELL_TOOLS_HOME/scripts"
+
+# Install the core Atlas module using a repo
+./atlas-shell-tools/scripts/atlas-config repo add atlas https://github.com/osmlab/atlas.git master
+./atlas-shell-tools/scripts/atlas-config repo install atlas
+
+# Modify the bash startup files with appropriate settings
+start_startup_line="# atlas-shell-tools startup: added automatically by quick_install_zsh.sh"
+end_startup_line="# END atlas-shell-tools startup"
+export_home_line="export ATLAS_SHELL_TOOLS_HOME=\"$full_installation_path/atlas-shell-tools\""
+export_path_line="export PATH=\"\$PATH:\$ATLAS_SHELL_TOOLS_HOME/scripts\""
+source_line="source \"\$ATLAS_SHELL_TOOLS_HOME/ast_completions.zsh\""
+
+echo
+echo "About to append ~/.zshenv with:"
+echo
+echo "    $start_startup_line";
+echo "    $export_home_line";
+echo "    $export_path_line";
+echo "    $source_line";
+echo "    $end_startup_line";
+echo
+if prompt_yn_was_yes "Is this OK (y/n)?";
+then
+    {
+        echo;
+        echo "$start_startup_line";
+        echo "$export_home_line";
+        echo "$export_path_line";
+        echo "$source_line";
+        echo "$end_startup_line";
+        echo;
+    } >> "$HOME/.zshenv"
+fi
+echo
+echo "About to append ~/.zshrc with:"
+echo
+echo "    $start_startup_line";
+echo "    $source_line";
+echo "    $end_startup_line";
+echo
+if prompt_yn_was_yes "Is this OK (y/n)?";
+then
+    {
+        echo;
+        echo "$start_startup_line";
+        echo "$source_line";
+        echo "$end_startup_line";
+        echo;
+    } >> "$HOME/.zshrc"
+fi
+
+# Complete the installation
+echo
+echo "Installation complete."
+echo "Restart your terminal and try 'man atlas-shell-tools' to get started."

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -1076,16 +1076,16 @@ elsif ($subcommand eq "update") {
 # These subcommands are "hidden", they are used by the completion scripts
 # to generate autocomplete suggestions.
 elsif ($subcommand eq "__completion_atlas__") {
-    $success = ast_completions::completion_atlas($ast_path, \@ARGV);
+    $success = ast_completions::completion_atlas($ast_path, 0, \@ARGV);
 }
 elsif ($subcommand eq "__completion_atlascfg__") {
-    $success = ast_completions::completion_atlascfg($ast_path, \@ARGV);
+    $success = ast_completions::completion_atlascfg($ast_path, 0, \@ARGV);
 }
 elsif ($subcommand eq "__completion_atlas_zsh__") {
-    $success = ast_completions::completion_atlas_zsh($ast_path, \@ARGV);
+    $success = ast_completions::completion_atlas($ast_path, 1, \@ARGV);
 }
 elsif ($subcommand eq "__completion_atlascfg_zsh__") {
-    $success = ast_completions::completion_atlascfg_zsh($ast_path, \@ARGV);
+    $success = ast_completions::completion_atlascfg($ast_path, 1, \@ARGV);
 }
 else {
     ast_utilities::error_output($program_name, "no such command ${bold_stderr}${subcommand}${reset_stderr}");

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -1081,6 +1081,12 @@ elsif ($subcommand eq "__completion_atlas__") {
 elsif ($subcommand eq "__completion_atlascfg__") {
     $success = ast_completions::completion_atlascfg($ast_path, \@ARGV);
 }
+elsif ($subcommand eq "__completion_atlas_zsh__") {
+    $success = ast_completions::completion_atlas_zsh($ast_path, \@ARGV);
+}
+elsif ($subcommand eq "__completion_atlascfg_zsh__") {
+    $success = ast_completions::completion_atlascfg_zsh($ast_path, \@ARGV);
+}
 else {
     ast_utilities::error_output($program_name, "no such command ${bold_stderr}${subcommand}${reset_stderr}");
     print STDERR "Try '${bold_stderr}${program_name} --help${reset_stderr}' for more information.\n";

--- a/atlas-shell-tools/scripts/common/ast_completions.pm
+++ b/atlas-shell-tools/scripts/common/ast_completions.pm
@@ -333,6 +333,15 @@ sub completion_atlascfg {
     return 1;
 }
 
+# TODO DEBUG BEGIN
+sub debug_dump_string {
+    my $string = shift;
+    open my $handle, '>>', "/Users/lucascram/Desktop/perl.debug";
+    print $handle $string;
+    close $handle;
+}
+# TODO DEBUG END
+
 # Perl modules must return a value. Returning a value perl considers "truthy"
 # signals that the module loaded successfully.
 1;

--- a/atlas-shell-tools/scripts/common/ast_completions.pm
+++ b/atlas-shell-tools/scripts/common/ast_completions.pm
@@ -128,6 +128,13 @@ sub completion_atlas {
     return 1;
 }
 
+sub completion_atlas_zsh {
+    my $ast_path = shift;
+    my $argv_ref = shift;
+
+    return 1;
+}
+
 sub completion_atlascfg {
     my $ast_path = shift;
     my $argv_ref = shift;
@@ -329,6 +336,38 @@ sub completion_atlascfg {
     # Generate completion matches based on prefix of current word
     my @completion_matches = completion_match_prefix($rargv, \@commands);
     print join("\n", @completion_matches) . "\n";
+
+    return 1;
+}
+
+sub completion_atlascfg_zsh {
+    my $ast_path = shift;
+    my $argv_ref = shift;
+
+    my @argv = @{$argv_ref};
+
+    # TODO DEBUG BEGIN
+    debug_dump_string("Initial ARGV\n");
+    foreach my $element (@argv) {
+        debug_dump_string(length($element) . ":${element}\n");
+    }
+    debug_dump_string("------------\n");
+    # TODO DEBUG END
+
+    # Shift "atlas-config" off the front of ARGV
+    shift @argv;
+
+    my %subcommand_classes = ast_module_subsystem::get_subcommand_to_class_hash($ast_path);
+
+    # Shift global options off the front of ARGV
+    foreach my $element (@argv) {
+        if (ast_utilities::string_starts_with($element, '-')) {
+            shift @argv;
+        }
+    }
+
+    my @commands = ();
+    my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
 
     return 1;
 }


### PR DESCRIPTION
### Description:
Atlas Shell Tools TAB completion now supports zsh as well as oh-my-zsh setups. The script `quick_install_zsh.sh` should take care of the setup. Additionally, one can follow the `Manual Install` steps listed in the README.

### Potential Impact:
Our zsh users will be happy!

### Unit Test Approach:
Performed interactive TAB completion testing the command line.

### Test Results:
Looks good!

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
