### PR TITLE
Fixed a false positive bug in the Change validation

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidator.java
@@ -87,11 +87,7 @@ public class ChangeValidator
 
     private <T> boolean differ(final T left, final T right, final BiPredicate<T, T> equal)
     {
-        if (left == null && right != null || left != null && right == null)
-        {
-            return true;
-        }
-        if (left != null/* right is implicitly not null here */)
+        if (left != null && right != null)
         {
             return !equal.test(left, right);
         }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -88,7 +88,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      */
     private static final int MAXIMUM_ALLOWED_COLUMN = 225;
 
-    private SimpleOptionAndArgumentParser parser;
+    private final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser();
     private final DocumentationRegistrar registrar = new DocumentationRegistrar();
 
     private boolean useColorStdout = false;
@@ -166,7 +166,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         throwIfInvalidNameOrDescription();
 
         final String[] argsCopy = unpackSentinelArguments(args);
-        this.parser = new SimpleOptionAndArgumentParser(this.ignoreUnknownOptions);
+        this.parser.ignoreUnknownOptions(this.ignoreUnknownOptions);
 
         // fill out appropriate data structures so the execute() implementation can query
         registerOptionsAndArguments();

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/parsing/SimpleOptionAndArgumentParser.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/parsing/SimpleOptionAndArgumentParser.java
@@ -235,14 +235,9 @@ public class SimpleOptionAndArgumentParser
     private final Map<String, List<String>> parsedArguments;
     private int currentContext;
     private boolean parseStepRanAtLeastOnce;
-    private final boolean ignoreUnknownOptions;
+    private boolean ignoreUnknownOptions;
 
     public SimpleOptionAndArgumentParser()
-    {
-        this(false);
-    }
-
-    public SimpleOptionAndArgumentParser(final boolean ignoreUnknownOptions)
     {
         this.contextToRegisteredOptions = new HashMap<>();
         this.contextToArgumentHintToArity = new HashMap<>();
@@ -259,7 +254,7 @@ public class SimpleOptionAndArgumentParser
         this.parsedArguments = new LinkedHashMap<>();
         this.currentContext = NO_CONTEXT;
         this.parseStepRanAtLeastOnce = false;
-        this.ignoreUnknownOptions = ignoreUnknownOptions;
+        this.ignoreUnknownOptions = false;
     }
 
     /**
@@ -497,6 +492,12 @@ public class SimpleOptionAndArgumentParser
             option = Optional.empty();
         }
         return option.isPresent();
+    }
+
+    public SimpleOptionAndArgumentParser ignoreUnknownOptions(final boolean ignore)
+    {
+        this.ignoreUnknownOptions = ignore;
+        return this;
     }
 
     public boolean isEmpty()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/ChangeTest.java
@@ -3,8 +3,10 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteArea;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.utilities.collections.Maps;
@@ -47,6 +49,31 @@ public class ChangeTest extends AbstractChangeTest
         final Area area = (Area) merged.getAfterView();
         Assert.assertEquals(Polygon.TEST_BUILDING, area.asPolygon());
         Assert.assertEquals(Maps.hashMap("key", "value"), area.getTags());
+    }
+
+    @Test
+    public void testEdgeNodeValidation()
+    {
+        final CompleteEdge edge1 = new CompleteEdge(1L, PolyLine.SIMPLE_POLYLINE,
+                Maps.hashMap("key1", "value1", "newKey", "newValue"), null, null, null);
+        final CompleteEdge edge1Reverse = new CompleteEdge(-1L, PolyLine.SIMPLE_POLYLINE.reversed(),
+                Maps.hashMap("key1", "value1", "newKey", "newValue"), 2L, 1L, null);
+        final Change change1 = ChangeBuilder.newInstance()
+                .addAll(FeatureChange.add(edge1), FeatureChange.add(edge1Reverse)).get();
+        Assert.assertEquals(2, change1.changeCount());
+    }
+
+    @Test
+    public void testEdgeNodeValidationFail()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("Forward edge 1 start node CompleteNode");
+        final CompleteEdge edge2 = new CompleteEdge(1L, PolyLine.SIMPLE_POLYLINE,
+                Maps.hashMap("key1", "value1", "newKey", "newValue"), 3L, 2L, null);
+        final CompleteEdge edge2Reverse = new CompleteEdge(-1L, PolyLine.SIMPLE_POLYLINE.reversed(),
+                Maps.hashMap("key1", "value1", "newKey", "newValue"), 2L, 1L, null);
+        final Change change2 = ChangeBuilder.newInstance()
+                .addAll(FeatureChange.add(edge2), FeatureChange.add(edge2Reverse)).get();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/validators/ChangeValidatorTest.java
@@ -98,20 +98,6 @@ public class ChangeValidatorTest
     }
 
     @Test
-    public void testMismatchingEdgeNodes()
-    {
-        this.expectedException.expect(CoreException.class);
-        this.expectedException.expectMessage("does not match its backward edge start node");
-
-        final ChangeBuilder builder = new ChangeBuilder();
-        builder.add(FeatureChange.add(
-                new CompleteEdge(123L, PolyLine.TEST_POLYLINE, Maps.hashMap(), null, 456L, null)));
-        builder.add(FeatureChange.add(new CompleteEdge(-123L, PolyLine.TEST_POLYLINE.reversed(),
-                Maps.hashMap(), null, null, null)));
-        builder.get();
-    }
-
-    @Test
     public void testMismatchingEdgeParentRelations()
     {
         final ChangeBuilder builder = new ChangeBuilder();

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/SimpleOptionAndArgumentParserTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/SimpleOptionAndArgumentParserTest.java
@@ -47,7 +47,8 @@ public class SimpleOptionAndArgumentParserTest
     @Test
     public void testIgnoreUnknownOptions()
     {
-        final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser(true);
+        final SimpleOptionAndArgumentParser parser = new SimpleOptionAndArgumentParser();
+        parser.ignoreUnknownOptions(true);
         parser.registerOption("opt1", "the 1st option", OptionOptionality.OPTIONAL, 1);
         parser.registerOption("opt2", "the 2nd option", OptionOptionality.OPTIONAL, 1);
 
@@ -67,7 +68,8 @@ public class SimpleOptionAndArgumentParserTest
         Assert.assertTrue(parser.hasOption("opt2"));
         Assert.assertFalse(parser.hasOption("opt3"));
 
-        final SimpleOptionAndArgumentParser parser2 = new SimpleOptionAndArgumentParser(true);
+        final SimpleOptionAndArgumentParser parser2 = new SimpleOptionAndArgumentParser();
+        parser2.ignoreUnknownOptions(true);
         parser2.registerOption("opt1", 'o', "the 1st option", OptionOptionality.OPTIONAL, 1);
 
         final List<String> arguments2 = Arrays.asList("-z", "-o");


### PR DESCRIPTION
### Description:
`Change` validation was over-zealous when checking reverse `CompleteEdge` nodes. It would throw an error when one `FeatureChange` specified `null` for a start/end node, while the other had a change. We can't actually throw an error here, since it is possible that the reverse edge was freshly added while the original master edge was changed in an unrelated way (e.g. tags).

### Potential Impact:
Fewer false positive errors in downstream code.

### Unit Test Approach:
Added two unit tests to show expected behavior.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)