### PR TITLE
Some Atlas Shell Tools bug fixes and zsh support follow-up

### DIFF
--- a/atlas-shell-tools/man/man1/atlas-config-list.1
+++ b/atlas-shell-tools/man/man1/atlas-config-list.1
@@ -28,15 +28,15 @@ atlas\-config\-list \-\- List installed Atlas Shell Tools modules and module sta
 .sp
 .nf
 \fIatlas\-config\fR \fIlist\fR \-\-help
-\fIatlas\-config\fR \fIlist\fR [\-\-current] [\-\-verbose]
+\fIatlas\-config\fR \fIlist\fR [\-\-current] [\-\-one\-line]
 .fi
 
 .SH "DESCRIPTION"
 .sp
 List installed modules with additional contextual information. This listing
-is also known as the module workspace. The \fB\-\-verbose\fR option can be used to
-display module metadata if present. The \fB\-\-current\fR option can be used to view
-only the current activated module, if there is one.
+is also known as the module workspace. The \fB\-\-current\fR option can be used to view
+only the current activated module, if there is one. The \fB\-\-one\-line\fR option can be used to
+suppress metadata output.
 
 A \fB*\fR next to a module denotes that the module is activated. Symlinked
 modules display their targets using the familiar arrow notation (\fB\->\fR). If a
@@ -59,9 +59,9 @@ Show this help menu.
 .RE
 
 .PP
-\fB\-\-verbose\fR, \fB-v\fR
+\fB\-\-one\-line\fR, \fB-1\fR
 .RS 4
-Show module metadata information below each module listing.
+Suppress the module metadata output, instead displaying each module on a single line.
 .RE
 
 .SH "SEE ALSO"

--- a/atlas-shell-tools/man/man1/atlas-config-preset.1
+++ b/atlas-shell-tools/man/man1/atlas-config-preset.1
@@ -29,11 +29,16 @@ atlas\-config\-preset \-\- Create and manage Atlas Shell Tools command presets
 .nf
 \fIatlas\-config\fR \fIpreset\fR \-\-help
 \fIatlas\-config\fR \fIpreset\fR \fIcopy\fR <command> <src> <dest>
+\fIatlas\-config\fR \fIpreset\fR \fIcopy\-global\fR <src> <dest>
 \fIatlas\-config\fR \fIpreset\fR \fIedit\fR <command> <preset>
+\fIatlas\-config\fR \fIpreset\fR \fIedit\-global\fR <preset>
 \fIatlas\-config\fR \fIpreset\fR \fIlist\fR [command [preset]]
+\fIatlas\-config\fR \fIpreset\fR \fIlist\-global\fR [preset]
 \fIatlas\-config\fR \fIpreset\fR \fInamespace\fR <subdirective> [namespace]
 \fIatlas\-config\fR \fIpreset\fR \fIremove\fR <command> [preset]
+\fIatlas\-config\fR \fIpreset\fR \fIremove\-global\fR [preset]
 \fIatlas\-config\fR \fIpreset\fR \fIsave\fR <command> <preset> <options...>
+\fIatlas\-config\fR \fIpreset\fR \fIsave\-global\fR <preset> <options...>
 .fi
 
 .SH "DESCRIPTION"
@@ -66,9 +71,24 @@ exist, else the copy will fail.
 .RE
 
 .PP
+\fIcopy\-global\fR
+.RS 4
+Copy global preset <src> into new global preset <dest>. <dest> must not already
+exist, else the copy will fail.
+.RE
+
+.PP
 \fIedit\fR
 .RS 4
-Edit preset <name> for <command>. If <name> does not exist, then it will be
+Edit preset <preset> for <command>. If <preset> does not exist, then it will be
+created when the edit is successfully saved. The default preset editor is \fBvim\fR,
+but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environment variable.
+.RE
+
+.PP
+\fIedit\-global\fR
+.RS 4
+Edit global preset <preset>. If <preset> does not exist, then it will be
 created when the edit is successfully saved. The default preset editor is \fBvim\fR,
 but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environment variable.
 .RE
@@ -76,8 +96,14 @@ but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environmen
 .PP
 \fIlist\fR
 .RS 4
-List all available presets, or list all presets for a given [command], or
-list contents of preset [name] for [command].
+List all available presets (including globals), or list all presets for a given [command], or
+list contents of preset [preset] for [command].
+.RE
+
+.PP
+\fIlist\-global\fR
+.RS 4
+List all available global presets, or list contents of global preset [preset].
 .RE
 
 .PP
@@ -96,10 +122,24 @@ Remove all presets for a given <command>, or remove the preset [name] for
 .RE
 
 .PP
+\fIremove\-global\fR
+.RS 4
+Remove all global presets, or remove the global preset [name].
+.RE
+
+.PP
 \fIsave\fR
 .RS 4
-Save a preset <name> for <command> without actually running the command.
+Save a preset <preset> for <command> without actually running the command.
 <options...> is a sequence of options to be saved in the preset.
+Again, recall that you must use the long option '=' syntax for specifying option
+arguments when saving a preset (e.g. '--opt=arg' and \fInot\fR '--opt arg').
+.RE
+
+.PP
+\fIsave\-global\fR
+.RS 4
+Save a global preset <preset>. <options...> is a sequence of options to be saved in the preset.
 Again, recall that you must use the long option '=' syntax for specifying option
 arguments when saving a preset (e.g. '--opt=arg' and \fInot\fR '--opt arg').
 .RE
@@ -112,10 +152,16 @@ Edit preset "p1" for command "MyCommand":
 $ atlas\-config preset edit MyCommand p1
 .RE
 .sp
-Creates a namespace called "namespace1":
+Create a namespace called "namespace1":
 .sp
 .RS 4
 $ atlas\-config preset namespace create namespace1
+.RE
+.sp
+Save a global preset "p1":
+.sp
+.RS 4
+$ atlas\-config preset save\-global p1 --opt1 --opt2=opt2Arg
 .RE
 .sp
 For more examples, see \fBatlas\-presets\fR(7).

--- a/atlas-shell-tools/man/man1/atlas-config-uninstall.1
+++ b/atlas-shell-tools/man/man1/atlas-config-uninstall.1
@@ -22,38 +22,38 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-uninstall \-\- Uninstall an Atlas Shell Tools module
+atlas\-config\-uninstall \-\- Uninstall Atlas Shell Tools module(s)
 
 .SH "SYNOPSIS"
 .sp
 .nf
 \fIatlas\-config\fR \fIuninstall\fR \-\-help
-\fIatlas\-config\fR \fIuninstall\fR [\-\-force] \-\-all
-\fIatlas\-config\fR \fIuninstall\fR [\-\-force] <\fImodule\fR>
+\fIatlas\-config\fR \fIuninstall\fR \-\-all
+\fIatlas\-config\fR \fIuninstall\fR [\-\-force] <\fImodules...\fR>
 .fi
 
 .SH "DESCRIPTION"
 .sp
-Remove an installed module. If the module is a symlink, this will only
+Remove installed module(s). If the module is a symlink, this will only
 remove the link. It will \fBnot\fR delete the linked\-to file. By default, this
 command will not uninstall an activated module. This can be overridden with the
-\fB\-\-force\fR option.
+\fB\-\-force\fR or \fB\-\-all\fR options.
 
 .SH "OPTIONS"
 .sp
 
 .PP
-<\fImodule\fR>
+<\fImodules...\fR>
 .RS 4
-This indicates a module. The module should be referred to using its name, as
+This indicates one or more modules. The modules should be referred to using their names as
 reported by \fBatlas-config-list\fR(1).
 .RE
 
 .PP
 \fB\-\-all\fR, \fB\-a\fR
 .RS 4
