### PR TITLE
AtlasEntity isCountrySliced Method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
@@ -24,7 +23,8 @@ import com.google.gson.JsonObject;
 public abstract class Area extends AtlasItem
 {
     private static final long serialVersionUID = 5244165133018408045L;
-    private static final Pattern CUT_IDENTIFIER_PATTERN = Pattern.compile("\\d*[1-9]000");
+    private static final int IDENTIFIER_SUFFIX_LENGTH = 6;
+    private static final int COUNTRY_SLICED_DIVISOR = 1000;
 
     protected Area(final Atlas atlas)
     {
@@ -82,7 +82,14 @@ public abstract class Area extends AtlasItem
     @Override
     public boolean isCountrySliced()
     {
-        return CUT_IDENTIFIER_PATTERN.matcher(String.valueOf(this.getIdentifier())).matches();
+        // Get the last 6 digits of the identifier
+        final String stringIdentifier = String.valueOf(this.getIdentifier());
+        final int lastSix = stringIdentifier.length() > IDENTIFIER_SUFFIX_LENGTH ? Integer.parseInt(
+                stringIdentifier.substring(stringIdentifier.length() - IDENTIFIER_SUFFIX_LENGTH))
+                : 0;
+        // If the the last 6 digits are not equal to 0 and are dividable by 1000 then this is
+        // country sliced
+        return lastSix != 0 && lastSix % COUNTRY_SLICED_DIVISOR == 0;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
@@ -87,7 +87,7 @@ public abstract class Area extends AtlasItem
         final int lastSix = stringIdentifier.length() > IDENTIFIER_SUFFIX_LENGTH ? Integer.parseInt(
                 stringIdentifier.substring(stringIdentifier.length() - IDENTIFIER_SUFFIX_LENGTH))
                 : 0;
-        // If the the last 6 digits are not equal to 0 and are dividable by 1000 then this is
+        // If the the last 6 digits are not equal to 0 and are divisible by 1000 then this is
         // country sliced
         return lastSix != 0 && lastSix % COUNTRY_SLICED_DIVISOR == 0;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
@@ -23,6 +24,7 @@ import com.google.gson.JsonObject;
 public abstract class Area extends AtlasItem
 {
     private static final long serialVersionUID = 5244165133018408045L;
+    private static final Pattern CUT_IDENTIFIER_PATTERN = Pattern.compile("\\d*[1-9]000");
 
     protected Area(final Atlas atlas)
     {
@@ -75,6 +77,12 @@ public abstract class Area extends AtlasItem
     public boolean intersects(final GeometricSurface surface)
     {
         return surface.overlaps(asPolygon());
+    }
+
+    @Override
+    public boolean isCountrySliced()
+    {
+        return CUT_IDENTIFIER_PATTERN.matcher(String.valueOf(this.getIdentifier())).matches();
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/AtlasEntity.java
@@ -194,6 +194,11 @@ public abstract class AtlasEntity
     public abstract boolean intersects(GeometricSurface surface);
 
     /**
+     * @return true if the entity has been sliced at a country border
+     */
+    public abstract boolean isCountrySliced();
+
+    /**
      * @return If available, the {@link Time} at which the entity was last edited.
      */
     public Optional<Time> lastEdit()

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.slicing.identifier.ReverseIdentifierFactory;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 
 import com.google.gson.JsonObject;
 
@@ -232,6 +233,12 @@ public abstract class Edge extends LineItem implements Comparable<Edge>
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isCountrySliced()
+    {
+        return this.connectedNodes().stream().anyMatch(SyntheticBoundaryNodeTag::isBoundaryNode);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
@@ -32,7 +32,7 @@ public abstract class Line extends LineItem
         final int lastSix = stringIdentifier.length() > IDENTIFIER_SUFFIX_LENGTH ? Integer.parseInt(
                 stringIdentifier.substring(stringIdentifier.length() - IDENTIFIER_SUFFIX_LENGTH))
                 : 0;
-        // If the the last 6 digits are not equal to 0 and are dividable by 1000 then this is
+        // If the the last 6 digits are not equal to 0 and are divisible by 1000 then this is
         // country sliced
         return lastSix != 0 && lastSix % COUNTRY_SLICED_DIVISOR == 0;
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
@@ -1,7 +1,5 @@
 package org.openstreetmap.atlas.geography.atlas.items;
 
-import java.util.regex.Pattern;
-
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 
 /**
@@ -12,7 +10,8 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 public abstract class Line extends LineItem
 {
     private static final long serialVersionUID = 5348604376185677L;
-    private static final Pattern CUT_IDENTIFIER_PATTERN = Pattern.compile("\\d*[1-9]000");
+    private static final int IDENTIFIER_SUFFIX_LENGTH = 6;
+    private static final int COUNTRY_SLICED_DIVISOR = 1000;
 
     protected Line(final Atlas atlas)
     {
@@ -28,7 +27,14 @@ public abstract class Line extends LineItem
     @Override
     public boolean isCountrySliced()
     {
-        return CUT_IDENTIFIER_PATTERN.matcher(String.valueOf(this.getIdentifier())).matches();
+        // Get the last 6 digits of the identifier
+        final String stringIdentifier = String.valueOf(this.getIdentifier());
+        final int lastSix = stringIdentifier.length() > IDENTIFIER_SUFFIX_LENGTH ? Integer.parseInt(
+                stringIdentifier.substring(stringIdentifier.length() - IDENTIFIER_SUFFIX_LENGTH))
+                : 0;
+        // If the the last 6 digits are not equal to 0 and are dividable by 1000 then this is
+        // country sliced
+        return lastSix != 0 && lastSix % COUNTRY_SLICED_DIVISOR == 0;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Line.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.items;
 
+import java.util.regex.Pattern;
+
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 
 /**
@@ -10,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 public abstract class Line extends LineItem
 {
     private static final long serialVersionUID = 5348604376185677L;
+    private static final Pattern CUT_IDENTIFIER_PATTERN = Pattern.compile("\\d*[1-9]000");
 
     protected Line(final Atlas atlas)
     {
@@ -20,6 +23,12 @@ public abstract class Line extends LineItem
     public ItemType getType()
     {
         return ItemType.LINE;
+    }
+
+    @Override
+    public boolean isCountrySliced()
+    {
+        return CUT_IDENTIFIER_PATTERN.matcher(String.valueOf(this.getIdentifier())).matches();
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Node.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Node.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 
 import org.apache.commons.lang3.Validate;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -94,6 +95,12 @@ public abstract class Node extends LocationItem
      * @return The {@link Edge}s that end at this node
      */
     public abstract SortedSet<Edge> inEdges();
+
+    @Override
+    public boolean isCountrySliced()
+    {
+        return SyntheticBoundaryNodeTag.isBoundaryNode(this);
+    }
 
     /**
      * @return The {@link Edge}s that start at this node

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java
@@ -23,6 +23,12 @@ public abstract class Point extends LocationItem
     }
 
     @Override
+    public boolean isCountrySliced()
+    {
+        return false;
+    }
+
+    @Override
     public String toDiffViewFriendlyString()
     {
         final String relationsString = this.parentRelationsAsDiffViewFriendlyString();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.items;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 
 /**
  * A Point that is not navigable.
@@ -25,7 +26,7 @@ public abstract class Point extends LocationItem
     @Override
     public boolean isCountrySliced()
     {
-        return false;
+        return SyntheticBoundaryNodeTag.isBoundaryNode(this);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java
@@ -304,6 +304,12 @@ public abstract class Relation extends AtlasEntity
         return intersectsInternal(surface, new LinkedHashSet<>());
     }
 
+    @Override
+    public boolean isCountrySliced()
+    {
+        return this.members().stream().anyMatch(member -> member.getEntity().isCountrySliced());
+    }
+
     public boolean isMultiPolygon()
     {
         return Validators.isOfType(this, RelationTypeTag.class, RelationTypeTag.MULTIPOLYGON,

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTest.java
@@ -17,13 +17,13 @@ public class CountrySliceTest
     @Test
     public void areaNotSliced()
     {
-        Assert.assertFalse(this.rule.getAtlas().area(1000000L).isCountrySliced());
+        Assert.assertFalse(this.rule.getAtlas().area(1L).isCountrySliced());
     }
 
     @Test
     public void areaSliced()
     {
-        Assert.assertTrue(this.rule.getAtlas().area(2001000L).isCountrySliced());
+        Assert.assertTrue(this.rule.getAtlas().area(2010000L).isCountrySliced());
     }
 
     @Test
@@ -63,15 +63,15 @@ public class CountrySliceTest
     }
 
     @Test
-    public void pointAlsoNotSliced()
-    {
-        Assert.assertFalse(this.rule.getAtlas().point(2000000L).isCountrySliced());
-    }
-
-    @Test
     public void pointNotSliced()
     {
         Assert.assertFalse(this.rule.getAtlas().point(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void pointSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().point(2000000L).isCountrySliced());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTest.java
@@ -1,0 +1,88 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AtlasEntity#isCountrySliced()}.
+ *
+ * @author bbreithaupt
+ */
+public class CountrySliceTest
+{
+    @Rule
+    public final CountrySliceTestRule rule = new CountrySliceTestRule();
+
+    @Test
+    public void areaNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().area(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void areaSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().area(2001000L).isCountrySliced());
+    }
+
+    @Test
+    public void edgeNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().edge(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void edgeSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().edge(2000000L).isCountrySliced());
+    }
+
+    @Test
+    public void lineNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().line(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void lineSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().line(2001000L).isCountrySliced());
+    }
+
+    @Test
+    public void nodeNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().node(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void nodeSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().node(3000000L).isCountrySliced());
+    }
+
+    @Test
+    public void pointAlsoNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().point(2000000L).isCountrySliced());
+    }
+
+    @Test
+    public void pointNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().point(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void relationNotSliced()
+    {
+        Assert.assertFalse(this.rule.getAtlas().relation(1000000L).isCountrySliced());
+    }
+
+    @Test
+    public void relationSliced()
+    {
+        Assert.assertTrue(this.rule.getAtlas().relation(2000000L).isCountrySliced());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTestRule.java
@@ -31,9 +31,9 @@ public class CountrySliceTestRule extends CoreTestRule
                             "synthetic_boundary_node=yes" }) },
             // Areas
             areas = {
-                    @Area(id = "1000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
+                    @Area(id = "1", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
                             @Loc(value = THREE), @Loc(value = ONE) }),
-                    @Area(id = "2001000", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
+                    @Area(id = "2010000", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
                             @Loc(value = THREE), @Loc(value = ONE) }) },
             // Edges
             edges = { @Edge(id = "1000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
@@ -45,15 +45,16 @@ public class CountrySliceTestRule extends CoreTestRule
                             @Loc(value = THREE) }) },
             // Points
             points = { @Point(id = "1000000", coordinates = @Loc(value = ONE)),
-                    @Point(id = "2000000", coordinates = @Loc(value = THREE)) },
+                    @Point(id = "2000000", coordinates = @Loc(value = THREE), tags = {
+                            "synthetic_boundary_node=yes" }) },
             // Relations
             relations = {
                     @Relation(id = "1000000", members = {
                             @Member(id = "1000000", role = "", type = "node"),
-                            @Member(id = "1000000", role = "", type = "area") }),
+                            @Member(id = "1", role = "", type = "area") }),
                     @Relation(id = "2000000", members = {
                             @Member(id = "1000000", role = "", type = "node"),
-                            @Member(id = "2001000", role = "", type = "area") }) })
+                            @Member(id = "2010000", role = "", type = "area") }) })
     private Atlas atlas;
 
     public Atlas getAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/CountrySliceTestRule.java
