### PR TITLE
Shard bounds command now supports a reverse match

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommand.java
@@ -2,13 +2,20 @@ package org.openstreetmap.atlas.utilities.command.subcommands;
 
 import java.util.List;
 
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.converters.WktPolygonConverter;
+import org.openstreetmap.atlas.geography.sharding.GeoHashSharding;
+import org.openstreetmap.atlas.geography.sharding.GeoHashTile;
 import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
 import org.openstreetmap.atlas.geography.sharding.converters.StringToShardConverter;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
 import org.openstreetmap.atlas.utilities.command.parsing.ArgumentArity;
 import org.openstreetmap.atlas.utilities.command.parsing.ArgumentOptionality;
+import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.terminal.TTYAttribute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +27,12 @@ public class ShardToBoundsCommand extends AbstractAtlasShellToolsCommand
 {
     private static final Logger logger = LoggerFactory.getLogger(ShardToBoundsCommand.class);
 
-    private static final String INPUT_SHARDS = "shards";
+    private static final String REVERSE_OPTION_LONG = "reverse";
+    private static final String REVERSE_OPTION_DESCRIPTION = "Convert given WKT bound(s) to SlippyTile/GeoHashTile shard(s) if possible. Supports up to slippy zoom level "
+            + Sharding.SLIPPY_ZOOM_MAXIMUM + " and geohash precision "
+            + GeoHashTile.MAXIMUM_PRECISION + ".";
+
+    private static final String INPUT = "input";
 
     private final OptionAndArgumentDelegate optionAndArgumentDelegate;
     private final CommandOutputDelegate outputDelegate;
@@ -39,18 +51,36 @@ public class ShardToBoundsCommand extends AbstractAtlasShellToolsCommand
     @Override
     public int execute()
     {
-        final List<String> shards = this.optionAndArgumentDelegate
-                .getVariadicArgument(INPUT_SHARDS);
-
-        for (int i = 0; i < shards.size(); i++)
+        if (this.optionAndArgumentDelegate.hasOption(REVERSE_OPTION_LONG))
         {
-            final String shard = shards.get(i);
-            parseShardAndPrintOutput(shard);
+            final List<String> wkts = this.optionAndArgumentDelegate.getVariadicArgument(INPUT);
 
-            // Only print a separating newline if there were multiple entries
-            if (i < shards.size() - 1)
+            for (int i = 0; i < wkts.size(); i++)
             {
-                this.outputDelegate.printlnStdout("");
+                final String wkt = wkts.get(i);
+                parseWktAndPrintOutput(wkt);
+
+                // Only print a separating newline if there were multiple entries
+                if (i < wkts.size() - 1)
+                {
+                    this.outputDelegate.printlnStdout("");
+                }
+            }
+        }
+        else
+        {
+            final List<String> shards = this.optionAndArgumentDelegate.getVariadicArgument(INPUT);
+
+            for (int i = 0; i < shards.size(); i++)
+            {
+                final String shard = shards.get(i);
+                parseShardAndPrintOutput(shard);
+
+                // Only print a separating newline if there were multiple entries
+                if (i < shards.size() - 1)
+                {
+                    this.outputDelegate.printlnStdout("");
+                }
             }
         }
 
@@ -81,7 +111,8 @@ public class ShardToBoundsCommand extends AbstractAtlasShellToolsCommand
     @Override
     public void registerOptionsAndArguments()
     {
-        registerArgument(INPUT_SHARDS, ArgumentArity.VARIADIC, ArgumentOptionality.REQUIRED);
+        registerOption(REVERSE_OPTION_LONG, REVERSE_OPTION_DESCRIPTION, OptionOptionality.OPTIONAL);
+        registerArgument(INPUT, ArgumentArity.VARIADIC, ArgumentOptionality.REQUIRED);
         super.registerOptionsAndArguments();
     }
 
@@ -99,5 +130,47 @@ public class ShardToBoundsCommand extends AbstractAtlasShellToolsCommand
             return;
         }
         this.outputDelegate.printlnStdout(shard.bounds().toWkt(), TTYAttribute.GREEN);
+    }
+
+    private void parseWktAndPrintOutput(final String wkt)
+    {
+        final Polygon polygon;
+        try
+        {
+            polygon = new WktPolygonConverter().backwardConvert(wkt);
+        }
+        catch (final Exception exception)
+        {
+            logger.error("unable to parse WKT polygon {}", wkt, exception);
+            return;
+        }
+        for (int zoom = 1; zoom <= Sharding.SLIPPY_ZOOM_MAXIMUM; zoom++)
+        {
+            final SlippyTileSharding sharding = new SlippyTileSharding(zoom);
+            for (final Shard shard : sharding.shardsIntersecting(polygon))
+            {
+                if (shard.toWkt().equals(wkt))
+                {
+                    this.outputDelegate.printlnStdout(wkt + " exactly matched shard:",
+                            TTYAttribute.BOLD);
+                    this.outputDelegate.printlnStdout(shard.toString(), TTYAttribute.GREEN);
+                    return;
+                }
+            }
+        }
+        for (int precision = 1; precision <= GeoHashTile.MAXIMUM_PRECISION; precision++)
+        {
+            final GeoHashSharding sharding = new GeoHashSharding(precision);
+            for (final Shard shard : sharding.shardsIntersecting(polygon))
+            {
+                if (shard.toWkt().equals(wkt))
+                {
+                    this.outputDelegate.printlnStdout(wkt + " exactly matched shard:",
+                            TTYAttribute.BOLD);
+                    this.outputDelegate.printlnStdout(shard.toString(), TTYAttribute.GREEN);
+                    return;
+                }
+            }
+        }
     }
 }

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandDescriptionSection.txt
@@ -1,3 +1,8 @@
 Given a shard (or multiple shards) in any format, output the WKT of the shard's boundary. This
 boundary will always be a rectangle. The shards should be specified using their getName() string
 format, e.g. the SlippyTile shard for [Zoom: 9, X: 168, Y: 233] would be specified as '9-168-233'.