-Uninstall all modules, ignoring the supplied <\fImodule\fR> argument if
-present. This is equivalent to running \fBatlas\-config reset \-\-modules\fR.
+Uninstall all modules including the activated module, ignoring the supplied <\fImodule\fR>
+argument if present. This is equivalent to running \fBatlas\-config reset \-\-modules\fR.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man1/atlas-config-update.1
+++ b/atlas-shell-tools/man/man1/atlas-config-update.1
@@ -22,7 +22,7 @@
 
 .SH "NAME"
 .sp
-atlas\-config\-update \-\- Update Atlas Shell Tools core toolset
+atlas\-config\-update \-\- Update the Atlas Shell Tools core toolkit
 
 .SH "SYNOPSIS"
 .sp
@@ -33,7 +33,7 @@ atlas\-config\-update \-\- Update Atlas Shell Tools core toolset
 
 .SH "DESCRIPTION"
 .sp
-Update the \fBatlas\-shell\-tools\fR(7) core toolset using \fBgit\fR(1). This will not
+Update the \fBatlas\-shell\-tools\fR(7) core toolkit using \fBgit\fR(1). This will not
 actually update any modules. To update modules using your repos, see
 \fBatlas\-config\-repo\fR(1).
 

--- a/atlas-shell-tools/man/man1/atlas-config.1
+++ b/atlas-shell-tools/man/man1/atlas-config.1
@@ -137,7 +137,7 @@ Uninstall a module.
 
 \fBatlas\-config\-update\fR(1)
 .RS 4
-Update Atlas Shell Tools core toolset.
+Update the Atlas Shell Tools core toolkit.
 .RE
 
 .SH "TERMINAL AND ENVIRONMENT"

--- a/atlas-shell-tools/man/man1/atlas.1
+++ b/atlas-shell-tools/man/man1/atlas.1
@@ -32,7 +32,7 @@ atlas \-\- Run an Atlas Shell Tools command
 \fIatlas\fR [\-\-no-pager] \-\-list
 \fIatlas\fR \-\-class\-of=<\fIcommand\fR>
 \fIatlas\fR [\-\-no\-pager] [\-\-debug] [\-\-memory=<amount>] [\-\-preset=<names>] 
-      [\-\-save\-preset=<new\-preset>] <\fIcommand\fR> [arg...]
+      [\-\-save\-preset=<new\-preset>] [\-\-save\-global\-preset=<new\-preset>] <\fIcommand\fR> [arg...]
 .fi
 
 .SH "DESCRIPTION"
@@ -125,6 +125,17 @@ Save the command ARGV to <new\-preset> before running <\fIcommand\fR>. If
 argument to \fB\-\-preset\fR is applied. So <new\-preset> will include ARGV
 elements inserted by the \fB\-\-preset\fR application in addition to those
 directly supplied by the user. See \fBatlas-presets\fR(7) for more information.
+.RE
+
+.PP
+\fB\-\-save\-global\-preset\fR=<new\-preset>
+.RS 4
+This option is the same as \fB\-\-save\-preset\fR, except it will instead save
+<new\-preset> to the global presets instead of the command\-specific presets.
+Note that it can be used in conjuction with \fB\-\-save\-preset\fR to save both
+a global and command preset at the same time. Also like \fB\-\-save\-preset\fR,
+\fB\-\-save\-global\-preset\fR saves ARGV after the the application of
+\fB\-\-preset\fR if present. See \fBatlas-presets\fR(7) for more information.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man1/atlas.1
+++ b/atlas-shell-tools/man/man1/atlas.1
@@ -31,7 +31,7 @@ atlas \-\- Run an Atlas Shell Tools command
 \fIatlas\fR \-\-version
 \fIatlas\fR [\-\-no-pager] \-\-list
 \fIatlas\fR \-\-class\-of=<\fIcommand\fR>
-\fIatlas\fR [\-\-no\-pager] [\-\-debug] [\-\-memory=<amount>] [\-\-preset=<preset>] 
+\fIatlas\fR [\-\-no\-pager] [\-\-debug] [\-\-memory=<amount>] [\-\-preset=<names>] 
       [\-\-save\-preset=<new\-preset>] <\fIcommand\fR> [arg...]
 .fi
 
@@ -104,10 +104,11 @@ Disable pagination for all documentation.
 .RE
 
 .PP
-\fB\-\-preset\fR=<preset>, \fB\-p\fR<preset>
+\fB\-\-preset\fR=<names>, \fB\-p\fR<names>
 .RS 4
-Apply the given preset before running <\fIcommand\fR>. See \fBatlas-presets\fR(7)
-for more information.
+Apply the given preset(s) before running <\fIcommand\fR>. A list of presets
+can be provided by separating preset names with either a colon or a comma.
+See \fBatlas-presets\fR(7) for more information.
 .RE
 
 .PP

--- a/atlas-shell-tools/man/man7/atlas-glossary.7
+++ b/atlas-shell-tools/man/man7/atlas-glossary.7
@@ -124,12 +124,12 @@ More info on repo objects can be found in \fBatlas\-plumbing\fR(5).
 .RE
 
 .sp
-\fBtoolset\fR
+\fBtoolkit\fR
 .RS 4
-Throughout the Atlas Shell Tools documentation, toolset generally refers to the
+Throughout the Atlas Shell Tools documentation, toolkit generally refers to the
 \fBatlas\fR(1) and \fBatlas\-config\fR(1) programs, the manpages included
 in the \fBatlas\-shell\-tools\fR(7) suite, and anything else stored in the directory pointed to
-by the \fBATLAS_SHELL_TOOLS_HOME\fR environment variable. The toolset does \fBnot\fR refer to
+by the \fBATLAS_SHELL_TOOLS_HOME\fR environment variable. The toolkit does \fBnot\fR refer to
 installed modules, repos, or any saved presets.
 .RE
 

--- a/atlas-shell-tools/man/man7/atlas-presets.7
+++ b/atlas-shell-tools/man/man7/atlas-presets.7
@@ -52,24 +52,25 @@ The three interface tiers are:
 
 .SH "TIER 1"
 Tier 1 provides a simple, lightweight interface for preset usage through the \fBatlas\fR(1) options
-\fB\-\-preset\fR=\fIname\fR and \fB\-\-save\-preset\fR=\fInew\-name\fR, where
-\fIname\fR is the name of the preset you would like to apply and \fInew\-name\fR is
+\fB\-\-preset\fR=\fInames\fR and \fB\-\-save\-preset\fR=\fInew\-name\fR, where
+\fInames\fR are the name(s) of the preset(s) you would like to apply and \fInew\-name\fR is
 the name of the preset you would like to create.
 .sp
-When running a command with the \fB\-\-preset\fR=\fIname\fR option,
+When running a command with the \fB\-\-preset\fR=\fInames\fR option,
 \fBatlas\fR(1) checks the list of saved presets associated with that command.
-If one of those presets matches with \fIname\fR, \fBatlas\fR(1) uses that preset. If
-\fBatlas\fR(1) cannot find a match with \fIname\fR, it displays the list and exits
-with an error.
+If one of those presets matches with one of the given \fInames\fR, \fBatlas\fR(1) will apply that
+preset. It will perform this check and application for each preset provided in \fInames\fR (which should
+be comma or colon separated). If one of the given \fInames\fR does not refer to a saved preset,
+\fBatlas\fR(1) displays the list of presets and exits with an error.
 .sp
 When running a command with the \fB\-\-save\-preset\fR=\fInew\-name\fR option,
 \fBatlas\fR attempts to save the current ARGV to a new preset called \fInew\-name\fR.
 If \fInew\-name\fR already exists, \fBatlas\fR(1) will exit with an error.
 .sp
