### PR TITLE
Expanded range of entity identifier generator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -25,8 +25,8 @@ import org.openstreetmap.atlas.utilities.collections.StringList;
  */
 public class EntityIdentifierGenerator
 {
-    private static final long HIGHEST_ATLAS_ID = 900000000999999L;
-    private static final long LOWEST_ATLAS_ID = -900000000999999L;
+    private static final long HIGHEST_ATLAS_ID = 9999999999999999L;
+    private static final long LOWEST_ATLAS_ID = -9999999999999999L;
 
     /**
      * Generate a 64 bit hash for a given non-{@link Edge} {@link CompleteEntity}. The entity must
@@ -201,6 +201,6 @@ public class EntityIdentifierGenerator
      */
     private boolean isHashSafeToUse(final long hash)
     {
-        return !(hash < HIGHEST_ATLAS_ID && hash >= LOWEST_ATLAS_ID);
+        return hash > HIGHEST_ATLAS_ID || hash < LOWEST_ATLAS_ID;
     }
 }


### PR DESCRIPTION
### Description:
Expanded range of entity identifier generator to account for high IDs of recent OSM nodes. For e.g. https://www.openstreetmap.org/node/7386467784

### Potential Impact:
A small slice of stable IDs now may be forced to change, since we padded out the range by 10x on either side. However, I would rate this as unlikely.

### Unit Test Approach:
Ran suite.

### Test Results:
Pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)