### PR TITLE
Better error message for null boundary

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -907,6 +907,11 @@ public class CountryBoundaryMap implements Serializable, GeoJson
         // Last piece is cells
         STRtree gridIndexFromFile = null;
 
+        if (resource == null)
+        {
+            throw new CoreException("Boundary map resource is null and could not be read.");
+        }
+
         for (final String line : resource.lines())
         {
             // Ignore empty lines


### PR DESCRIPTION
### Description:

Previously if a boundary resource was left blank or mistyped, atlas generation would throw a NPE. This adds a check for null boundary resource when attempting to read the boundary file.

### Potential Impact:

Better error description.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
