### PR TITLE
Fix NullPointerException in Line Slicing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -202,7 +202,9 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         // slicing)
         if (result.isEmpty())
         {
-            if (CountryBoundaryMap.getGeometryProperty(geometry, ISOCountryTag.KEY).isEmpty())
+            final String countryName = CountryBoundaryMap.getGeometryProperty(geometry,
+                    ISOCountryTag.KEY);
+            if (countryName == null || countryName.isEmpty())
             {
                 logger.error("Invalid Geometry for line {} for Atlas {}", lineIdentifier,
                         getShardOrAtlasName());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTest.java
@@ -27,8 +27,8 @@ import org.openstreetmap.atlas.tags.SyntheticNearestNeighborCountryCodeTag;
  */
 public class LineAndPointSlicingTest
 {
-    private static RawAtlasCountrySlicer rawAtlasSlicer;
-    private static AtlasLoadingOption loadingOption;
+    private static final RawAtlasCountrySlicer rawAtlasSlicer;
+    private static final AtlasLoadingOption loadingOption;
 
     static
     {
@@ -449,5 +449,13 @@ public class LineAndPointSlicingTest
                     "Expect a nearest neighbor country code tag to be present for all points",
                     point.getTag(SyntheticNearestNeighborCountryCodeTag.KEY).isPresent());
         });
+    }
+
+    @Test
+    public void testSingleNodeLine()
+    {
+        final Atlas rawAtlas = this.setup.getSingleNodeLine();
+        final Atlas slicedAtlas = rawAtlasSlicer.slice(rawAtlas);
+        Assert.assertEquals(1, slicedAtlas.numberOfLines());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/LineAndPointSlicingTestRule.java
@@ -143,6 +143,17 @@ public class LineAndPointSlicingTestRule extends CoreTestRule
                     @Loc(value = IVORY_COAST_END) }, tags = { "highway=primary" }) })
     private Atlas roadAcrossTwoCountriesWithPointOnBorder;
 
+    @TestAtlas(
+
+            lines = {
+
+                    @Line(id = "1", coordinates = { @Loc(LIBERIA_1), @Loc(LIBERIA_1) })
+
+            }
+
+    )
+    private Atlas singleNodeLine;
+
     public Atlas getClosedEdgeSpanningTwoCountriesAtlas()
     {
         return this.closedEdgeSpanningTwoCountries;
@@ -186,5 +197,10 @@ public class LineAndPointSlicingTestRule extends CoreTestRule
     public Atlas getRoadWeavingAlongBoundaryAtlas()
     {
         return this.roadWeavingAcrossBoundary;
+    }
+
+    public Atlas getSingleNodeLine()
+    {
+        return this.singleNodeLine;
     }
 }


### PR DESCRIPTION
### Description:

When a way is made of two nodes that are at the same location (usually this is bad data) the line slicer was throwing a NPE. This PR fixes it.

Example: https://www.openstreetmap.org/way/408600053

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1944860/76801141-4cd2f000-6792-11ea-8626-18ce4ad3185f.png">

### Potential Impact:

No NPE in line slicer

### Unit Test Approach:

Added one test for the case

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
