### PR TITLE
Minor bug fixes for line slicing and CountryBoundaryMap

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -202,9 +202,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         // slicing)
         if (result.isEmpty())
         {
-            final String countryName = CountryBoundaryMap.getGeometryProperty(geometry,
-                    ISOCountryTag.KEY);
-            if (countryName == null || countryName.isEmpty())
+            if (CountryBoundaryMap.getGeometryProperty(geometry, ISOCountryTag.KEY).isEmpty())
             {
                 logger.error("Invalid Geometry for line {} for Atlas {}", lineIdentifier,
                         getShardOrAtlasName());
@@ -308,10 +306,17 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
                         ISOCountryTag.KEY);
                 CountryBoundaryMap.setGeometryProperty(clipped, ISOCountryTag.KEY, countryCode);
                 addResult(clipped, results);
-
-                // Update target to be what's left after clipping
-                currentTarget = currentTarget.difference(candidate);
-
+                try
+                {
+                    currentTarget = currentTarget.difference(candidate);
+                }
+                catch (final IllegalArgumentException exception)
+                {
+                    logger.warn(
+                            "Aborting slicing for way {} because the remainder was a heterogeneous GeometryCollection",
+                            identifier);
+                    return currentTarget;
+                }
                 // If the remaining piece is very small and we ignore it. This helps avoid
                 // cutting features just a little over boundary lines and generating too many
                 // new nodes, which is both unnecessary and exhausts node identifier resources.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -202,7 +202,9 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         // slicing)
         if (result.isEmpty())
         {
-            if (CountryBoundaryMap.getGeometryProperty(geometry, ISOCountryTag.KEY).isEmpty())
+            final String countryName = CountryBoundaryMap.getGeometryProperty(geometry,
+                     ISOCountryTag.KEY);
+            if (countryName == null || countryName.isEmpty())
             {
                 logger.error("Invalid Geometry for line {} for Atlas {}", lineIdentifier,
                         getShardOrAtlasName());

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasPointAndLineSlicer.java
@@ -203,7 +203,7 @@ public class RawAtlasPointAndLineSlicer extends RawAtlasSlicer
         if (result.isEmpty())
         {
             final String countryName = CountryBoundaryMap.getGeometryProperty(geometry,
-                     ISOCountryTag.KEY);
+                    ISOCountryTag.KEY);
             if (countryName == null || countryName.isEmpty())
             {
                 logger.error("Invalid Geometry for line {} for Atlas {}", lineIdentifier,

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -436,6 +436,8 @@ public class CountryBoundaryMap implements Serializable, GeoJson
 
         if (this.envelope.intersects(polygon.getEnvelopeInternal()))
         {
+            setGeometryProperty(polygon, ISOCountryTag.KEY, country);
+            setGeometryProperty(polygon, POLYGON_ID_KEY, "0");
             this.rawIndex.insert(polygon.getEnvelopeInternal(), polygon);
         }
     }


### PR DESCRIPTION
### Description:

This PR fixes two minor issues. First, in certain extremely rare cases, the difference operation during slicing returns a heterogeneous geometry collection. This isn't something we can continue to perform slicing operations on, so we will now correctly abort slicing and log the error should this happen. It's exceptionally rare and hard to predict, so there's no unit test for this case.

Second is a very minor bug in CountryBoundaryMap.addCountry(Polygon) where the country code property was not being initialized as it was in the multipolygon version of the same method.
### Potential Impact:
None, just bug fixes.
### Unit Test Approach:
N/A
### Test Results:
N/A
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