+
+This command also supports a reverse match for SlippyTile and GeoHashTile shards using the
+'--reverse' option. The reverse match expects WKT polygon(s) as input, and will spit out any shards
+whose bounds exactly match a given WKT. If no matches are found, the command will print nothing and
+exit.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/ShardToBoundsCommandExamplesSection.txt
@@ -4,3 +4,5 @@ Get the boundary of a GeoHashTile shard:
 #$ shard-bounds dd4fb
 Get the boundaries of an assortment of shards:
 #$ shard-bounds DMA_9-168-233 1-2-3 f45tkp8n
+Get the shard, if it exists, with the given bounds:
+#$ shard-bounds --reverse 'POLYGON ((0 -85.0511288, 0 0, 180 0, 180 -85.0511288, 0 -85.0511288))'


### PR DESCRIPTION
### Description:
The `shard-bounds` command can now do a reverse match using `--reverse`. E.g.
```
$ atlas shard-bounds --reverse 'POLYGON ((-67.5 74.0195433, -67.5 79.1713346, -45 79.1713346, -45 74.0195433, -67.5 74.0195433))' 'POLYGON ((-53.4375 59.4140625, -53.4375 59.5898438, -53.0859375 59.5898438, -53.0859375 59.4140625, -53.4375 59.4140625))'
POLYGON ((-67.5 74.0195433, -67.5 79.1713346, -45 79.1713346, -45 74.0195433, -67.5 74.0195433)) exactly matched shard:
[SlippyTile: zoom = 4, x = 5, y = 2]

POLYGON ((-53.4375 59.4140625, -53.4375 59.5898438, -53.0859375 59.5898438, -53.0859375 59.4140625, -53.4375 59.4140625)) exactly matched shard:
[GeoHashTile: value = ffd4]
```

### Potential Impact:
Users now have more functionality.

### Unit Test Approach:
Ran local tests with command line.

### Test Results:
Command looks good!

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)