### PR TITLE
Option for quadratic wait in Retry

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -19,9 +19,9 @@ public final class Duration implements Serializable, Comparable<Duration>
     public static final Duration ONE_SECOND = seconds(1);
     public static final Duration ZERO = milliseconds(0);
     public static final Duration MAXIMUM = milliseconds(Long.MAX_VALUE);
+
     private static final long NANOSECONDS_PER_MILLISECONDS = 1_000_000;
     private static final long MILLISECONDS_PER_SECOND = 1000;
-
     private static final long SECONDS_PER_MINUTE = 60;
     private static final long MINUTES_PER_HOUR = 60;
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -17,10 +17,8 @@ public final class Duration implements Serializable, Comparable<Duration>
     public static final Duration ONE_HOUR = hours(1);
     public static final Duration ONE_MINUTE = minutes(1);
     public static final Duration ONE_SECOND = seconds(1);
-
     public static final Duration ZERO = milliseconds(0);
     public static final Duration MAXIMUM = milliseconds(Long.MAX_VALUE);
-
     private static final long NANOSECONDS_PER_MILLISECONDS = 1_000_000;
     private static final long MILLISECONDS_PER_SECOND = 1000;
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -13,18 +13,20 @@ public final class Duration implements Serializable, Comparable<Duration>
 {
     private static final long serialVersionUID = 8306012362496627267L;
 
+    public static final Duration ONE_DAY = hours(24);
+    public static final Duration ONE_HOUR = hours(1);
+    public static final Duration ONE_MINUTE = minutes(1);
     public static final Duration ONE_SECOND = seconds(1);
 
     public static final Duration ZERO = milliseconds(0);
     public static final Duration MAXIMUM = milliseconds(Long.MAX_VALUE);
+
     private static final long NANOSECONDS_PER_MILLISECONDS = 1_000_000;
     private static final long MILLISECONDS_PER_SECOND = 1000;
 
     private static final long SECONDS_PER_MINUTE = 60;
-    public static final Duration ONE_MINUTE = minutes(1);
     private static final long MINUTES_PER_HOUR = 60;
-    public static final Duration ONE_DAY = hours(24);
-    public static final Duration ONE_HOUR = hours(1);
+
     private final long milliseconds;
 
     public static Duration hours(final double hours)

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -12,11 +12,14 @@ import org.openstreetmap.atlas.exception.CoreException;
 public final class Duration implements Serializable, Comparable<Duration>
 {
     private static final long serialVersionUID = 8306012362496627267L;
+
+    public static final Duration ONE_SECOND = seconds(1);
+
     public static final Duration ZERO = milliseconds(0);
     public static final Duration MAXIMUM = milliseconds(Long.MAX_VALUE);
     private static final long NANOSECONDS_PER_MILLISECONDS = 1_000_000;
     private static final long MILLISECONDS_PER_SECOND = 1000;
-    public static final Duration ONE_SECOND = seconds(1);
+
     private static final long SECONDS_PER_MINUTE = 60;
     public static final Duration ONE_MINUTE = minutes(1);
     private static final long MINUTES_PER_HOUR = 60;

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Duration.java
@@ -12,19 +12,16 @@ import org.openstreetmap.atlas.exception.CoreException;
 public final class Duration implements Serializable, Comparable<Duration>
 {
     private static final long serialVersionUID = 8306012362496627267L;
-
-    public static final Duration ONE_DAY = hours(24);
-    public static final Duration ONE_HOUR = hours(1);
-    public static final Duration ONE_MINUTE = minutes(1);
-    public static final Duration ONE_SECOND = seconds(1);
     public static final Duration ZERO = milliseconds(0);
     public static final Duration MAXIMUM = milliseconds(Long.MAX_VALUE);
-
     private static final long NANOSECONDS_PER_MILLISECONDS = 1_000_000;
     private static final long MILLISECONDS_PER_SECOND = 1000;
+    public static final Duration ONE_SECOND = seconds(1);
     private static final long SECONDS_PER_MINUTE = 60;
+    public static final Duration ONE_MINUTE = minutes(1);
     private static final long MINUTES_PER_HOUR = 60;
-
+    public static final Duration ONE_DAY = hours(24);
+    public static final Duration ONE_HOUR = hours(1);
     private final long milliseconds;
 
     public static Duration hours(final double hours)
@@ -182,6 +179,15 @@ public final class Duration implements Serializable, Comparable<Duration>
         {
             throw new CoreException("Could not sleep {}", this, e);
         }
+    }
+
+    public Duration times(final double multiplier)
+    {
+        if (multiplier < 0)
+        {
+            throw new CoreException("Duration multiplier cannot be negative. Was {}", multiplier);
+        }
+        return Duration.seconds(this.asSeconds() * multiplier);
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/DurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/DurationTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.utilities.time.Time;
 
 /**
@@ -72,5 +73,19 @@ public class DurationTest
         // sort and test
         durationUnsorted.sort(Duration::compareTo);
         Assert.assertEquals(durationSorted, durationUnsorted);
+    }
+
+    @Test
+    public void testTimes()
+    {
+        final Duration duration = Duration.ONE_SECOND;
+        Assert.assertEquals(2.0, duration.times(2.0).asSeconds(), 3);
+        Assert.assertEquals(5000.0, duration.times(5000.0).asSeconds(), 3);
+    }
+
+    @Test(expected = CoreException.class)
+    public void testTimesException()
+    {
+        Duration.ONE_SECOND.times(-2.0);
     }
 }


### PR DESCRIPTION
### Description:

Add an option in `Retry` to wait twice as long as the time before. We call it quadratic wait.

### Potential Impact:

None, this is a new option. Linear wait is still supported

### Unit Test Approach:

Updated unit tests and added new ones

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