-If both \fB\-\-preset\fR=\fIname\fR and \fB\-\-save\-preset\fR=\fInew\-name\fR
-are applied at the same time, \fBatlas\fR(1) will attempt to apply \fIname\fR before
+If both \fB\-\-preset\fR=\fInames\fR and \fB\-\-save\-preset\fR=\fInew\-name\fR
+are applied at the same time, \fBatlas\fR(1) will attempt to apply \fInames\fR before
 saving \fInew\-name\fR. This allows you to easily save new presets that iterate
-on a previously created preset.
+on previously created presets.
 .sp
 Note that preset names are bound to the target command at save\-time \- 
 a preset name without its command context is meaningless. This means that preset
@@ -107,7 +108,7 @@ $ atlas \-\-preset=p1 MyCommand arg1 arg2 \-\-opt2=OverrideOpt2Arg
 This will run the same command as the above 2 examples, except it will override
 the preset value of \-\-opt2 with your new value "OverrideOpt2Arg".
 .sp
-Finally, you can extend presets by applying and saving at the same time. Here,
+You can extend presets by applying and saving at the same time. Here,
 we apply our preset "p1" while also saving a new preset called "p2", based off
 the contents of "p1":
 .sp
@@ -120,6 +121,16 @@ The new preset "p2" will contain the following contents:
 \-\-opt2 is repeated, this is OK. When multiple instances of the same option are
 supplied, the option parser will use ARGV's rightmost instance of that option.
 .sp
+Let's look at one final example where we apply two presets at once. Assuming you now have
+a preset "p3" with contents: ["\-\-opt3"], you could run:
+.sp
+.RS 4
+$ atlas \-\-preset=p1,p3 MyCommand
+.RE
+.sp
+This would run MyCommand with ["\-\-opt1", "\-\-opt2=opt2Arg", "\-\-opt3"] as the effective ARGV.
+Note that the rightmost ARGV selection strategy for duplicate options applies here as well. Keep this in
+mind when applying multiple presets that contain the same option.
 
 .SH "TIER 2"
 Tier 2 provides more precise preset management using the \fBatlas\-config\fR(1)

--- a/atlas-shell-tools/man/man7/atlas-presets.7
+++ b/atlas-shell-tools/man/man7/atlas-presets.7
@@ -45,6 +45,10 @@ The three interface tiers are:
 .RS 4
 \fBTier 1)\fR Basic preset creation and use with \fBatlas\fR(1) options \fB\-\-save\-preset\fR and \fB\-\-preset\fR.
 
+.RS 8
+\fBGlobal Presets)\fR A brief addendum to Tier 1 about global preset saving.
+.RE
+
 \fBTier 2)\fR More precise preset management with \fBatlas-config-preset\fR(1), including editing, copying, etc.
 
 \fBTier 3)\fR Preset namespace management with the \fBatlas-config-preset\fR(1) \fBnamespace\fR directive.
@@ -132,6 +136,39 @@ This would run MyCommand with ["\-\-opt1", "\-\-opt2=opt2Arg", "\-\-opt3"] as th
 Note that the rightmost ARGV selection strategy for duplicate options applies here as well. Keep this in
 mind when applying multiple presets that contain the same option.
 
+.SS "Global Presets"
+In addition to the presets tied to each command, you can also save global presets
+using the \fBatlas\fR(1) option \fB\-\-save\-global\-preset\fR=\fInew\-name\fR. Global presets
+can be applied to any command using the \fB\-\-preset\fR=\fInames\fR option.
+When checking the \fInames\fR given to \fB\-\-preset\fR, the \fBatlas\fR(1) preset system will always attempt
+to use global presets as a fall back. This means, for example, that if you have a preset "p1" for "MyCommand" as well
+as global presets "p1" and "p2", supplying \fB\-\-preset=p1,p2\fR when running MyCommand will use the "p1" associated with "MyCommand",
+but it will use the global preset "p2".
+.sp
+For the following examples, let's assume we have a command "MyCommand" with a preset "p1". We also have a command
+"AnotherCommand" with no presets. Finally we have global presets "p1" and "p2".
+.sp
+The following will run "MyCommand" with its version of "p1" but with global "p2":
+.sp
+.RS 4
+$ atlas \-\-preset=p1,p2 MyCommand
+.RE
+.sp
+This next command will run "AnotherCommand" with globals "p1" and "p2":
+.sp
+.RS 4
+$ atlas \-\-preset=p1,p2 AnotherCommand
+.RE
+.sp
+Finally, this last command will fail since there is no preset "p3" associated with "MyCommand", nor is
+there a global definition of "p3":
+.sp
+.RS 4
+$ atlas \-\-preset=p1,p2,p3 MyCommand
+.RE
+.sp
+
+
 .SH "TIER 2"
 Tier 2 provides more precise preset management using the \fBatlas\-config\fR(1)
 subcommand \fBpreset\fR. \fBatlas\-config\-preset\fR(1) takes a mandatory \fIdirective\fR,
@@ -158,6 +195,23 @@ when you want to make multiple versions of a long preset, each with some minor d
 
 .sp
 .RS 4
+\fBcopy\-global\fR <source> <destination>
+.RS 4
+Copy global preset <source> into new preset <destination>.
+<destination> must not already exist, else the copy will fail. The following example
+copies the global preset "p1" into new global preset "p2":
+.sp
+.RS 4
+$ atlas\-config preset copy\-global p1 p2
+.RE
+.sp
+Like the \fBcopy\fR directive, the \fBcopy\-global\fR is useful in combination
+with the \fBedit\-global\fR directive for quick preset iteration.
+.RE
+.RE
+
+.sp
+.RS 4
 \fBedit\fR \fIcommand\fR <name>
 .RS 4
 Edit preset <name> for \fIcommand\fR. If <name> does not exist, then it will be
@@ -173,9 +227,24 @@ $ atlas\-config preset edit MyCommand p1
 
 .sp
 .RS 4
+\fBedit\-global\fR <name>
+.RS 4
+Edit global preset <name>. If <name> does not exist, then it will be
+created when the edit is successfully saved. The default preset editor is \fBvim\fR,
+but this can be changed by setting the \fBATLAS_SHELL_TOOLS_EDITOR\fR environment variable.
+The following example will edit global preset "p1":
+.sp
+.RS 4
+$ atlas\-config preset edit\-global p1
+.RE
+.RE
+.RE
+
+.sp
+.RS 4
 \fBlist\fR [\fIcommand\fR [name]]
 .RS 4
-List all available presets, or list all presets for a given [\fIcommand\fR], or
+List all available presets (including globals), or list all presets for a given [\fIcommand\fR], or
 list contents of preset [name] for [\fIcommand\fR]. The following example lists
 all available presets, then lists all presets for "MyCommand", and finally lists
 the contents of preset "p1" for command "MyCommand":
@@ -186,6 +255,23 @@ $ atlas\-config preset list
 $ atlas\-config preset list MyCommand
 
 $ atlas\-config preset list MyCommand p1
+.RE
+.sp
+.RE
+.RE
+
+.sp
+.RS 4
+\fBlist\-global\fR [name]
+.RS 4
+List all available global presets, or list contents of global preset [name]. The
+following example lists all available global presets, then lists the contents of
+global preset "p1":
+.sp
+.RS 4
+$ atlas\-config preset list\-global
+
+$ atlas\-config preset list\-global p1
 .RE
 .sp
 .RE
@@ -222,6 +308,22 @@ $ atlas\-config preset remove AnotherCommand p1
 
 .sp
 .RS 4