@@ -1,0 +1,63 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * Unit test rule for {@link CountrySliceTest}.
+ *
+ * @author bbreithaupt
+ */
+public class CountrySliceTestRule extends CoreTestRule
+{
+    private static final String ONE = "62.614939, -141.000650";
+    private static final String TWO = "62.615151, -141.001114";
+    private static final String THREE = "62.615304, -141.001447";
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE), tags = {
+                            "synthetic_boundary_node=yes" }) },
+            // Areas
+            areas = {
+                    @Area(id = "1000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
+                            @Loc(value = THREE), @Loc(value = ONE) }),
+                    @Area(id = "2001000", coordinates = { @Loc(value = ONE), @Loc(value = TWO),
+                            @Loc(value = THREE), @Loc(value = ONE) }) },
+            // Edges
+            edges = { @Edge(id = "1000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = ONE),
+                            @Loc(value = THREE) }) },
+            // Lines
+            lines = { @Line(id = "1000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Line(id = "2001000", coordinates = { @Loc(value = ONE),
+                            @Loc(value = THREE) }) },
+            // Points
+            points = { @Point(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Point(id = "2000000", coordinates = @Loc(value = THREE)) },
+            // Relations
+            relations = {
+                    @Relation(id = "1000000", members = {
+                            @Member(id = "1000000", role = "", type = "node"),
+                            @Member(id = "1000000", role = "", type = "area") }),
+                    @Relation(id = "2000000", members = {
+                            @Member(id = "1000000", role = "", type = "node"),
+                            @Member(id = "2001000", role = "", type = "area") }) })
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}


### PR DESCRIPTION
### Description:
When working with country sliced atlases it is often necessary to control for edge effects by filtering out Atlas entities that have been trimmed at the border. This is frequently done in AtlasChecks when working with Edges and Edge networks by checking for synthetic boundary nodes. 
This seeks to make that process easier and more uniform for all Atlas entities by adding an `isCountrySliced()` method to the abstract AtlasEntity class. Each entity has its own logic for calculation this as detailed below.

isCountrySliced logic:
Area: identifier suffix is an increment of 1000
Edge: is connected to a synthetic boundary node
Line: identifier suffix is an increment of 1000
Node: has a synthetic boundary node tag
Point: has a synthetic boundary node tag
Relation: any of its members are country sliced


### Potential Impact:
Requires an extra method for classes that extend AtlasEntity.
Should make identifying country sliced entities easier.

### Unit Test Approach:

Created unit tests for each type of AtlasEntity that check sliced and non-sliced versions. 

### Test Results:
Tested using the `isCountrySliced()` method as a filter to create a sub atlas from a country sliced atlas. The resulting sub atlas contained all of the AtlasEntity types, and sampling the entities showed them to all have been country sliced.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
