### PR TITLE
TurnRestrictions should be Taggable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/TurnRestriction.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas.items;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,7 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.LocationIterableProperties;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.TurnRestrictionTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.StringList;
@@ -28,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author matthieun
  * @author sbhalekar
  */
-public final class TurnRestriction implements Located, Serializable
+public final class TurnRestriction implements Located, Serializable, Taggable
 {
     /**
      * The type of a {@link TurnRestriction}
@@ -39,7 +41,7 @@ public final class TurnRestriction implements Located, Serializable
     {
         NO,
         ONLY,
-        OTHER;
+        OTHER
     }
 
     private static final Logger logger = LoggerFactory.getLogger(TurnRestriction.class);
@@ -50,7 +52,7 @@ public final class TurnRestriction implements Located, Serializable
     private final Relation relation;
     private Route route;
     private Route too;
-    private TurnRestrictionType type;
+    private final TurnRestrictionType type;
     private Route via;
 
     /**
@@ -217,7 +219,7 @@ public final class TurnRestriction implements Located, Serializable
     /**
      * @param turnRestriction
      *            The {@link TurnRestriction} to use for comparison
-     * @param path
+     * @param route
      *            The target {@link Route} to examine
      * @return {@code true} if the given {@link Route} contains all parts - via/from/to edges
      */
@@ -373,6 +375,18 @@ public final class TurnRestriction implements Located, Serializable
     public Route getFrom()
     {
         return this.from;
+    }
+
+    @Override
+    public Optional<String> getTag(final String key)
+    {
+        return this.relation.getTag(key);
+    }
+
+    @Override
+    public Map<String, String> getTags()
+    {
+        return new HashMap<>(this.relation.getTags());
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
@@ -192,6 +192,23 @@ public class ComplexTurnRestrictionTest
     }
 
     @Test
+    public void testTurnRestrictionTags()
+    {
+        final Atlas testAtlas = this.rule.getAtlasNoUTurn();
+
+        final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
+                .from(testAtlas.relation(1L));
+
+        Assert.assertTrue(possibleTurnRestriction.isPresent());
+
+        final TurnRestriction turnRestriction = possibleTurnRestriction.get();
+
+        // Make sure both tags exist
+        Assert.assertEquals(2, turnRestriction.getTags().size());
+        Assert.assertEquals("no_left_turn", turnRestriction.getTag("restriction").get());
+    }
+
+    @Test
     public void testTurnRestrictionWithTwoViaNodesInRelation()
     {
         final Atlas testAtlas = this.rule.getRelationWithTwoViaNodes();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/restriction/ComplexTurnRestrictionTest.java
@@ -22,6 +22,7 @@ import org.openstreetmap.atlas.geography.atlas.items.complex.bignode.BigNodeFind
 import org.openstreetmap.atlas.geography.atlas.items.complex.bignode.RestrictedPath;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.tags.TurnRestrictionTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -194,7 +195,7 @@ public class ComplexTurnRestrictionTest
     @Test
     public void testTurnRestrictionTags()
     {
-        final Atlas testAtlas = this.rule.getAtlasNoUTurn();
+        final Atlas testAtlas = this.rule.getAtlasNo();
 
         final Optional<TurnRestriction> possibleTurnRestriction = TurnRestriction
                 .from(testAtlas.relation(1L));
@@ -205,7 +206,13 @@ public class ComplexTurnRestrictionTest
 
         // Make sure both tags exist
         Assert.assertEquals(2, turnRestriction.getTags().size());
-        Assert.assertEquals("no_left_turn", turnRestriction.getTag("restriction").get());
+
+        final Optional<String> turnRestrictionTagValue = turnRestriction
+                .getTag(TurnRestrictionTag.KEY);
+        Assert.assertTrue(turnRestrictionTagValue.isPresent());
+        // The tags defined in the test atlas (and typically in osm) are lower case
+        Assert.assertEquals(TurnRestrictionTag.NO_LEFT_TURN.toString().toLowerCase(),
+                turnRestrictionTagValue.get());
     }
 
     @Test


### PR DESCRIPTION
### Description:
Let's make TurnRestrictions a Taggable.  The underlying relation is already stored in the TurnRestriction objects - so to make TurnRestrictions a Taggable, we can return the tags from the relation.

I've also fixed a few stylistic issues I found while reading through the file.

### Potential Impact:
None - this is new functionality not used yet.

### Unit Test Approach:
I will update unit tests to make sure TurnRestrictions can return tags from the underlying relation.

### Test Results:
I've updated the ComplexTurnRestrictionTest (where most TurnRestriction testing seems to be happening) and have added a unit test to fetch the tags and make sure the tags are present.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
