### PR TITLE
AtlasResourceLoader now handles text atlases

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -120,6 +120,17 @@ public class AtlasResourceLoader
         return load(Iterables.from(resource));
     }
 
+    public Atlas loadRecursively(final File... file)
+    {
+        return loadRecursively(Iterables.from(file));
+    }
+
+    public Atlas loadRecursively(final Iterable<File> input)
+    {
+        // TODO
+        return null;
+    }
+
     /**
      * Optionally add an {@link AtlasEntity} filter
      *

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -88,6 +88,11 @@ public class AtlasResourceLoader
                 ? IS_ATLAS
                 : this.alwaysTrueAtlasFilter;
 
+        /*
+         * FIXME These filters are wonky when the resource name is null, since the name filters let
+         * null-named resources pass through. What we should do is disallow resources will
+         * null-names, and fix all unit tests that forget to set a resource name.
+         */
         final List<Resource> binaryResources = Iterables.stream(input).flatMap(this::resourcesIn)
                 .filter(toggleableAtlasFileFilter).filter(this.resourceFilter).collectToList();
         final List<Resource> textResources = Iterables.stream(input).flatMap(this::resourcesIn)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
@@ -88,15 +89,16 @@ public class AtlasResourceLoader
                 ? IS_ATLAS
                 : this.alwaysTrueAtlasFilter;
 
-        /*
-         * FIXME These filters are wonky when the resource name is null, since the name filters let
-         * null-named resources pass through. What we should do is disallow resources will
-         * null-names, and fix all unit tests that forget to set a resource name.
-         */
         final List<Resource> binaryResources = Iterables.stream(input).flatMap(this::resourcesIn)
                 .filter(toggleableAtlasFileFilter).filter(this.resourceFilter).collectToList();
         final List<Resource> textResources = Iterables.stream(input).flatMap(this::resourcesIn)
                 .filter(IS_TEXT_ATLAS).filter(this.resourceFilter).collectToList();
+
+        if (Stream.concat(binaryResources.stream(), textResources.stream())
+                .anyMatch(resource -> resource.getName() == null))
+        {
+            throw new CoreException("Cannot load atlas from a Resource with a null name");
+        }
 
         final long size = binaryResources.size() + (long) textResources.size();
         if (size == 1)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader2.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader2.java
