### PR TITLE
Quadratic retries with the NamespaceCachingStrategy

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -41,7 +41,7 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
     private static final String PROPERTY_LOCAL_TEMPORARY_DIRECTORY = "java.io.tmpdir";
     private static final String TEMPORARY_DIRECTORY_STRING = System
             .getProperty(PROPERTY_LOCAL_TEMPORARY_DIRECTORY);
-    private static final Retry RETRY = new Retry(5, Duration.ONE_SECOND);
+    private static final Retry RETRY = new Retry(5, Duration.ONE_SECOND).withQuadratic(true);
 
     private final String namespace;
     private boolean preserveFileExtension;

--- a/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/caching/strategies/NamespaceCachingStrategy.java
@@ -41,7 +41,9 @@ public class NamespaceCachingStrategy extends AbstractCachingStrategy
     private static final String PROPERTY_LOCAL_TEMPORARY_DIRECTORY = "java.io.tmpdir";
     private static final String TEMPORARY_DIRECTORY_STRING = System
             .getProperty(PROPERTY_LOCAL_TEMPORARY_DIRECTORY);
-    private static final Retry RETRY = new Retry(5, Duration.ONE_SECOND).withQuadratic(true);
+    private static final int RETRY_NUMBER = 5;
+    private static final Retry RETRY = new Retry(RETRY_NUMBER, Duration.ONE_SECOND)
+            .withQuadratic(true);
 
     private final String namespace;
     private boolean preserveFileExtension;


### PR DESCRIPTION
### Description:

Retries happen mostly with network-based file systems, and for those it is always better to wait longer and longer between retries. This does that for the `NamespaceCachingStrategy`.

### Potential Impact:

None

### Unit Test Approach:

This is covered by existing tests!

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
