### PR TITLE
ProtectClassTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/ProtectClassTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ProtectClassTag.java
@@ -1,0 +1,34 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Range;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.OrdinalExtractor;
+
+/**
+ * OSM protect_class tag
+ *
+ * @author bbreithaupt
+ */
+@Tag(value = Validation.ORDINAL, range = @Range(min = 1, max = 99), taginfo = "https://taginfo.openstreetmap.org/keys/protect_class", osm = "https://wiki.openstreetmap.org/wiki/Key:protect_class")
+public interface ProtectClassTag
+{
+    @TagKey
+    String KEY = "protect_class";
+
+    static Optional<Integer> getValue(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            final OrdinalExtractor extractor = new OrdinalExtractor();
+            return extractor.validateAndExtract(tagValue.get(),
+                    ProtectClassTag.class.getDeclaredAnnotation(Tag.class));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/ProtectClassTagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ProtectClassTagTest.java
@@ -34,7 +34,7 @@ public class ProtectClassTagTest
     public void getValueWrongTagTest()
     {
         final Optional<Integer> tagValue = ProtectClassTag
-                .getValue(Taggable.with("protect_class", "bad"));
+                .getValue(Taggable.with("highway", "primary"));
         Assert.assertFalse(tagValue.isPresent());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/tags/ProtectClassTagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ProtectClassTagTest.java
@@ -1,0 +1,40 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ProtectClassTag}.
+ *
+ * @author bbreithaupt
+ */
+public class ProtectClassTagTest
+{
+
+    @Test
+    public void getValueNotNumberTest()
+    {
+        final Optional<Integer> tagValue = ProtectClassTag
+                .getValue(Taggable.with("protect_class", "bad"));
+        Assert.assertFalse(tagValue.isPresent());
+    }
+
+    @Test
+    public void getValueTest()
+    {
+        final Optional<Integer> tagValue = ProtectClassTag
+                .getValue(Taggable.with("protect_class", "1"));
+        Assert.assertTrue(tagValue.isPresent());
+        Assert.assertEquals((Integer) 1, tagValue.get());
+    }
+
+    @Test
+    public void getValueWrongTagTest()
+    {
+        final Optional<Integer> tagValue = ProtectClassTag
+                .getValue(Taggable.with("protect_class", "bad"));
+        Assert.assertFalse(tagValue.isPresent());
+    }
+}


### PR DESCRIPTION
### Description:

Adds a tag class for the [protect_class tag](https://wiki.openstreetmap.org/wiki/Key:protect_class). This tag is used in conjunction with the protected_area tag (which already has a tag class in atlas).

This tag has ordinal values of 1-99. A getValue() method is available to retrieve the value as an integer. 

### Potential Impact:

None, just a new tag class.

### Unit Test Approach:

Added unit test for the getValue() method. 

### Test Results:

None

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