@@ -1,0 +1,277 @@
+package org.openstreetmap.atlas.geography.atlas;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load an {@link Atlas} from a {@link Resource} or an {@link Iterable} of {@link Resource}s. Also
+ * supports loading based on a resource name filter. To recursively load all {@link Atlas}es in a
+ * directory, see the {@link AtlasResourceLoader2#loadRecursively} method.
+ *
+ * @author lcram
+ */
+public class AtlasResourceLoader2
+{
+    private static final Logger logger = LoggerFactory.getLogger(AtlasResourceLoader2.class);
+    private static final Predicate<Resource> LOOKS_LIKE_TEXT_ATLAS = resource ->
+    {
+        if (resource instanceof File && !((File) resource).exists())
+        {
+            logger.warn("Resource {} was of type File but it could not be found",
+                    resource.getName());
+            return false;
+        }
+        return resource.firstLine().equals(TextAtlasBuilder.getNodesHeader());
+    };
+    private static final Predicate<Resource> LOOKS_LIKE_BINARY_ATLAS = resource ->
+    {
+        if (resource instanceof File && !((File) resource).exists())
+        {
+            logger.warn("Resource {} was of type File but it could not be found",
+                    resource.getName());
+            return false;
+        }
+        return !resource.firstLine().equals(TextAtlasBuilder.getNodesHeader());
+    };
+
+    private final Predicate<Resource> resourceFilter;
+    private final Predicate<AtlasEntity> atlasEntityFilter;
+    private String multiAtlasName;
+
+    public AtlasResourceLoader2()
+    {
+        this.resourceFilter = resource -> true;
+        this.atlasEntityFilter = null;
+    }
+
+    /**
+     * Load an {@link Atlas} from the provided {@link Resource}(s). If more than one
+     * {@link Resource} is provided, the method will utilize the {@link MultiAtlas} to combine them.
+     * This method will fail if any of the provided {@link Resource}s do not contain a valid binary
+     * or text {@link Atlas}.
+     *
+     * @param resource
+     *            the {@link Resource}(s) from which to load
+     * @return the loaded {@link Atlas}
+     */
+    public Atlas load(final Resource... resource)
+    {
+        return load(Iterables.from(resource));
+    }
+
+    /**
+     * Load an {@link Atlas} from an {@link Iterable} of {@link Resource}s. If more than one
+     * {@link Resource} is provided, the method will utilize the {@link MultiAtlas} to combine them.
+     * This method will fail if any of the provided {@link Resource}s do not contain a valid binary
+     * or text {@link Atlas}.
+     *
+     * @param input
+     *            the {@link Iterable} of {@link Resource}s from which to load
+     * @return the loaded {@link Atlas}
+     */
+    public Atlas load(final Iterable<? extends Resource> input)
+    {
+        final List<Resource> atlasResources = Iterables.stream(input)
+                .flatMap(this::upcastAndRemoveNullResources).filter(this.resourceFilter)
+                .collectToList();
+
+        /*
+         * It would probably be better to throw an exception here, but for backwards-compatibility
+         * we will return null instead.
+         */
+        if (atlasResources.isEmpty())
+        {
+            return null;
+        }
+        else if (atlasResources.size() == 1)
+        {
+            return loadAndFilterAtlasResource(atlasResources.get(0));
+        }
+        else
+        {
+            return loadAndFilterMultipleAtlasResources(atlasResources);
+        }
+    }
+
+    /**
+     * Load an {@link Atlas} from the provided {@link File} {@link Resource}(s). If any of the
+     * provided {@link File}(s) are directories, the method will recursively descend into the
+     * directory and include every {@link Atlas} it discovers. It identifies {@link Atlas}es by
+     * looking for {@link FileSuffix#ATLAS}, {@link FileSuffix#TEXT_ATLAS}, and
+     * {@link FileSuffix#GZIP_ATLAS} file extensions. Like with the
+     * {@link AtlasResourceLoader2#load} method, this method will utilize the {@link MultiAtlas} to
+     * combine the {@link Atlas}es.
+     *
+     * @param file
+     *            the {@link File}(s) from which to load
+     * @return the loaded {@link Atlas}
+     */
+    public Atlas loadRecursively(final File... file)
+    {
+        return loadRecursively(Iterables.from(file));
+    }
+
+    /**
+     * Load an {@link Atlas} from an {@link Iterable} of {@link File} {@link Resource}s. If any of
+     * the provided {@link File}(s) are directories, the method will recursively descend into the
+     * directory and include every {@link Atlas} it discovers. It identifies {@link Atlas}es by
+     * looking for {@link FileSuffix#ATLAS} {@link FileSuffix#TEXT_ATLAS}, and
+     * {@link FileSuffix#GZIP_ATLAS} file extensions. Like with the
+     * {@link AtlasResourceLoader2#load} method, this method will utilize the {@link MultiAtlas} to
+     * combine the {@link Atlas}es.
+     *
+     * @param input
+     *            the {@link Iterable} of {@link File} {@link Resource}s from which to load
+     * @return the loaded {@link Atlas}
+     */
+    public Atlas loadRecursively(final Iterable<File> input)
+    {
+        // TODO
+        return null;
+    }
+
+    private List<Resource> filterForBinaryAtlasResources(final List<Resource> atlasResources)
+    {
+        return atlasResources.stream().filter(LOOKS_LIKE_BINARY_ATLAS).collect(Collectors.toList());
+    }
+
+    private List<Resource> filterForTextAtlasResources(final List<Resource> atlasResources)
+    {
+        return atlasResources.stream().filter(LOOKS_LIKE_TEXT_ATLAS).collect(Collectors.toList());
+    }
+
+    private Atlas loadAndFilterAtlasResource(final Resource resource)
+    {
+        Atlas result;
+
+        if (resource instanceof File && !((File) resource).exists())
+        {
+            logger.warn("Resource {} was of type File but it could not be found",
+                    resource.getName());
+            return null;
+        }
+
+        if (resource.firstLine().equals(TextAtlasBuilder.getNodesHeader()))
+        {
+            result = new TextAtlasBuilder().read(resource);
+        }
+        else
+        {
+            try
+            {
+                result = PackedAtlas.load(resource);
+            }
+            catch (final Exception exception)
+            {
+                throw new CoreException("Failed to load an atlas from {} with name {}",
+                        resource.getClass().getName(), resource.getName(), exception);
+            }
+        }
+        if (this.atlasEntityFilter != null)
+        {
+            final Optional<Atlas> subAtlas = result.subAtlas(this.atlasEntityFilter,
+                    AtlasCutType.SOFT_CUT);
+            result = subAtlas.orElse(null);
+        }
+        return result;
+    }
+
+    private Atlas loadAndFilterMultipleAtlasResources(final List<Resource> atlasResources)
+    {
+        final List<Resource> binaryResources = filterForBinaryAtlasResources(atlasResources);
+        final List<Resource> textResources = filterForTextAtlasResources(atlasResources);
+
+        /*
+         * There are three scenarios that must be handled. 1) There were only binary atlases. 2)
+         * There was a mix of binary and text atlases. 3) There were only text atlases.
+         */
+        MultiAtlas resultAtlas = null;
+        if (!binaryResources.isEmpty())
+        {
+            resultAtlas = this.atlasEntityFilter == null
+                    ? MultiAtlas.loadFromPackedAtlas(binaryResources)
+                    : MultiAtlas.loadFromPackedAtlas(binaryResources, this.atlasEntityFilter);
+        }
+        if (!textResources.isEmpty())
+        {
+            final List<Atlas> textAtlases = loadAndFilterTextAtlasesFromResources(textResources);
+            if (!textAtlases.isEmpty())
+            {
+                final MultiAtlas textMultiAtlas = new MultiAtlas(textAtlases);
+                /*
+                 * In this case, 'resultAtlas' is not null because there was a mix of binary and
+                 * text atlases.
+                 */
+                if (resultAtlas != null)
+                {
+                    resultAtlas = new MultiAtlas(resultAtlas, textMultiAtlas);
+                }
+                /*
+                 * For this case, there was no previous resultAtlas since no binary atlases for
+                 * found.
+                 */
+                else
+                {
+                    resultAtlas = textMultiAtlas;
+                }
+            }
+        }
+
+        if (this.multiAtlasName != null && resultAtlas != null)
+        {
+            resultAtlas.setName(this.multiAtlasName);
+        }
+        return resultAtlas;
+    }
+
+    private List<Atlas> loadAndFilterTextAtlasesFromResources(
+            final List<Resource> textAtlasResources)
+    {
+        final List<Atlas> textAtlases = new ArrayList<>();
+        for (final Resource textResource : textAtlasResources)
+        {
+            final Atlas atlas = new TextAtlasBuilder().read(textResource);
+            if (this.atlasEntityFilter != null)
+            {
+                final Optional<Atlas> filtered = atlas.subAtlas(this.atlasEntityFilter,
+                        AtlasCutType.SOFT_CUT);
+                if (!filtered.isPresent())
+                {
+                    continue;
+                }
+                textAtlases.add(filtered.get());
+            }
+            else
+            {
+                textAtlases.add(atlas);
+            }
+        }
+        return textAtlases;
+    }
+
+    private List<Resource> upcastAndRemoveNullResources(final Resource resource)
+    {
+        final List<Resource> result = new ArrayList<>();
+        if (resource != null)
+        {
+            result.add(resource);
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/text/TextAtlasBuilder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/text/TextAtlasBuilder.java
@@ -86,7 +86,6 @@ public class TextAtlasBuilder
     }
 
     private static final Logger logger = LoggerFactory.getLogger(TextAtlasBuilder.class);
-
     private static final String NODES_HEADER = "# Nodes";
     private static final String EDGES_HEADER = "# Edges";
     private static final String AREAS_HEADER = "# Areas";
@@ -97,6 +96,11 @@ public class TextAtlasBuilder
     private static final String SECONDARY_SEPARATOR = " || ";
     private static final String TERTIARY_SEPARATOR = " -> ";
     private static final String SEPARATOR_REPLACEMENT = " ";
+
+    public static String getNodesHeader()
+    {
+        return NODES_HEADER;
+    }
 
     public PackedAtlas read(final Resource resource)
     {

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/AbstractResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/AbstractResource.java
@@ -25,6 +25,10 @@ public abstract class AbstractResource implements Resource
     @Override
     public String getName()
     {
+        if (this.name == null)
+        {
+            return Resource.super.getName();
+        }
         return this.name;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
@@ -31,7 +31,7 @@ public enum FileSuffix
     WKT(".wkt"),
     WKB(".wkb");
 
-    private String suffix;
+    private final String suffix;
 
     public static FileSuffix getEnum(final String value)
     {
@@ -42,19 +42,13 @@ public enum FileSuffix
     public static Predicate<Path> pathFilter(final FileSuffix... listOfSuffixes)
     {
         final String suffix = Joiner.on("").join(listOfSuffixes);
-        return path ->
-        {
-            return path.getFileName().toString().toLowerCase().endsWith(suffix);
-        };
+        return path -> path.getFileName().toString().toLowerCase().endsWith(suffix);
     }
 
     public static Predicate<Resource> resourceFilter(final FileSuffix... listOfSuffixes)
     {
         final String suffix = Joiner.on("").join(listOfSuffixes);
-        return resource ->
-        {
-            return resource.getName() == null || resource.getName().endsWith(suffix);
-        };
+        return resource -> resource.getName() == null || resource.getName().endsWith(suffix);
     }
 
     public static Optional<FileSuffix> suffixFor(final String value)

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
@@ -13,6 +13,7 @@ import com.google.common.base.Joiner;
 public enum FileSuffix
 {
     ATLAS(".atlas"),
+    TEXT_ATLAS(".atlas.txt"),
     CHANGESET(".cs"),
     CSV(".csv"),
     GEO_JSON(".geojson"),
@@ -48,7 +49,7 @@ public enum FileSuffix
     public static Predicate<Resource> resourceFilter(final FileSuffix... listOfSuffixes)
     {
         final String suffix = Joiner.on("").join(listOfSuffixes);
-        return resource -> resource.getName() == null || resource.getName().endsWith(suffix);
+        return resource -> resource.getName().endsWith(suffix);
     }
 
     public static Optional<FileSuffix> suffixFor(final String value)

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/FileSuffix.java
@@ -14,6 +14,7 @@ public enum FileSuffix
 {
     ATLAS(".atlas"),
     TEXT_ATLAS(".atlas.txt"),
+    GZIP_ATLAS(".atlas.gz"),
     CHANGESET(".cs"),
     CSV(".csv"),
     GEO_JSON(".geojson"),

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/Resource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/Resource.java
@@ -96,7 +96,7 @@ public interface Resource
      */
     default String getName()
     {
-        return null;
+        return getClass().getName() + "@" + Integer.toHexString(hashCode());
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader2Test.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoader2Test.java
@@ -1,0 +1,44 @@
+package org.openstreetmap.atlas.geography.atlas;
+
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
+import org.openstreetmap.atlas.streaming.resource.File;
+
+/**
+ * @author lcram
+ */
+public class AtlasResourceLoader2Test
+{
+    @Test
+    public void attemptToLoadNonAtlas()
+    {
+        final ByteArrayResource nonAtlasResource = new ByteArrayResource();
+        nonAtlasResource.writeAndClose("some random data");
+
+        new AtlasResourceLoader2().load(nonAtlasResource);
+    }
+
+    @Test
+    public void missingDirectory()
+    {
+        Assert.assertNull(new AtlasResourceLoader2().load(new File(
+                Paths.get(System.getProperty("user.home"), "FileThatDoesntExist").toString())));
+    }
+
+    @Test
+    public void multipleFiles()
+    {
+        final File parent = File.temporaryFolder();
+        try
+        {
+            new AtlasResourceLoader2().load(parent);
+        }
+        finally
+        {
+            parent.deleteRecursively();
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/AtlasResourceLoaderTest.java
@@ -18,9 +18,11 @@ import org.openstreetmap.atlas.geography.Latitude;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Longitude;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader.AtlasFileSelector;
+import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
@@ -153,6 +155,65 @@ public class AtlasResourceLoaderTest
         assert identifier.equals(deserializedIdentifier);
         assert numOfEdges == deserializedNumOfEdges;
         assert numOfNodes == deserializedNumOfNodes;
+    }
+
+    @Test
+    public void testLoadTextBasedAtlasMulti()
+    {
+        final PackedAtlasBuilder builder1 = new PackedAtlasBuilder();
+        builder1.addPoint(1, new Location(Latitude.degrees(1), Longitude.degrees(1)),
+                Maps.hashMap("a", "b"));
+        final Atlas packedAtlas1 = builder1.get();
+
+        final PackedAtlasBuilder builder2 = new PackedAtlasBuilder();
+        builder2.addPoint(2, new Location(Latitude.degrees(2), Longitude.degrees(2)),
+                Maps.hashMap("c", "d"));
+        final Atlas packedAtlas2 = builder2.get();
+
+        final PackedAtlasBuilder builder3 = new PackedAtlasBuilder();
+        builder3.addPoint(3, new Location(Latitude.degrees(3), Longitude.degrees(3)),
+                Maps.hashMap("e", "f"));
+        final Atlas packedAtlas3 = builder3.get();
+
+        final TextAtlasBuilder textBuilder1 = new TextAtlasBuilder();
+        final ByteArrayResource atlasTextResource1 = new ByteArrayResource()
+                .withName("iAmATextAtlas1.atlas.txt");
+        textBuilder1.write(packedAtlas1, atlasTextResource1);
+
+        final TextAtlasBuilder textBuilder2 = new TextAtlasBuilder();
+        final ByteArrayResource atlasTextResource2 = new ByteArrayResource()
+                .withName("iAmATextAtlas2.atlas.txt");
+        textBuilder2.write(packedAtlas2, atlasTextResource2);
+
+        final ByteArrayResource atlasBinaryResource1 = new ByteArrayResource()
+                .withName("iAmABinaryAtlas1.atlas");
+        packedAtlas3.save(atlasBinaryResource1);
+
+        final Atlas loadedAtlas1 = new AtlasResourceLoader().load(atlasTextResource1,
+                atlasTextResource2);
+        Assert.assertEquals(new MultiAtlas(packedAtlas1, packedAtlas2), loadedAtlas1);
+
+        final Atlas loadedAtlas2 = new AtlasResourceLoader().load(atlasTextResource1,
+                atlasTextResource2, atlasBinaryResource1);
+        Assert.assertEquals(new MultiAtlas(packedAtlas1, packedAtlas2, packedAtlas3), loadedAtlas2);
+    }
+
+    @Test
+    public void testLoadTextBasedAtlasSingle()
+    {
+        final PackedAtlasBuilder builder = new PackedAtlasBuilder();
+        builder.addPoint(1, new Location(Latitude.degrees(0), Longitude.degrees(0)),
+                Maps.hashMap("a", "b"));
+        final Atlas packedAtlas = builder.get();
+
+        final TextAtlasBuilder textBuilder = new TextAtlasBuilder();
+        final ByteArrayResource atlasTextResource = new ByteArrayResource()
+                .withName("iAmATextAtlas.atlas.txt");
+        textBuilder.write(packedAtlas, atlasTextResource);
+
+        final Atlas loadedAtlas = new AtlasResourceLoader().load(atlasTextResource);
+
+        Assert.assertEquals(packedAtlas, loadedAtlas);
     }
 
     @Test


### PR DESCRIPTION
### Description:
`AtlasResourceLoader` can now handle text based atlases. Note that it expects text based atlases to have the extension `.atlas.txt`

### Potential Impact:
Should be none, but users now no longer need to add explicit handling code when testing with text vs binary atlases.

### Unit Test Approach:
Added some unit tests. See diff.

### Test Results:
Tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)