### PR TITLE
Fixed bug with FeatureChange JSON serialization

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/serializer/FeatureChangeGeoJsonSerializer.java
@@ -207,7 +207,6 @@ public class FeatureChangeGeoJsonSerializer
         return result;
     };
 
-    private static final String NULL = "null";
     private final Gson jsonSerializer;
 
     private static <T> void add(final JsonObject result, final String name, final T property,
@@ -215,7 +214,7 @@ public class FeatureChangeGeoJsonSerializer
     {
         if (property == null)
         {
-            result.addProperty(name, NULL);
+            result.addProperty(name, (String) null);
         }
         else
         {
@@ -226,7 +225,7 @@ public class FeatureChangeGeoJsonSerializer
     private static <T> void addProperty(final JsonObject result, final String name,
             final T property, final Function<T, ? extends Object> writer)
     {
-        result.addProperty(name, property == null ? NULL : writer.apply(property).toString());
+        result.addProperty(name, property == null ? null : writer.apply(property).toString());
     }
 
     public FeatureChangeGeoJsonSerializer(final boolean prettyPrint, final boolean showDescription)

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaNull.json
@@ -41,8 +41,8 @@
     "entityType": "AREA",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteArea",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "POLYGON ((-122.0310473 37.3909505, -122.0314121 37.3903197, -122.0311332 37.3901066, -122.0306289 37.3908482, -122.0310473 37.3909505, -122.0310473 37.3909505))",
     "bboxWKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaNull.json
@@ -41,8 +41,6 @@
     "entityType": "AREA",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteArea",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "POLYGON ((-122.0310473 37.3909505, -122.0314121 37.3903197, -122.0311332 37.3901066, -122.0306289 37.3908482, -122.0310473 37.3909505, -122.0310473 37.3909505))",
     "bboxWKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaRemove.json
@@ -41,8 +41,8 @@
     "entityType": "AREA",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteArea",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))",
     "bboxWKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAreaRemove.json
@@ -41,8 +41,6 @@
     "entityType": "AREA",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteArea",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))",
     "bboxWKT": "POLYGON ((-122.0314121 37.3901066, -122.0314121 37.3909505, -122.0306289 37.3909505, -122.0306289 37.3901066, -122.0314121 37.3901066))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeNull.json
@@ -39,10 +39,6 @@
     "entityType": "EDGE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
-    "startNode": null,
-    "endNode": null,
     "WKT": "LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535)",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeNull.json
@@ -39,10 +39,10 @@
     "entityType": "EDGE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
-    "startNode": "null",
-    "endNode": "null",
+    "tags": null,
+    "relations": null,
+    "startNode": null,
+    "endNode": null,
     "WKT": "LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535)",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeRemove.json
@@ -41,10 +41,10 @@
     "entityType": "EDGE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
-    "startNode": "null",
-    "endNode": "null",
+    "tags": null,
+    "relations": null,
+    "startNode": null,
+    "endNode": null,
     "WKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedEdgeRemove.json
@@ -41,10 +41,6 @@
     "entityType": "EDGE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
-    "startNode": null,
-    "endNode": null,
     "WKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineNull.json
@@ -39,8 +39,6 @@
     "entityType": "LINE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteLine",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535)",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineNull.json
@@ -39,8 +39,8 @@
     "entityType": "LINE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteLine",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "LINESTRING (-122.052138 37.317585, -122.0304871 37.3314171, -122.028932 37.332451, -122.009566 37.33531, -122.031007 37.390535)",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineRemove.json
@@ -41,8 +41,8 @@
     "entityType": "LINE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteLine",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedLineRemove.json
@@ -41,8 +41,6 @@
     "entityType": "LINE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteLine",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))",
     "bboxWKT": "POLYGON ((-122.052138 37.317585, -122.052138 37.390535, -122.009566 37.390535, -122.009566 37.317585, -122.052138 37.317585))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeNull.json
@@ -21,10 +21,10 @@
     "entityType": "NODE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteNode",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
-    "inEdges": "null",
-    "outEdges": "null",
+    "tags": null,
+    "relations": null,
+    "inEdges": null,
+    "outEdges": null,
     "WKT": "POINT (12.49234 41.890224)",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeNull.json
@@ -21,10 +21,6 @@
     "entityType": "NODE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteNode",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
-    "inEdges": null,
-    "outEdges": null,
     "WKT": "POINT (12.49234 41.890224)",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeRemove.json
@@ -37,10 +37,6 @@
     "entityType": "NODE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteNode",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
-    "inEdges": null,
-    "outEdges": null,
     "WKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedNodeRemove.json
@@ -37,10 +37,10 @@
     "entityType": "NODE",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteNode",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
-    "inEdges": "null",
-    "outEdges": "null",
+    "tags": null,
+    "relations": null,
+    "inEdges": null,
+    "outEdges": null,
     "WKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointNull.json
@@ -21,8 +21,8 @@
     "entityType": "POINT",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompletePoint",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "POINT (12.49234 41.890224)",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointNull.json
@@ -21,8 +21,6 @@
     "entityType": "POINT",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompletePoint",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "POINT (12.49234 41.890224)",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointRemove.json
@@ -37,8 +37,8 @@
     "entityType": "POINT",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompletePoint",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "WKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedPointRemove.json
@@ -37,8 +37,6 @@
     "entityType": "POINT",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompletePoint",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "WKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))",
     "bboxWKT": "POLYGON ((12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224, 12.49234 41.890224))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationNull.json
@@ -41,8 +41,6 @@
     "entityType": "RELATION",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
     "members": [
       "{Member: ID = 456, Type = EDGE, Role = role1}",
       "{Member: ID = 789, Type = AREA, Role = role2}"

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationNull.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationNull.json
@@ -41,8 +41,8 @@
     "entityType": "RELATION",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
+    "tags": null,
+    "relations": null,
     "members": [
       "{Member: ID = 456, Type = EDGE, Role = role1}",
       "{Member: ID = 789, Type = AREA, Role = role2}"

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationRemove.json
@@ -41,9 +41,9 @@
     "entityType": "RELATION",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation",
     "identifier": 123,
-    "tags": "null",
-    "relations": "null",
-    "members": "null",
+    "tags": null,
+    "relations": null,
+    "members": null,
     "WKT": "POLYGON ((-122.031905 37.328167, -122.031905 37.330394, -122.029051 37.330394, -122.029051 37.328167, -122.031905 37.328167))",
     "bboxWKT": "POLYGON ((-122.031905 37.328167, -122.031905 37.330394, -122.029051 37.330394, -122.029051 37.328167, -122.031905 37.328167))"
   }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationRemove.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedRelationRemove.json
@@ -41,9 +41,6 @@
     "entityType": "RELATION",
     "completeEntityClass": "org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation",
     "identifier": 123,
-    "tags": null,
-    "relations": null,
-    "members": null,
     "WKT": "POLYGON ((-122.031905 37.328167, -122.031905 37.330394, -122.029051 37.330394, -122.029051 37.328167, -122.031905 37.328167))",
     "bboxWKT": "POLYGON ((-122.031905 37.328167, -122.031905 37.330394, -122.029051 37.330394, -122.029051 37.328167, -122.031905 37.328167))"
   }


### PR DESCRIPTION
### Description:
`FeatureChange` GeoJSON serialization no longer serializes `null` valued properties with `"null"`. It will now instead simply omit the field.

### Potential Impact:
Downstream users depending on `null` valued fields having a value `"null"` will need to adjust.
 
### Unit Test Approach:
Updated relevant unit tests.

### Test Results:
All pass!

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)