### PR TITLE
Made Atlas toString less verbose

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -955,7 +955,18 @@ public interface Atlas
     Optional<Atlas> subAtlas(Predicate<AtlasEntity> matcher, AtlasCutType cutType);
 
     /**
-     * @return A summary of this {@link Atlas}
+     * Get a summary of this {@link Atlas}. This string should be relatively compact, for e.g. just
+     * the entity counts.
+     * 
+     * @return A summary of this {@link Atlas}.
      */
     String summary();
+
+    /**
+     * Get a complete string representation of this {@link Atlas}. This string may include details
+     * on all contained entities.
+     * 
+     * @return a complete string representation of this {@link Atlas}
+     */
+    String toStringDetailed();
 }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -60,8 +60,8 @@ import com.google.gson.JsonObject;
  */
 public abstract class BareAtlas implements Atlas
 {
-    private static final long serialVersionUID = 4733707438968864018L;
     public static final int MAXIMUM_RELATION_DEPTH = 500;
+    private static final long serialVersionUID = 4733707438968864018L;
     private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
 
     static
@@ -659,6 +659,12 @@ public abstract class BareAtlas implements Atlas
 
     @Override
     public String toString()
+    {
+        return summary();
+    }
+
+    @Override
+    public String toStringDetailed()
     {
         final String newLineAfterFeature = ",\n\t\t";
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
@@ -654,4 +654,10 @@ public class EmptyAtlas implements Atlas
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String toStringDetailed()
+    {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
### Description:
`BareAtlas#toString` now defaults to printing entity counts only, like `BareAtlas#summary`. Previous `toString` functionality, which printed all entities in detail, has been moved to `BareAtlas#toStringDetailed`.

### Potential Impact:
Downstream users relying on a specific `toString` outcome may be affected.

### Unit Test Approach:
Ran full test suite, including integration tests.

### Test Results:
All tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
