### PR TITLE
Separate out JTS-based enclosing method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Polygon.java
@@ -197,9 +197,7 @@ public class Polygon extends PolyLine implements GeometricSurface
         // if this value overflows, use JTS to correctly calculate covers
         if (awtOverflows())
         {
-            final org.locationtech.jts.geom.Polygon polygon = JTS_POLYGON_CONVERTER.convert(this);
-            final Point point = new JtsPointConverter().convert(location);
-            return polygon.covers(point);
+            return fullyGeometricallyEnclosesJTS(location);
         }
         // for most cases use the faster awt covers
         else
@@ -290,6 +288,23 @@ public class Polygon extends PolyLine implements GeometricSurface
             }
         }
         return this.fullyGeometricallyEncloses(segment.middle());
+    }
+
+    /**
+     * Tests if this {@link Polygon} fully encloses (geometrically contains) a {@link Location}
+     * according to the JTS definition, which includes points touching all boundaries of the
+     * polygon.
+     * 
+     * @param location
+     *            The location to test
+     * @return True if the {@link Polygon} fully encloses (geometrically contains) the
+     *         {@link Location}
+     */
+    public boolean fullyGeometricallyEnclosesJTS(final Location location)
+    {
+        final org.locationtech.jts.geom.Polygon polygon = JTS_POLYGON_CONVERTER.convert(this);
+        final Point point = new JtsPointConverter().convert(location);
+        return polygon.covers(point);
     }
 
     @Override


### PR DESCRIPTION
### Description:

When calling `fullyGeometricallyEncloses ` on a location, the default method uses AWT by default which is really fast, but excludes some points that are on the Polygon's boundary.
This update separates the JTS-based version of that call so the user can choose to have greater accuracy and accept a worse performance.

### Potential Impact:

A new option for the user, the rest should not change

### Unit Test Approach:

Covered by existing tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
