### PR TITLE
WktPolygonConverter to read single outer MultiPolygons

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/converters/WktPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/WktPolygonConverter.java
@@ -5,7 +5,9 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.converters.jts.JtsMultiPolygonToMultiPolygonConverter;
 import org.openstreetmap.atlas.geography.converters.jts.JtsPolygonConverter;
 import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
 
@@ -13,23 +15,41 @@ import org.openstreetmap.atlas.utilities.conversion.TwoWayConverter;
  * Given an WKT string generate a Polygon and vice-versa
  *
  * @author cstaylor
+ * @author matthieun
  */
 public class WktPolygonConverter implements TwoWayConverter<Polygon, String>
 {
+    private static final JtsMultiPolygonToMultiPolygonConverter JTS_MULTI_POLYGON_TO_MULTI_POLYGON_CONVERTER = new JtsMultiPolygonToMultiPolygonConverter();
+
     @Override
     public Polygon backwardConvert(final String wkt)
     {
-        org.locationtech.jts.geom.Polygon geometry = null;
         final WKTReader myReader = new WKTReader();
         try
         {
-            geometry = (org.locationtech.jts.geom.Polygon) myReader.read(wkt);
+            final Geometry result = myReader.read(wkt);
+            if (result instanceof org.locationtech.jts.geom.Polygon)
+            {
+                return new JtsPolygonConverter()
+                        .backwardConvert((org.locationtech.jts.geom.Polygon) result);
+            }
+            else if (result instanceof org.locationtech.jts.geom.MultiPolygon)
+            {
+                final MultiPolygon castResult = JTS_MULTI_POLYGON_TO_MULTI_POLYGON_CONVERTER
+                        .convert((org.locationtech.jts.geom.MultiPolygon) result);
+                if (castResult.outers().size() == 1 && castResult.inners().isEmpty())
+                {
+                    return castResult.outers().iterator().next();
+                }
+            }
+            throw new CoreException(
+                    "Cannot convert wkt which is not a Polygon or single-outer MultiPolygon: {}",
+                    wkt);
         }
-        catch (final ParseException | ClassCastException e)
+        catch (final ParseException e)
         {
-            throw new CoreException("Cannot parse wkt : {}", wkt);
+            throw new CoreException("Cannot parse wkt: {}", wkt, e);
         }
-        return new JtsPolygonConverter().backwardConvert(geometry);
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/geography/converters/WktPolygonConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/converters/WktPolygonConverterTest.java
@@ -1,0 +1,43 @@
+package org.openstreetmap.atlas.geography.converters;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Polygon;
+
+/**
+ * @author matthieun
+ */
+public class WktPolygonConverterTest
+{
+    private static final WktPolygonConverter CONVERTER = new WktPolygonConverter();
+
+    private static final Location LOCATION_1 = Location.forString("24.2889638, 68.763726");
+    private static final Location LOCATION_2 = Location.forString("24.2847937, 68.7691521");
+    private static final Location LOCATION_3 = Location.forString("24.2726051, 68.7695996");
+    private static final Location LOCATION_4 = Location.forString("24.2558968, 68.7686899");
+
+    @Test
+    public void testConversionMultiPolygonSingleOuter()
+    {
+        final String wkt = "MULTIPOLYGON (((68.763726 24.2889638, 68.7691521 24.2847937, 68.7695996 24.2726051, "
+                + "68.7686899 24.2558968, 68.763726 24.2889638)))";
+        final Polygon polygon = CONVERTER.backwardConvert(wkt);
+        final Polygon truth = new Polygon(LOCATION_1, LOCATION_2, LOCATION_3, LOCATION_4);
+        Assert.assertEquals(truth, polygon);
+    }
+
+    @Test(expected = CoreException.class)
+    public void testConversionMultiPolygonWithMultipleOuters()
+    {
+        final String wkt = "MULTIPOLYGON ("
+                + "((68.763726 24.2889638, 68.7691521 24.2847937, 68.7695996 24.2726051, "
+                + "68.7686899 24.2558968, 68.763726 24.2889638), "
+                + "(68.763726 24.2889638, 68.7691521 24.2847937, 68.7695996 24.2726051, 68.763726 24.2889638)), "
+                + "((68.763726 24.2889638, 68.7691521 24.2847937, 68.7695996 24.2726051, 68.763726 24.2889638), "
+                + "(68.763726 24.2889638, 68.7691521 24.2847937, 68.7695996 24.2726051, 68.763726 24.2889638))"
+                + ")";
+        CONVERTER.backwardConvert(wkt);
+    }
+}


### PR DESCRIPTION
### Description:

Allow WktPolygonConverter to read single outer MultiPolygons (in WKT) and return them as Polygon objects.

### Potential Impact:

New feature, so no real impact

### Unit Test Approach:

Added some unit tests

### Test Results:

pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