+\fBremove\-global\fR [name]
+.RS 4
+Remove all global presets , or remove the global preset [name].
+The following example removes all global presets, then removes globa preset "p1":
+.sp
+.RS 4
+$ atlas\-config preset remove\-global
+
+$ atlas\-config preset remove\-global p1
+.RE
+.sp
+.RE
+.RE
+
+.sp
+.RS 4
 \fBsave\fR \fIcommand\fR <name> <options...>
 .RS 4
 Save a preset <name> for \fIcommand\fR without actually running the command.
@@ -233,6 +335,23 @@ The following example saves preset "p1" to command "MyCommand" with some options
 .sp
 .RS 4
 $ atlas\-config preset save MyCommand p1 --opt1 --opt2=opt2Arg
+.RE
+.sp
+.RE
+.RE
+
+.sp
+.RS 4
+\fBsave\-global\fR <name> <options...>
+.RS 4
+Save a global preset <name>. <options...> is a sequence of options to be savedin the preset.
+Again, recall that you must use the long option '=' syntax for specifying option
+arguments when saving a preset (e.g. '--opt=arg' and \fInot\fR '--opt arg').
+The following example saves global preset "p1" with some options
+--opt1 and --opt2=opt2Arg:
+.sp
+.RS 4
+$ atlas\-config preset save\-global p1 --opt1 --opt2=opt2Arg
 .RE
 .sp
 .RE

--- a/atlas-shell-tools/man/man7/atlas-shell-tools.7
+++ b/atlas-shell-tools/man/man7/atlas-shell-tools.7
@@ -22,13 +22,13 @@
 
 .SH "NAME"
 .sp
-atlas\-shell\-tools \-\- A command line toolset for Atlas and related projects
+atlas\-shell\-tools \-\- A command line toolkit for Atlas and related projects
 
 .SH "SYNOPSIS"
 *
 
 .SH "DESCRIPTION"
-The Atlas Shell Tools are a command line toolset for running commands defined
+The Atlas Shell Tools are a command line toolkit for running commands defined
 in Atlas and related projects. The main tool for running commands is
 \fBatlas\fR(1), and the installation can be configured with \fBatlas\-config\fR(1)
 and its various subcommands.
@@ -93,12 +93,12 @@ Refresh the installation based on the active module
 
 \fBatlas\-config\-uninstall\fR(1)
 .RS 4
-Uninstall a module
+Uninstall Atlas Shell Tools module(s)
 .RE
 
 \fBatlas\-config\-update\fR(1)
 .RS 4
-Update Atlas Shell Tools core toolset
+Update the Atlas Shell Tools core toolkit
 .RE
 
 \fBatlas\-plumbing\fR(5)

