### PR TITLE
Reworked to use String values for ISOCountryTag values

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasRelationSlicer.java
@@ -111,7 +111,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
         super(loadingOption, new CoordinateToNewPointMapping(), atlas);
         this.initialShard = initialShard;
         this.pointCandidatesForRemoval = new HashSet<>();
-        this.isInCountry = entity -> ISOCountryTag.isIn(this.getIsoCountries()).test(entity);
+        this.isInCountry = entity -> ISOCountryTag.isIn(this.getCountries()).test(entity);
     }
 
     /**
@@ -630,7 +630,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                                 .get(member.getEntity().getIdentifier());
                         final RelationMember lineMember = new RelationMember(member.getRole(), line,
                                 relationIdentifier);
-                        ISOCountryTag.allCountryStrings(line)
+                        ISOCountryTag.all(line)
                                 .forEach(country -> countryEntityMap.add(country, lineMember));
                     }
                     else
@@ -639,7 +639,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                                 .from(getStartingAtlas().line(member.getEntity().getIdentifier()));
                         final RelationMember lineMember = new RelationMember(member.getRole(), line,
                                 relationIdentifier);
-                        ISOCountryTag.allCountryStrings(line)
+                        ISOCountryTag.all(line)
                                 .forEach(country -> countryEntityMap.add(country, lineMember));
                     }
                     break;
@@ -648,7 +648,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                             .from(getStartingAtlas().point(member.getEntity().getIdentifier()));
                     final RelationMember pointMember = new RelationMember(member.getRole(), point,
                             relationIdentifier);
-                    ISOCountryTag.allCountryStrings(point)
+                    ISOCountryTag.all(point)
                             .forEach(country -> countryEntityMap.add(country, pointMember));
             }
         });
@@ -1014,7 +1014,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
             // we're keeping these members, but do need to check that any child relations that have
             // been split are updated
             if (this.getCountries().contains(entry.getKey())
-                    || String.join(",", this.getCountries()).equals(entry.getKey()))
+                    || ISOCountryTag.join(this.getCountries()).equals(entry.getKey()))
             {
                 relationMembers.addAll(entry.getValue());
             }
@@ -1038,10 +1038,10 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                     countries.add(country);
                 }
             });
-            updatedRelation.withAddedTag(ISOCountryTag.KEY, String.join(",", countries));
+            updatedRelation.withAddedTag(ISOCountryTag.KEY, ISOCountryTag.join(countries));
             this.changes.add(FeatureChange.add(updatedRelation));
             final HashMap<String, CompleteRelation> relationByCountry = new HashMap<>();
-            relationByCountry.put(String.join(",", countries), updatedRelation);
+            relationByCountry.put(ISOCountryTag.join(countries), updatedRelation);
             this.splitRelations.put(updatedRelation.getIdentifier(), relationByCountry);
             relation.members().stream().filter(member -> !relationMembers.contains(member))
                     .forEach(filteredMember ->
@@ -1150,7 +1150,7 @@ public class RawAtlasRelationSlicer extends RawAtlasSlicer
                 }
             });
             newRelation.withAddedTag(SyntheticRelationMemberAdded.KEY,
-                    String.join(",", syntheticIds));
+                    SyntheticRelationMemberAdded.join(syntheticIds));
             this.changes.add(FeatureChange.add(newRelation));
 
         });

--- a/src/main/java/org/openstreetmap/atlas/tags/SyntheticRelationMemberAdded.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/SyntheticRelationMemberAdded.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.tags;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -46,5 +47,10 @@ public interface SyntheticRelationMemberAdded
     static boolean hasAddedRelationMember(final Taggable taggable)
     {
         return taggable.getTag(KEY).isPresent();
+    }
+
+    static String join(final Collection<String> ids)
+    {
+        return String.join(MEMBER_DELIMITER, ids);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RelationSlicingTest.java
@@ -20,7 +20,6 @@ import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
-import org.openstreetmap.atlas.locale.IsoCountry;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
@@ -88,13 +87,13 @@ public class RelationSlicingTest
         {
             return relation.isMultiPolygon()
                     && Validators.isOfType(relation, NaturalTag.class, NaturalTag.WATER)
-                    && ISOCountryTag.isIn(IsoCountry.forCountryCode("LBR").get()).test(relation);
+                    && ISOCountryTag.isIn("LBR").test(relation);
         })));
         Assert.assertEquals(1, Iterables.size(slicedAtlas.relations(relation ->
         {
             return relation.isMultiPolygon()
                     && Validators.isOfType(relation, NaturalTag.class, NaturalTag.WATER)
-                    && ISOCountryTag.isIn(IsoCountry.forCountryCode("CIV").get()).test(relation);
+                    && ISOCountryTag.isIn("CIV").test(relation);
         })));
 
         // check that these relations close
@@ -113,10 +112,8 @@ public class RelationSlicingTest
         // check the non multipolygon relation and make sure it was left intact and tagged with both
         // country codes
         Assert.assertNotNull(slicedAtlas.relation(214806000000L));
-        Assert.assertTrue(ISOCountryTag.isIn(IsoCountry.forCountryCode("CIV").get())
-                .test(slicedAtlas.relation(214806000000L)));
-        Assert.assertTrue(ISOCountryTag.isIn(IsoCountry.forCountryCode("LBR").get())
-                .test(slicedAtlas.relation(214806000000L)));
+        Assert.assertTrue(ISOCountryTag.isIn("CIV").test(slicedAtlas.relation(214806000000L)));
+        Assert.assertTrue(ISOCountryTag.isIn("LBR").test(slicedAtlas.relation(214806000000L)));
     }
 
     @Test
@@ -176,7 +173,7 @@ public class RelationSlicingTest
         {
             return relation.isMultiPolygon()
                     && Validators.isOfType(relation, NaturalTag.class, NaturalTag.WATER)
-                    && ISOCountryTag.isIn(IsoCountry.forCountryCode("LBR").get()).test(relation);
+                    && ISOCountryTag.isIn("LBR").test(relation);
         })));
 
         // check that these relations close
@@ -191,10 +188,8 @@ public class RelationSlicingTest
         // check the non multipolygon relation and make sure it was left intact and tagged with only
         // the country we're slicing
         Assert.assertNotNull(slicedAtlas.relation(214806000000L));
-        Assert.assertFalse(ISOCountryTag.isIn(IsoCountry.forCountryCode("CIV").get())
-                .test(slicedAtlas.relation(214806000000L)));
-        Assert.assertTrue(ISOCountryTag.isIn(IsoCountry.forCountryCode("LBR").get())
-                .test(slicedAtlas.relation(214806000000L)));
+        Assert.assertFalse(ISOCountryTag.isIn("CIV").test(slicedAtlas.relation(214806000000L)));
+        Assert.assertTrue(ISOCountryTag.isIn("LBR").test(slicedAtlas.relation(214806000000L)));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/tags/ISOCountryTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ISOCountryTagTestCase.java
@@ -1,12 +1,12 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openstreetmap.atlas.locale.IsoCountry;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
@@ -25,35 +25,20 @@ public class ISOCountryTagTestCase
     {
         final TestTaggable testable = new TestTaggable(ISOCountryTag.KEY, "PRK,KOR,USA");
 
-        final List<IsoCountry> isoCountries = Lists.newArrayList(ISOCountryTag.all(testable));
-        Assert.assertTrue(isoCountries.size() == 3);
-        Assert.assertTrue(isoCountries.contains(IsoCountry.forCountryCode("PRK").get()));
-        Assert.assertTrue(isoCountries.contains(IsoCountry.forCountryCode("KOR").get()));
-        Assert.assertTrue(isoCountries.contains(IsoCountry.forCountryCode("USA").get()));
-    }
-
-    @Test
-    public void testBestKorea()
-    {
-        final TestTaggable testable = new TestTaggable(ISOCountryTag.KEY, "PRK");
-
-        final List<IsoCountry> isoCountries = Lists.newArrayList(ISOCountryTag.all(testable));
-        Assert.assertTrue(isoCountries.size() == 1);
-        Assert.assertTrue(isoCountries.contains(IsoCountry.forCountryCode("PRK").get()));
-
-        final Iterable<IsoCountry> possibleCountry = ISOCountryTag.all(testable);
-        Assert.assertTrue(Iterables.size(possibleCountry) > 0);
-        Assert.assertNotEquals(IsoCountry.forCountryCode("KOR"),
-                Optional.of(possibleCountry.iterator().next()));
-        Assert.assertEquals(IsoCountry.forCountryCode("PRK"),
-                Optional.of(possibleCountry.iterator().next()));
+        final List<String> countries = Lists.newArrayList(ISOCountryTag.all(testable));
+        Assert.assertTrue(countries.size() == 3);
+        Assert.assertTrue(countries.contains("PRK"));
+        Assert.assertTrue(countries.contains("KOR"));
+        Assert.assertTrue(countries.contains("USA"));
     }
 
     @Test
     public void testFilterAllIn()
     {
-        final Predicate<Taggable> checkMe = ISOCountryTag.allIn(
-                IsoCountry.forCountryCode("KOR").get(), IsoCountry.forCountryCode("USA").get());
+        final Collection<String> countries = new HashSet<>();
+        countries.add("KOR");
+        countries.add("USA");
+        final Predicate<Taggable> checkMe = ISOCountryTag.allIn(countries);
 
         Assert.assertFalse(checkMe.test(new TestTaggable(ISOCountryTag.KEY, "PRK,KOR,USA,RUS")));
         Assert.assertFalse(checkMe.test(new TestTaggable(ISOCountryTag.KEY, "PRK,KOR,USA")));
@@ -67,8 +52,7 @@ public class ISOCountryTagTestCase
     @Test
     public void testFilterIsIn()
     {
-        final Predicate<Taggable> checkMe = ISOCountryTag
-                .isIn(IsoCountry.forCountryCode("KOR").get());
+        final Predicate<Taggable> checkMe = ISOCountryTag.isIn("KOR");
         Assert.assertTrue(checkMe.test(new TestTaggable(ISOCountryTag.KEY, "KOR")));
         Assert.assertFalse(checkMe.test(new TestTaggable(ISOCountryTag.KEY, "PRK")));
     }
@@ -79,10 +63,9 @@ public class ISOCountryTagTestCase
         // We expect PRK to be the country code because it's the first in the list
         final TestTaggable testable = new TestTaggable(ISOCountryTag.KEY, "PRK,KOR,USA");
 
-        final Iterable<IsoCountry> possibleCountry = ISOCountryTag.all(testable);
+        final Iterable<String> possibleCountry = ISOCountryTag.all(testable);
         Assert.assertTrue(Iterables.size(possibleCountry) > 0);
-        Assert.assertEquals(IsoCountry.forCountryCode("PRK"),
-                Optional.of(possibleCountry.iterator().next()));
+        Assert.assertEquals("PRK", possibleCountry.iterator().next());
     }
 
     @Test
@@ -90,22 +73,13 @@ public class ISOCountryTagTestCase
     {
         final TestTaggable testable = new TestTaggable(ISOCountryTag.KEY, "KOR");
 
-        final List<IsoCountry> isoCountries = Lists.newArrayList(ISOCountryTag.all(testable));
-        Assert.assertTrue(isoCountries.size() == 1);
-        Assert.assertTrue(isoCountries.contains(IsoCountry.forCountryCode("KOR").get()));
+        final List<String> countries = Lists.newArrayList(ISOCountryTag.all(testable));
+        Assert.assertTrue(countries.size() == 1);
+        Assert.assertTrue(countries.contains("KOR"));
 
-        final Iterable<IsoCountry> possibleCountry = ISOCountryTag.all(testable);
+        final Iterable<String> possibleCountry = ISOCountryTag.all(testable);
         Assert.assertTrue(Iterables.size(possibleCountry) > 0);
-        final IsoCountry country = possibleCountry.iterator().next();
-        Assert.assertEquals(IsoCountry.forCountryCode("KOR"), Optional.of(country));
-    }
-
-    @Test
-    public void testNoData()
-    {
-        final TestTaggable testable = new TestTaggable(ISOCountryTag.KEY, "NOPE");
-
-        Assert.assertTrue(Lists.newArrayList(ISOCountryTag.all(testable)).isEmpty());
-        Assert.assertFalse(Iterables.size(ISOCountryTag.all(testable)) > 0);
+        final String country = possibleCountry.iterator().next();
+        Assert.assertEquals("KOR", country);
     }
 }


### PR DESCRIPTION
### Description:
Pretty much what the title says! Changes ISOCountryTag methods to use String values, and the few classes that called those methods have been updated accordingly.

### Potential Impact:
Should be limited, most places were using the String value of the tag already.

### Unit Test Approach:

Use existing tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
