### PR TITLE
Fix bug with empty MultiPolygon conversion

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsCoordinateArrayConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsCoordinateArrayConverter.java
@@ -22,6 +22,12 @@ public class JtsCoordinateArrayConverter
 {
     private static final JtsLocationConverter LOCATION_CONVERTER = new JtsLocationConverter();
 
+    public static CoordinateSequence empty()
+    {
+        final Coordinate[] emptyCoordinateArray = new Coordinate[0];
+        return new CoordinateArraySequence(emptyCoordinateArray);
+    }
+
     @Override
     public Iterable<Location> backwardConvert(final CoordinateSequence coordinateSequence)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsLinearRingConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsLinearRingConverter.java
@@ -30,6 +30,11 @@ public class JtsLinearRingConverter implements TwoWayConverter<Polygon, LinearRi
     // (found x - must be 0 or >= 4)
     private static final int MINIMUM_LINEAR_RING_SIZE = 4;
 
+    public static LinearRing empty()
+    {
+        return new LinearRing(JtsCoordinateArrayConverter.empty(), FACTORY);
+    }
+
     @Override
     public Polygon backwardConvert(final LinearRing object)
     {

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsPolygonToMultiPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsPolygonToMultiPolygonConverter.java
@@ -24,6 +24,12 @@ public class JtsPolygonToMultiPolygonConverter
     @Override
     public org.locationtech.jts.geom.Polygon backwardConvert(final MultiPolygon object)
     {
+        if (object.getOuterToInners().isEmpty())
+        {
+            final LinearRing[] emptyInners = new LinearRing[0];
+            return new org.locationtech.jts.geom.Polygon(JtsLinearRingConverter.empty(),
+                    emptyInners, FACTORY);
+        }
         if (object.getOuterToInners().keySet().size() != 1)
         {
             throw new CoreException(

--- a/src/test/java/org/openstreetmap/atlas/geography/converters/WktMultiPolygonConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/converters/WktMultiPolygonConverterTest.java
@@ -68,4 +68,12 @@ public class WktMultiPolygonConverterTest
         Assert.assertEquals(truth, multiPolygon);
         Assert.assertEquals(wkt, CONVERTER.convert(truth));
     }
+
+    @Test
+    public void testEmptyMultiPolygon()
+    {
+        final MultiMap<Polygon, Polygon> outersToInners = new MultiMap<>();
+        final MultiPolygon multiPolygon = new MultiPolygon(outersToInners);
+        Assert.assertEquals("POLYGON EMPTY", multiPolygon.toWkt());
+    }
 }


### PR DESCRIPTION
### Description:

In case a `MultiPolygon` is empty, the WKT converter would fail since it was mistakenly categorized as a size 1 or less. Now this is fixed with additional checks for empty multipolygons.

### Potential Impact:

The exception `A MultiPolygon can be converted to JTS Polygon only if it has no more than one outer ring.` should not be thrown for empty `MultiPolygon`s.

### Unit Test Approach:

Added one unit test for the case

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
