### PR TITLE
Fixed a file extension in packed2text

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
@@ -109,7 +109,8 @@ public class PackedToTextAtlasCommand extends AtlasLoaderCommand
         if (this.optionAndArgumentDelegate
                 .getParserContext() == AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT)
         {
-            outputFile = new File(concatenatedPath.toAbsolutePath().toString() + FileSuffix.TEXT);
+            outputFile = new File(
+                    concatenatedPath.toAbsolutePath().toString() + FileSuffix.TEXT_ATLAS);
             outputAtlas.saveAsText(outputFile);
         }
         else if (this.optionAndArgumentDelegate.getParserContext() == GEOJSON_CONTEXT)


### PR DESCRIPTION
### Description:
`packed2text` now saves text atlases with `.atlas.txt` instead of `.txt`. This complies with the new `AtlasResourceLoader` mechanics.

### Potential Impact:
Users will see different file extensions.

### Unit Test Approach:
Command line testing.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)