--- a/atlas-shell-tools/scripts/atlas
+++ b/atlas-shell-tools/scripts/atlas
@@ -425,6 +425,11 @@ if (defined $use_preset) {
 }
 
 if (defined $save_preset) {
+    unless (ast_preset_subsystem::preset_regex_ok($save_preset)) {
+            ast_utilities::error_output($program_name, "invalid preset name ${bold_stderr}${save_preset}${reset_stderr}");
+            print STDERR "Name must match regex: " . ast_preset_subsystem::preset_regex() . "\n";
+            exit 1;
+    }
     if ($debug_flag) {
         print "Would save preset ${save_preset} for ${subcommand} to namespace ${current_namespace}\n";
         print "Preset ARGV: \"@new_argv\"\n\n";

--- a/atlas-shell-tools/scripts/atlas
+++ b/atlas-shell-tools/scripts/atlas
@@ -248,12 +248,12 @@ my $help_argument;
 my $show_list;
 my $class_of;
 my $save_preset;
+my $save_global_preset;
 my $use_preset;
 my $remove_preset;
 my $all_presets;
 my $show_preset;
 my $edit_preset;
-my $cfg_preset;
 my $allow_run_as_root;
 Getopt::Long::Configure(qw(no_ignore_case_always));
 GetOptions(
@@ -264,13 +264,14 @@ GetOptions(
         print "$program_version\n";
         exit 0;
     },
-    "quiet|q"           => \$quiet,
-    "list|l"            => \$show_list,
-    "class-of=s"        => \$class_of,
-    "preset|p=s"        => \$use_preset,
-    "save-preset=s"     => \$save_preset,
-    "debug"             => \$debug_flag,
-    "allow-run-as-root" => \$allow_run_as_root,
+    "quiet|q"               => \$quiet,
+    "list|l"                => \$show_list,
+    "class-of=s"            => \$class_of,
+    "preset|p=s"            => \$use_preset,
+    "save-preset=s"         => \$save_preset,
+    "save-global-preset=s"  => \$save_global_preset,
+    "debug"                 => \$debug_flag,
+    "allow-run-as-root"     => \$allow_run_as_root,
     # This callback occurs the first time we see a non-option argument.
     # In our case, this will be the subcommand.
     "<>"                => sub {
@@ -360,16 +361,6 @@ if ($debug_flag) {
     print "---- ATLAS DEBUG MODE ----\n";
 }
 
-# Handle the case where the user supplied the cfg.preset arg. When this happens,
-# then any arg after it should be passed forward to the cfg.preset handler
-if (defined $cfg_preset) {
-    my $success = atlas_cfgpreset($debug_flag, \@ARGV);
-    unless ($success) {
-        exit 1;
-    }
-    exit 0;
-}
-
 # Handle case where user entered --help=TOPIC flag
 # We waited until after verifying that a command index exists
 if (defined $help_argument) {
@@ -419,8 +410,7 @@ my $current_namespace = ast_preset_subsystem::get_namespace($ast_path);
 if (defined $use_preset) {
     @new_argv = ast_preset_subsystem::apply_preset_or_exit($ast_path, $program_name, $quiet, $use_preset, $subcommand, $current_namespace, \@ARGV);
     if ($debug_flag) {
-        print "Applying preset ${use_preset} for ${subcommand} in namespace ${current_namespace}\n";
-        print "Try \'${bold_stdout}${ast_utilities::CONFIG_PROGRAM} preset list ${subcommand} ${use_preset}${reset_stdout}\' to see the preset.\n\n";
+        print "Applying preset(s) ${use_preset} for ${subcommand} in namespace ${current_namespace}\n";
     }
 }
 
@@ -436,6 +426,25 @@ if (defined $save_preset) {
     }
     else {
         my $success = ast_preset_subsystem::save_preset($ast_path, $program_name, $quiet, $save_preset, $subcommand, $current_namespace, \@new_argv);
+        unless ($success) {
+            exit 1;
+        }
+        print "Launching command ${bold_stdout}${subcommand}${reset_stdout}...\n\n";
+    }
+}
+
+if (defined $save_global_preset) {
+    unless (ast_preset_subsystem::preset_regex_ok($save_global_preset)) {
+            ast_utilities::error_output($program_name, "invalid preset name ${bold_stderr}${save_global_preset}${reset_stderr}");
+            print STDERR "Name must match regex: " . ast_preset_subsystem::preset_regex() . "\n";
+            exit 1;
+    }
+    if ($debug_flag) {
+        print "Would save global preset ${save_global_preset} to namespace ${current_namespace}\n";
+        print "Preset ARGV: \"@new_argv\"\n\n";
+    }
+    else {
+        my $success = ast_preset_subsystem::save_preset($ast_path, $program_name, $quiet, $save_global_preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace, \@new_argv);
         unless ($success) {
             exit 1;
         }

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -294,11 +294,11 @@ sub execute_command_install {
 sub execute_command_list {
     my $current = 0;
     my $help_flag;
-    my $verbose = 0;
+    my $one_line = 0;
     GetOptions(
         'current|c' => \$current,
         'help|h'    => \$help_flag,
-        'verbose|v' => \$verbose
+        'one-line|1' => \$one_line
     ) or ast_utilities::getopt_failure_and_exit($program_name, "list");
 
     if (defined $help_flag) {
@@ -380,7 +380,7 @@ sub execute_command_list {
 
         print "$display\n";
 
-        if ($verbose) {
+        unless ($one_line) {
             if (%module_metadata) {
                 foreach my $metadata_key (sort {lc $a cmp lc $b} keys %module_metadata) {
                     print "          ${metadata_key}: $module_metadata{$metadata_key}\n";
@@ -389,7 +389,7 @@ sub execute_command_list {
             print "\n";
         }
     }
-    unless ($verbose) {
+    if ($one_line) {
         print "\n";
     }
 

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -632,6 +632,7 @@ sub execute_command_preset {
         }
         unless (ast_preset_subsystem::preset_regex_ok($preset)) {
             ast_utilities::error_output($program_name . ": preset", "invalid preset name ${bold_stderr}${preset}${reset_stderr}");
+            print STDERR "Name must match regex: " . ast_preset_subsystem::preset_regex() . "\n";
             print STDERR "Usage: ${bold_stderr}${program_name} preset save <command> <preset> <options...>${reset_stderr}\n";
             print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
             return 0;

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -315,6 +315,7 @@ sub execute_command_list {
     unless (keys %modules) {
         ast_utilities::error_output($program_name . ": list", "found no installed modules");
         print STDERR "Try '${bold_stderr}${program_name} install /path/to/module.jar${reset_stderr}' to install a module.\n";
+        print STDERR "Or try '${bold_stderr}${program_name} repo install atlas${reset_stderr}' to install the commands from the atlas repo.\n";
         return 0;
     }
 
@@ -542,6 +543,23 @@ sub execute_command_preset {
         }
         $success = ast_preset_subsystem::copy_preset($ast_path, $program_name, $quiet, $src_preset, $dest_preset, $command_context, $current_namespace);
     }
+    elsif ($directive eq 'copy-global') {
+        my $src_preset = shift @ARGV;
+        my $dest_preset = shift @ARGV;
+        unless (defined $src_preset) {
+            ast_utilities::error_output($program_name . ": preset", "must specify a source preset");
+            print STDERR "Usage: ${bold_stderr}${program_name} preset copy-global <src> <dest>${reset_stderr}\n";
+            print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
+            return 0;
+        }
+        unless (defined $dest_preset) {
+            ast_utilities::error_output($program_name . ": preset", "must specify a destination preset");
+            print STDERR "Usage: ${bold_stderr}${program_name} preset copy-global <src> <dest>${reset_stderr}\n";
+            print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
+            return 0;
+        }
+        $success = ast_preset_subsystem::copy_preset($ast_path, $program_name, $quiet, $src_preset, $dest_preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
+    }
     elsif ($directive eq 'edit') {
         my $command_context = shift @ARGV;
         unless (defined $command_context) {
@@ -565,6 +583,16 @@ sub execute_command_preset {
         }
         $success = ast_preset_subsystem::edit_preset($ast_path, $program_name, $quiet, $preset, $command_context, $current_namespace);
     }
+    elsif ($directive eq 'edit-global') {
+        my $preset = shift @ARGV;
+        unless (defined $preset) {
+            ast_utilities::error_output($program_name . ": preset", "must specify a preset");
+            print STDERR "Usage: ${bold_stderr}${program_name} preset edit-global <preset>${reset_stderr}\n";
+            print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
+            return 0;
+        }
+        $success = ast_preset_subsystem::edit_preset($ast_path, $program_name, $quiet, $preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
+    }
     elsif ($directive eq 'list') {
         my $command_context = shift @ARGV;
         unless (defined $command_context) {
@@ -582,6 +610,15 @@ sub execute_command_preset {
         }
         else {
             $success = ast_preset_subsystem::all_presets_for_command($ast_path, $program_name, $quiet, $command_context, $current_namespace);
+        }
+    }
+    elsif ($directive eq 'list-global') {
+        my $preset = shift @ARGV;
+        if (defined $preset) {
+            $success = ast_preset_subsystem::show_preset($ast_path, $program_name, $quiet, $preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
+        }
+        else {
+            $success = ast_preset_subsystem::all_presets_for_command($ast_path, $program_name, $quiet, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
         }
     }
     elsif ($directive eq 'namespace') {
@@ -607,6 +644,15 @@ sub execute_command_preset {
         }
         else {
             $success = ast_preset_subsystem::remove_all_presets_for_command($ast_path, $program_name, $quiet, $command_context, $current_namespace);
+        }
+    }
+    elsif ($directive eq 'remove-global') {
+        my $preset = shift @ARGV;
+        if (defined $preset) {
+            $success = ast_preset_subsystem::remove_preset($ast_path, $program_name, $quiet, $preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
+        }
+        else {
+            $success = ast_preset_subsystem::remove_all_presets_for_command($ast_path, $program_name, $quiet, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace);
         }
     }
     elsif ($directive eq 'save') {
@@ -639,9 +685,26 @@ sub execute_command_preset {
         }
         $success = ast_preset_subsystem::save_preset($ast_path, $program_name, $quiet, $preset, $command_context, $current_namespace, \@ARGV);
     }
+    elsif ($directive eq 'save-global') {
+        my $preset = shift @ARGV;
+        unless (defined $preset) {
+            ast_utilities::error_output($program_name . ": preset", "must specify a preset");
+            print STDERR "Usage: ${bold_stderr}${program_name} preset save-global <preset> <options...>${reset_stderr}\n";
+            print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
+            return 0;
+        }
+        unless (ast_preset_subsystem::preset_regex_ok($preset)) {
+            ast_utilities::error_output($program_name . ": preset", "invalid preset name ${bold_stderr}${preset}${reset_stderr}");
+            print STDERR "Name must match regex: " . ast_preset_subsystem::preset_regex() . "\n";
+            print STDERR "Usage: ${bold_stderr}${program_name} preset save-global <preset> <options...>${reset_stderr}\n";
+            print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
+            return 0;
+        }
+        $success = ast_preset_subsystem::save_preset($ast_path, $program_name, $quiet, $preset, $ast_preset_subsystem::GLOBAL_FOLDER, $current_namespace, \@ARGV);
+    }
     else {
         ast_utilities::error_output($program_name . ": preset", "unrecognized ${bold_stderr}${program_name} preset${reset_stderr} directive '${bold_stderr}${directive}${reset_stderr}'");
-        print STDERR "Available directives: ${bold_stderr}copy${reset_stderr}, ${bold_stderr}edit${reset_stderr}, ${bold_stderr}list${reset_stderr}, ${bold_stderr}namespace${reset_stderr}, ${bold_stderr}remove${reset_stderr}, or ${bold_stderr}save${reset_stderr}\n";
+        print STDERR "Available directives: ${bold_stderr}copy[-global]${reset_stderr}, ${bold_stderr}edit[-global]${reset_stderr}, ${bold_stderr}list[-global]${reset_stderr}, ${bold_stderr}namespace${reset_stderr}, ${bold_stderr}remove[-global]${reset_stderr}, or ${bold_stderr}save[-global]${reset_stderr}\n";
         print STDERR "Try \'${bold_stderr}${program_name} preset --help${reset_stderr}\' for more information.\n";
         return 0;
     }
@@ -886,6 +949,14 @@ sub execute_command_sync {
     my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
     my %modules_links = ast_module_subsystem::get_module_to_symlink_hash($ast_path);
     my @activated_modules = ast_module_subsystem::get_activated_modules(\%modules);
+
+    if (scalar @activated_modules == 0) {
+        ast_utilities::error_output($program_name . ": sync", 'found no activated module');
+        print STDERR "To see installed modules, try '${bold_stderr}${ast_utilities::CONFIG_PROGRAM} list${reset_stderr}'.\n";
+        print STDERR "Then run '${bold_stderr}${ast_utilities::CONFIG_PROGRAM} activate <module>${reset_stderr}' to activate <module>.\n";
+        return 0;
+    }
+
     # If the currently active module is a broken symlink, warn the user
     if ($modules_links{$activated_modules[0]} == $ast_module_subsystem::BROKEN_SYMLINK) {
         ast_utilities::error_output($program_name . ": sync", 'current active module is a broken symlink');
@@ -896,6 +967,8 @@ sub execute_command_sync {
 
     ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
     ast_module_subsystem::generate_active_module_index($ast_path, $program_name, $quiet, 1);
+
+    return 1;
 }
 
 sub execute_command_uninstall {

--- a/atlas-shell-tools/scripts/atlas-config
+++ b/atlas-shell-tools/scripts/atlas-config
@@ -839,6 +839,7 @@ sub execute_command_reset {
             foreach my $module (keys %modules) {
                 ast_module_subsystem::perform_uninstall($module, $ast_path, $program_name, $quiet, 1);
             }
+            ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
         }
         $ran_at_least_one_directive = 1;
     }
@@ -913,8 +914,9 @@ sub execute_command_uninstall {
     if (defined $allflag) {
         my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
         foreach my $module (keys %modules) {
-            ast_module_subsystem::perform_uninstall($module, $ast_path, $program_name, $quiet, $forceflag);
+            ast_module_subsystem::perform_uninstall($module, $ast_path, $program_name, $quiet, 1);
         }
+        ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
         return 1;
     }
 
@@ -927,15 +929,16 @@ sub execute_command_uninstall {
     my %modules = ast_module_subsystem::get_module_to_status_hash($ast_path);
     my @activated_modules = ast_module_subsystem::get_activated_modules(\%modules);
     my $activated_module = $activated_modules[0];
-    my $success = ast_module_subsystem::perform_uninstall($module_to_uninstall, $ast_path, $program_name, $quiet, $forceflag);
-    unless ($success) {
-        return 0;
-    }
 
-    if (defined $activated_module) {
-        if ($module_to_uninstall eq $activated_module) {
-            ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
+    while (defined $module_to_uninstall) {
+        my $success = ast_module_subsystem::perform_uninstall($module_to_uninstall, $ast_path, $program_name, $quiet, $forceflag);
+        unless ($success) {
+            ast_utilities::error_output($program_name . ": uninstall", "failed to uninstall ${bold_stderr}${module_to_uninstall}${reset_stderr}");
         }
+        elsif (defined $activated_module && $module_to_uninstall eq $activated_module) {
+                ast_module_subsystem::remove_active_module_index($ast_path, $program_name, $quiet);
+        }
+        $module_to_uninstall = shift @ARGV;
     }
 
     return 1;

--- a/atlas-shell-tools/scripts/common/ast_completions.pm
+++ b/atlas-shell-tools/scripts/common/ast_completions.pm
@@ -103,7 +103,7 @@ sub completion_atlas {
     # Autocomplete the '--preset' and '--save-preset' flags, since they are probably the most used flags
     # TODO FIXME this will do strange things when completing subcommand options, since it's not positionally-aware
     if (ast_utilities::string_starts_with($rargv, '-')) {
-        my @flags = qw(--preset --save-preset);
+        my @flags = qw(--preset --save-preset --save-global-preset);
         my @completion_matches = completion_match_prefix($rargv, \@flags);
         print join("\n", @completion_matches) . "\n";
         return 1;
@@ -258,7 +258,7 @@ sub completion_atlascfg {
 
     # 'atlas-config preset' command will complete 'preset' subcommands
     elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'preset')) {
-        @commands = qw(save edit remove list namespace copy);
+        @commands = qw(save save-global edit edit-global remove remove-global list list-global namespace copy copy-global);
     }
 
     # 'atlas-config preset save' command will complete atlas shell tools commands
@@ -276,6 +276,11 @@ sub completion_atlascfg {
         @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $rargv_m1);
     }
 
+    # 'atlas-config preset edit-global' command will complete any global presets
+    elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'edit-global')) {
+        @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $ast_preset_subsystem::GLOBAL_FOLDER);
+    }
+
     # 'atlas-config preset remove' command will complete atlas shell tools commands
     elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'remove')) {
         @commands = keys %subcommand_classes;
@@ -286,6 +291,11 @@ sub completion_atlascfg {
         @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $rargv_m1);
     }
 
+    # 'atlas-config preset remove-global' command will complete any global presets
+    elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'remove-global')) {
+        @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $ast_preset_subsystem::GLOBAL_FOLDER);
+    }
+
     # 'atlas-config preset list' command will complete atlas shell tools commands
     elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'list')) {
         @commands = keys %subcommand_classes;
@@ -294,6 +304,11 @@ sub completion_atlascfg {
     # 'atlas-config preset list <command>' command will complete any presets for <command>
     elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m3 && $rargv_m3 eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'list') && (defined $rargv_m1)) {
         @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $rargv_m1);
+    }
+
+    # 'atlas-config preset list-global' will complete any global presets
+    elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'list-global')) {
+        @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $ast_preset_subsystem::GLOBAL_FOLDER);
     }
 
     # 'atlas-config preset namespace' command will complete 'namespace' subcommands
@@ -324,6 +339,11 @@ sub completion_atlascfg {
     # 'atlas-config preset copy <command>' command will complete any presets for <command>
     elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m3 && $rargv_m3 eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'copy') && (defined $rargv_m1)) {
         @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $rargv_m1);
+    }
+
+    # 'atlas-config preset copy-global' command will complete any global presets
+    elsif ((defined $argv[0] && $argv[0] eq 'preset') && (defined $rargv_m2 && $rargv_m2 eq 'preset') && (defined $rargv_m1 && $rargv_m1 eq 'copy-global')) {
+        @commands = ast_preset_subsystem::get_all_presets_for_command($ast_path, $ast_preset_subsystem::GLOBAL_FOLDER);
     }
 
     # 'atlas-config log' command will complete log subcommands

--- a/atlas-shell-tools/scripts/common/ast_completions.pm
+++ b/atlas-shell-tools/scripts/common/ast_completions.pm
@@ -216,8 +216,8 @@ sub completion_atlascfg {
         @commands = ast_module_subsystem::get_activated_modules(\%modules);
     }
 
-    # 'atlas-config uninstall' command will complete all modules
-    elsif ((defined $argv[0] && $argv[0] eq 'uninstall') && (defined $rargv_m1 && $rargv_m1 eq 'uninstall')) {
+    # 'atlas-config uninstall' command will complete all modules as many times as desired
+    elsif ((defined $argv[0] && $argv[0] eq 'uninstall')) {
         @commands = keys %modules;
     }
 

--- a/atlas-shell-tools/scripts/common/ast_preset_subsystem.pm
+++ b/atlas-shell-tools/scripts/common/ast_preset_subsystem.pm
@@ -35,11 +35,13 @@ our @EXPORT = qw(
     remove_namespace
     get_all_presets_in_current_namespace
     get_all_presets_for_command
+    get_all_global_presets
     preset_regex_ok
     preset_regex
 );
 
 our $PRESETS_FOLDER = 'presets';
+our $GLOBAL_FOLDER = '.global';
 
 our $CURRENT_NAMESPACE_FILE = '.current_namespace';
 our $NAMESPACE_PATH = File::Spec->catfile($PRESETS_FOLDER, $CURRENT_NAMESPACE_FILE);
@@ -134,7 +136,11 @@ sub save_preset {
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
     if (-f $preset_file) {
-        ast_utilities::error_output($program_name, "preset ${bold_stderr}${preset}${reset_stderr} already exists for ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "global preset ${bold_stderr}${preset}${reset_stderr} already exists");
+        } else {
+            ast_utilities::error_output($program_name, "preset ${bold_stderr}${preset}${reset_stderr} already exists for ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
@@ -168,7 +174,11 @@ sub save_preset {
         return 0;
     }
 
-    print "Preset ${bold_stdout}${preset}${reset_stdout} for command ${bold_stdout}${command}${reset_stdout}:\n";
+    if ($command eq $GLOBAL_FOLDER) {
+        print "Global preset ${bold_stdout}${preset}${reset_stdout}:\n";
+    } else {
+        print "Preset ${bold_stdout}${preset}${reset_stdout} for command ${bold_stdout}${command}${reset_stdout}:\n";
+    }
     print "\n${bunl_stdout}Preset ARGV${eunl_stdout}${reset_stdout}\n";
     open my $file_handle, '>', "$preset_file";
     foreach my $option (@detected_options) {
@@ -178,7 +188,11 @@ sub save_preset {
     close $file_handle;
 
     unless ($quiet) {
-        print "\nPreset ${bold_stdout}${preset}${reset_stdout} saved for command ${bold_stdout}${command}${reset_stdout}.\n";
+        if ($command eq $GLOBAL_FOLDER) {
+            print "\nGlobal preset ${bold_stdout}${preset}${reset_stdout} saved.\n";
+        } else {
+            print "\nPreset ${bold_stdout}${preset}${reset_stdout} saved for command ${bold_stdout}${command}${reset_stdout}.\n";
+        }
     }
 
     return 1;
@@ -205,14 +219,24 @@ sub remove_preset {
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
     unless (-f $preset_file) {
-        ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "no such global preset ${bold_stderr}${preset}${reset_stderr}");
+        }
+        else {
+            ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
     unlink $preset_file;
 
     unless ($quiet) {
-        print "Removed preset ${bold_stdout}${preset}${reset_stdout} for ${bold_stdout}${command}${reset_stdout}.\n";
+        if ($command eq $GLOBAL_FOLDER) {
+            print "Removed global preset ${bold_stdout}${preset}${reset_stdout}.\n";
+        }
+        else {
+            print "Removed preset ${bold_stdout}${preset}${reset_stdout} for ${bold_stdout}${command}${reset_stdout}.\n";
+        }
     }
 
     if (ast_utilities::is_dir_empty($preset_subfolder)) {
@@ -240,14 +264,23 @@ sub remove_all_presets_for_command {
     my $preset_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $command);
 
     unless (-d $preset_subfolder) {
-        ast_utilities::error_output($program_name, "no presets found for command ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "no global presets found");
+        } else {
+            ast_utilities::error_output($program_name, "no presets found for command ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
     rmtree($preset_subfolder);
 
     unless ($quiet) {
-        print "Removed all presets for ${bold_stdout}${command}${reset_stdout}.\n";
+        if ($command eq $GLOBAL_FOLDER) {
+            print "Removed all global presets.\n";
+        }
+        else {
+            print "Removed all presets for ${bold_stdout}${command}${reset_stdout}.\n";
+        }
     }
 
     return 1;
@@ -271,6 +304,9 @@ sub all_presets_for_command {
     my $preset_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $command);
 
     unless (-d $preset_subfolder) {
+        if ($command eq $GLOBAL_FOLDER) {
+            die "no global presets folder found in namespace ${namespace}";
+        }
         ast_utilities::error_output($program_name, "no presets found for ${bold_stderr}${command}${reset_stderr}");
         return 0;
     }
@@ -288,12 +324,18 @@ sub all_presets_for_command {
     }
 
     if (scalar @filtered_presets == 0) {
-        ast_utilities::error_output($program_name, "no presets found for ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            return 0;
+        }
         return 0;
     }
 
-    print "Command ${bold_stdout}${command}${reset_stdout} presets:\n\n";
-    for my $found_preset (sort {lc $a cmp lc $b} @filtered_presets) {
+    if ($command eq $GLOBAL_FOLDER) {
+        print "Global presets:\n\n";
+    } else {
+        print "Command ${bold_stdout}${command}${reset_stdout} presets:\n\n";
+    }
+    foreach my $found_preset (sort {lc $a cmp lc $b} @filtered_presets) {
         print "    ${bold_stdout}${found_preset}${reset_stdout}\n";
     }
     print "\n";
@@ -327,18 +369,25 @@ sub all_presets {
         return 0;
     }
 
-    print "${bunl_stdout}Presets in namespace ${bold_stdout}${namespace}${reset_stdout}${eunl_stdout}\n\n";
-
     opendir my $namespace_dir_handle, $namespace_folder or die "Something went wrong opening dir: $!";
     my @command_folders = readdir $namespace_dir_handle;
     closedir $namespace_dir_handle;
 
+    my $found_at_least_one = 0;
     foreach my $found_command (@command_folders) {
         my $command_folder = File::Spec->catfile($namespace_folder, $found_command);
-        # we need to filter '.', '..'
-        unless ($found_command eq '.' || $found_command eq '..') {
-            all_presets_for_command($ast_path, $program_name, $quiet, $found_command, $namespace);
+        # we need to filter '.', '..', and the '.global' folder
+        unless ($found_command eq '.' || $found_command eq '..' || $found_command eq $GLOBAL_FOLDER) {
+            $found_at_least_one |= all_presets_for_command($ast_path, $program_name, $quiet, $found_command, $namespace);
         }
+    }
+
+    my $global_folder = File::Spec->catfile($namespace_folder, $GLOBAL_FOLDER);
+    $found_at_least_one |= all_presets_for_command($ast_path, $program_name, $quiet, $GLOBAL_FOLDER, $namespace);
+
+    unless ($found_at_least_one) {
+        ast_utilities::error_output($program_name, "no presets found");
+        return 0;
     }
 
     return 1;
@@ -365,12 +414,20 @@ sub show_preset {
     my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
 
     unless (-f $preset_file) {
-        ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "no such global preset ${bold_stderr}${preset}${reset_stderr}");
+        } else {
+            ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
     my @presets_from_file = read_preset($ast_path, $program_name, $quiet, $preset, $command, $namespace);
-    print "Preset ${bold_stdout}${preset}${reset_stdout} for command ${bold_stdout}${command}${reset_stdout}:\n";
+    if ($command eq $GLOBAL_FOLDER) {
+        print "Global preset ${bold_stdout}${preset}${reset_stdout}:\n";
+    } else {
+        print "Preset ${bold_stdout}${preset}${reset_stdout} for command ${bold_stdout}${command}${reset_stdout}:\n";
+    }
     print "\n${bunl_stdout}Preset ARGV${eunl_stdout}${reset_stdout}\n";
     for my $preset_from_file (@presets_from_file) {
         print "${bold_stdout}${preset_from_file}${reset_stderr}\n";
@@ -526,12 +583,21 @@ sub copy_preset {
     my $dest_file = File::Spec->catfile($preset_subfolder, $dest_preset);
 
     unless (-e $source_file) {
-        ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${src_preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "no such global preset ${bold_stderr}${src_preset}${reset_stderr}");
+        } else {
+            ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${src_preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
     if (-e $dest_file) {
-        ast_utilities::error_output($program_name, "preset ${bold_stderr}${dest_preset}${reset_stderr} already exists for ${bold_stderr}${command}${reset_stderr}");
+        if ($command eq $GLOBAL_FOLDER) {
+            ast_utilities::error_output($program_name, "global preset ${bold_stderr}${dest_preset}${reset_stderr} already exists");
+        }
+        else {
+            ast_utilities::error_output($program_name, "preset ${bold_stderr}${dest_preset}${reset_stderr} already exists for ${bold_stderr}${command}${reset_stderr}");
+        }
         return 0;
     }
 
@@ -590,18 +656,30 @@ sub apply_preset_or_exit {
     }
 
     my @final_argv = ();
+    my $use_global = 0;
     foreach my $preset (@presets_array) {
         my $preset_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $command);
         my $preset_file = File::Spec->catfile($preset_subfolder, $preset);
         unless (-f $preset_file) {
-            ast_utilities::error_output($program_name, "no such preset ${bold_stderr}${preset}${reset_stderr} for command ${bold_stderr}${command}${reset_stderr}");
-            all_presets_for_command($ast_path, $program_name, $quiet, $command, $namespace);
-            exit 1;
+            # Fall back and try global presets
+            my $global_subfolder = File::Spec->catfile($ast_path, $PRESETS_FOLDER, $namespace, $GLOBAL_FOLDER);
+            my $global_file = File::Spec->catfile($global_subfolder, $preset);
+            unless (-f $global_file) {
+                ast_utilities::error_output($program_name, "preset ${bold_stderr}${preset}${reset_stderr} not found for command ${bold_stderr}${command}${reset_stderr}");
+                ast_utilities::error_output($program_name, "preset ${bold_stderr}${preset}${reset_stderr} not found in globals");
+                all_presets_for_command($ast_path, $program_name, $quiet, $command, $namespace);
+                all_presets_for_command($ast_path, $program_name, $quiet, $GLOBAL_FOLDER, $namespace);
+                exit 1;
+            }
+            $use_global = 1;
         }
 
-        my @argv_from_presets = read_preset($ast_path, $program_name, $quiet, $preset, $command, $namespace);
-
-
+        my @argv_from_presets = ();
+        if ($use_global) {
+            @argv_from_presets = read_preset($ast_path, $program_name, $quiet, $preset, $GLOBAL_FOLDER, $namespace);
+        } else {
+            @argv_from_presets = read_preset($ast_path, $program_name, $quiet, $preset, $command, $namespace);
+        }
         foreach my $preset_argv_elem (@argv_from_presets) {
             push @final_argv, $preset_argv_elem;
         }
@@ -729,6 +807,7 @@ sub create_namespace {
     my $current_namespace = get_namespace($ast_path);
     my $preset_folder = File::Spec->catfile($ast_path, $PRESETS_FOLDER);
     my $new_namespace_folder = File::Spec->catfile($preset_folder, $new_namespace);
+    my $global_folder = File::Spec->catfile($preset_folder, $new_namespace, $GLOBAL_FOLDER);
 
     unless (-d $preset_folder) {
         die "The folder $PRESETS_FOLDER did not exist at $ast_path";
@@ -740,6 +819,11 @@ sub create_namespace {
     }
 
     make_path("$new_namespace_folder", {
+        verbose => 0,
+        mode    => 0755
+    });
+
+    make_path("$global_folder", {
         verbose => 0,
         mode    => 0755
     });
@@ -830,7 +914,7 @@ sub remove_namespace {
     return 1;
 }
 
-# Get an array of all presets in the current namespace.
+# Get an array of all presets in the current namespace, including global presets.
 # Params:
 #   $ast_path: the path to the atlas-shell-tools data folder
 # Return: the preset array
@@ -842,6 +926,7 @@ sub get_all_presets_in_current_namespace {
 
     my $preset_folder = File::Spec->catfile($ast_path, $PRESETS_FOLDER);
     my $namespace_folder = File::Spec->catfile($preset_folder, $namespace);
+    my $global_folder = File::Spec->catfile($namespace_folder, $GLOBAL_FOLDER);
 
     opendir my $namespace_dir_handle, $namespace_folder or die "Something went wrong opening dir: $!";
     my @command_folders = readdir $namespace_dir_handle;
@@ -861,6 +946,17 @@ sub get_all_presets_in_current_namespace {
                     push @all_presets, $found_preset;
                 }
             }
+        }
+    }
+
+    opendir my $global_dir_handle, $global_folder or die "Something went wrong opening dir: $!";
+    my @preset_files = readdir $global_dir_handle;
+    closedir $global_dir_handle;
+
+    foreach my $found_preset (@preset_files) {
+        # we need to filter '.', '..'
+        unless ($found_preset eq '.' || $found_preset eq '..') {
+            push @all_presets, $found_preset;
         }
     }
 
@@ -890,6 +986,38 @@ sub get_all_presets_for_command {
     opendir my $command_dir_handle, $command_folder or die "Something went wrong opening dir: $!";
     my @preset_files = readdir $command_dir_handle;
     closedir $command_dir_handle;
+
+    foreach my $found_preset (@preset_files) {
+        # we need to filter '.', '..'
+        unless ($found_preset eq '.' || $found_preset eq '..') {
+            push @all_presets, $found_preset;
+        }
+    }
+
+    return @all_presets;
+}
+
+# Get an array of all global presets in the current namespace
+# Params:
+#   $ast_path: the path to the atlas-shell-tools data folder
+# Return: the preset array
+sub get_all_global_presets {
+    my $ast_path = shift;
+
+    my $namespace = get_namespace($ast_path);
+    my @all_presets = ();
+
+    my $preset_folder = File::Spec->catfile($ast_path, $PRESETS_FOLDER);
+    my $namespace_folder = File::Spec->catfile($preset_folder, $namespace);
+    my $global_folder = File::Spec->catfile($namespace_folder, $GLOBAL_FOLDER);
+
+    unless (-d $global_folder) {
+        return @all_presets;
+    }
+
+    opendir my $global_dir_handle, $global_folder or die "Something went wrong opening dir: $!";
+    my @preset_files = readdir $global_dir_handle;
+    closedir $global_dir_handle;
 
     foreach my $found_preset (@preset_files) {
         # we need to filter '.', '..'

--- a/atlas-shell-tools/scripts/common/ast_utilities.pm
+++ b/atlas-shell-tools/scripts/common/ast_utilities.pm
@@ -144,6 +144,16 @@ sub create_data_directory {
         ast_preset_subsystem::reset_namespace($data_directory);
     }
 
+    # add a .global folder to all namespaces if it is missing
+    my @namespaces = ast_preset_subsystem::get_namespaces_array($data_directory);
+    foreach my $namespace (@namespaces) {
+        my $global_subfolder = File::Spec->catfile($data_directory, $ast_preset_subsystem::PRESETS_FOLDER, $namespace, $ast_preset_subsystem::GLOBAL_FOLDER);
+        make_path("$global_subfolder", {
+            verbose => 0,
+            mode    => 0755
+        });
+    }
+
     return $data_directory;
 }
 


### PR DESCRIPTION
### Description:
This PR:
- Fixes a bug with `atlas` command preset completion
- Supports a global presets feature
- `--preset` option now supports multiple presets at once like `--preset=p1,p2` or `--preset=p1:p2`
- `atlas-config uninstall` can uninstall multiple modules
- `atlas-config list` now shows metadata by default

### Potential Impact:
Users have more features!

### Unit Test Approach:
Again, extensive command line testing.

### Test Results:
All good!

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
