### PR TITLE
Changed field name to match geojson Descriptor class

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/descriptors/LongElementChangeDescriptor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/descriptors/LongElementChangeDescriptor.java
@@ -64,11 +64,11 @@ public class LongElementChangeDescriptor implements ChangeDescriptor
         final JsonObject descriptor = (JsonObject) ChangeDescriptor.super.toJsonElement();
         if (this.beforeElement != null)
         {
-            descriptor.addProperty("beforeView", this.beforeElement.toString());
+            descriptor.addProperty("beforeElement", this.beforeElement.toString());
         }
         if (this.afterElement != null)
         {
-            descriptor.addProperty("afterView", this.afterElement.toString());
+            descriptor.addProperty("afterElement", this.afterElement.toString());
         }
         return descriptor;
     }

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAddEdgeWithDescription.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAddEdgeWithDescription.json
@@ -58,22 +58,22 @@
         {
           "name": "PARENT_RELATION",
           "type": "ADD",
-          "afterView": "1"
+          "afterElement": "1"
         },
         {
           "name": "PARENT_RELATION",
           "type": "ADD",
-          "afterView": "2"
+          "afterElement": "2"
         },
         {
           "name": "START_NODE",
           "type": "ADD",
-          "afterView": "1"
+          "afterElement": "1"
         },
         {
           "name": "END_NODE",
           "type": "ADD",
-          "afterView": "2"
+          "afterElement": "2"
         }
       ]
     },

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAddRelationWithDescription.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedAddRelationWithDescription.json
@@ -48,12 +48,12 @@
         {
           "name": "PARENT_RELATION",
           "type": "ADD",
-          "afterView": "1"
+          "afterElement": "1"
         },
         {
           "name": "PARENT_RELATION",
           "type": "ADD",
-          "afterView": "2"
+          "afterElement": "2"
         },
         {
           "name": "RELATION_MEMBER",

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedUpdateEdgeWithDescription.json
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/change/serializer/serializedUpdateEdgeWithDescription.json
@@ -71,24 +71,24 @@
         {
           "name": "PARENT_RELATION",
           "type": "ADD",
-          "afterView": "3"
+          "afterElement": "3"
         },
         {
           "name": "PARENT_RELATION",
           "type": "REMOVE",
-          "beforeView": "1"
+          "beforeElement": "1"
         },
         {
           "name": "START_NODE",
           "type": "UPDATE",
-          "beforeView": "1",
-          "afterView": "10"
+          "beforeElement": "1",
+          "afterElement": "10"
         },
         {
           "name": "END_NODE",
           "type": "UPDATE",
-          "beforeView": "2",
-          "afterView": "20"
+          "beforeElement": "2",
+          "afterElement": "20"
         }
       ]
     },


### PR DESCRIPTION
### Description:
`LongElementChangeDescriptor` now uses `before/afterElement` instead of `before/afterView`.

### Potential Impact:
Anyone depending on the name of this JSON field will need to update their code.

### Unit Test Approach:
Fixed unit tests to reflect name change.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)