### PR TITLE
Added in tag summary map method for Change

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.change;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -17,6 +19,9 @@ import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescription;
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptorName;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.TagChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.change.serializer.ChangeGeoJsonSerializer;
 import org.openstreetmap.atlas.geography.atlas.change.serializer.FeatureChangeGeoJsonSerializer;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
@@ -156,6 +161,11 @@ public class Change implements Located, Serializable
         return Objects.equals(this.featureChanges, that.featureChanges);
     }
 
+    public List<FeatureChange> getFeatureChanges()
+    {
+        return this.featureChanges;
+    }
+
     public int getIdentifier()
     {
         return this.identifier;
@@ -178,6 +188,23 @@ public class Change implements Located, Serializable
     public int hashCode()
     {
         return Objects.hashCode(this.featureChanges);
+    }
+
+    /**
+     * Transform this {@link Change} into a pretty string. This will use the pretty strings for
+     * {@link CompleteEntity} classes that make up this {@link Change}'s constituent
+     * {@link FeatureChange}s.
+     *
+     * @param featureChangeFormat
+     *            the format type for the the constituent {@link FeatureChange}s
+     * @param completeEntityFormat
+     *            the format type for the constituent {@link CompleteEntity}s
+     * @return the pretty string
+     */
+    public String prettify(final PrettifyStringFormat featureChangeFormat,
+            final PrettifyStringFormat completeEntityFormat)
+    {
+        return this.prettify(featureChangeFormat, completeEntityFormat, true);
     }
 
     /**
@@ -212,23 +239,6 @@ public class Change implements Located, Serializable
     }
 
     /**
-     * Transform this {@link Change} into a pretty string. This will use the pretty strings for
-     * {@link CompleteEntity} classes that make up this {@link Change}'s constituent
-     * {@link FeatureChange}s.
-     *
-     * @param featureChangeFormat
-     *            the format type for the the constituent {@link FeatureChange}s
-     * @param completeEntityFormat
-     *            the format type for the constituent {@link CompleteEntity}s
-     * @return the pretty string
-     */
-    public String prettify(final PrettifyStringFormat featureChangeFormat,
-            final PrettifyStringFormat completeEntityFormat)
-    {
-        return this.prettify(featureChangeFormat, completeEntityFormat, true);
-    }
-
-    /**
      * Save a JSON representation of that feature change.
      *
      * @param resource
@@ -251,6 +261,77 @@ public class Change implements Located, Serializable
     public void save(final WritableResource resource, final boolean showDescription)
     {
         new ChangeGeoJsonSerializer(true, showDescription).accept(this, resource);
+    }
+
+    public String summaryString()
+    {
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append(this.getClass().getSimpleName() + " [");
+        builder.append("\n");
+        for (final ItemType itemType : ItemType.values())
+        {
+            for (final ChangeDescriptorType changeType : ChangeDescriptorType.values())
+            {
+                builder.append(itemType);
+                builder.append(" had ");
+                builder.append(changeCountFor(itemType, changeType));
+                builder.append(" ");
+                builder.append(changeType);
+                builder.append(" changes\n");
+            }
+        }
+        builder.append("]");
+
+        return builder.toString();
+    }
+
+    public Map<ItemType, Map<ChangeDescriptorType, Map<String, AtomicLong>>> tagCountMap()
+    {
+        final Map<ItemType, Map<ChangeDescriptorType, Map<String, AtomicLong>>> tagMap = new EnumMap<>(
+                ItemType.class);
+        for (final ItemType itemType : ItemType.values())
+        {
+            final Map<ChangeDescriptorType, Map<String, AtomicLong>> descriptorMap = new EnumMap<>(
+                    ChangeDescriptorType.class);
+            for (final ChangeDescriptorType type : ChangeDescriptorType.values())
+            {
+                descriptorMap.put(type, new HashMap<>());
+            }
+            tagMap.put(itemType, descriptorMap);
+            this.featureChanges.stream().filter(change -> change.getItemType().equals(itemType)
+                    && change.explain().getChangeDescriptorType()
+                            .equals(ChangeDescriptorType.UPDATE)
+                    && change.explain().getChangeDescriptors().stream().anyMatch(
+                            descriptor -> descriptor.getName().equals(ChangeDescriptorName.TAG)))
+                    .forEach(
+                            change -> change.explain().getChangeDescriptors().stream()
+                                    .filter(changeDescriptor -> changeDescriptor.getName()
+                                            .equals(ChangeDescriptorName.TAG))
+                                    .forEach(changeDescriptor ->
+                                    {
+                                        final TagChangeDescriptor tagChangeDescriptor = (TagChangeDescriptor) changeDescriptor;
+                                        if (tagMap.get(itemType)
+                                                .get(tagChangeDescriptor.getChangeDescriptorType())
+                                                .containsKey(tagChangeDescriptor.getKey()))
+                                        {
+                                            tagMap.get(itemType)
+                                                    .get(tagChangeDescriptor
+                                                            .getChangeDescriptorType())
+                                                    .get(tagChangeDescriptor.getKey())
+                                                    .incrementAndGet();
+                                        }
+                                        else
+                                        {
+                                            tagMap.get(itemType)
+                                                    .get(tagChangeDescriptor
+                                                            .getChangeDescriptorType())
+                                                    .put(tagChangeDescriptor.getKey(),
+                                                            new AtomicLong(1));
+                                        }
+                                    }));
+        }
+        return tagMap;
     }
 
     public String toJson()
@@ -339,8 +420,9 @@ public class Change implements Located, Serializable
         return this;
     }
 
-    List<FeatureChange> getFeatureChanges()
+    private long changeCountFor(final ItemType itemType, final ChangeDescriptorType changeType)
     {
-        return this.featureChanges;
+        return this.featureChanges.stream().filter(change -> change.getItemType().equals(itemType)
+                && change.explain().getChangeDescriptorType().equals(changeType)).count();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/Change.java
@@ -299,6 +299,10 @@ public class Change implements Located, Serializable
                 descriptorMap.put(type, new HashMap<>());
             }
             tagMap.put(itemType, descriptorMap);
+
+            // The first stream here gets all update changes with Tag changes; the second
+            // iterates over those changes and places them in the map based on their tag key
+            // and update type
             this.featureChanges.stream().filter(change -> change.getItemType().equals(itemType)
                     && change.explain().getChangeDescriptorType()
                             .equals(ChangeDescriptorType.UPDATE)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
@@ -114,8 +114,6 @@ public class AtlasDiffTest
                 tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.ADD).get("tag2").get());
         Assert.assertEquals(1,
                 tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.REMOVE).get("tag2").get());
-
-        System.out.println(tagCountMap);
     }
 
     private void assertChangeAtlasConsistency(final Atlas beforeAtlas, final Atlas afterAtlas,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/diff/AtlasDiffTest.java
@@ -1,5 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.change.diff;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -7,6 +10,8 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.change.Change;
 import org.openstreetmap.atlas.geography.atlas.change.ChangeAtlas;
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +100,22 @@ public class AtlasDiffTest
         final int expectedNumberOfChanges = 3;
 
         assertChangeAtlasConsistency(atlasX, atlasY, expectedNumberOfChanges);
+
+        final Change changeBeforeToAfter = new AtlasDiff(atlasX, atlasY).generateChange()
+                .orElseThrow(() -> new CoreException(
+                        "This Change should never be empty. The unit test may be broken."));
+        final Map<ItemType, Map<ChangeDescriptorType, Map<String, AtomicLong>>> tagCountMap = changeBeforeToAfter
+                .tagCountMap();
+        Assert.assertEquals(1, tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.ADD).size());
+        Assert.assertEquals(1,
+                tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.REMOVE).size());
+
+        Assert.assertEquals(2,
+                tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.ADD).get("tag2").get());
+        Assert.assertEquals(1,
+                tagCountMap.get(ItemType.NODE).get(ChangeDescriptorType.REMOVE).get("tag2").get());
+
+        System.out.println(tagCountMap);
     }
 
     private void assertChangeAtlasConsistency(final Atlas beforeAtlas, final Atlas afterAtlas,


### PR DESCRIPTION
### Description:

This PR adds in a set of summaries for a Change object. The first is a String that summarizes the number of changes for each ItemType and ChangeType that the Change contains. The second is a complex map of ItemType to ChangeDescriptorType to Tag key, mapping to the number of changes to that Tag for that ItemType and ChangeDescriptorType. For example, if there were 7 areas with the tag `last_edit_user_name` changed, then the map would contain an entry `(AREA, UPDATE, last_edit_user_name) -> 7`. This tag summary provides a direct way to parse and understand tag changes, which are often large in scale and hard to understand otherwise.

### Potential Impact:
None, this is additive.

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
