### PR TITLE
Expose underlying expander map in dynamic atlas

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.dynamic;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -186,6 +188,15 @@ public class DynamicAtlas extends BareAtlas // NOSONAR
     public DynamicAtlasPolicy getPolicy()
     {
         return this.expander.getPolicy();
+    }
+
+    /**
+     * @return A copy of the {@link Shard} to {@link Atlas} {@link Map} populated by the underlying
+     *         {@link DynamicAtlasExpander}
+     */
+    public Map<Shard, Atlas> getShardToAtlasMap()
+    {
+        return new HashMap<>(this.expander.getLoadedShards());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlas.java
@@ -192,11 +192,13 @@ public class DynamicAtlas extends BareAtlas // NOSONAR
 
     /**
      * @return A copy of the {@link Shard} to {@link Atlas} {@link Map} populated by the underlying
-     *         {@link DynamicAtlasExpander}
+     *         {@link DynamicAtlasExpander}, with any null Atlases filtered out
      */
     public Map<Shard, Atlas> getShardToAtlasMap()
     {
-        return new HashMap<>(this.expander.getLoadedShards());
+        return new HashMap<>(this.expander.getLoadedShards().entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -79,6 +79,13 @@ public class DynamicAtlasTest
         this.dynamicAtlas.preemptiveLoad();
         final Set<Atlas> atlases = this.dynamicAtlas.getAtlasesLoaded();
         Assert.assertEquals(4, atlases.size());
+
+        final Map<Shard, Atlas> atlasMap = this.dynamicAtlas.getShardToAtlasMap();
+        Assert.assertEquals(4, atlasMap.size());
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1870, 12)));
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1869, 12)));
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1349, 1870, 12)));
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1349, 1869, 12)));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -56,6 +56,23 @@ public class DynamicAtlasTest
                 }
             }, new SlippyTileSharding(12), new SlippyTile(1350, 1870, 12), Rectangle.MAXIMUM);
 
+    private final Supplier<DynamicAtlasPolicy> policySupplierWithMissingAtlas = () -> new DynamicAtlasPolicy(
+            shard ->
+            {
+                if (shard.equals(new SlippyTile(1349, 1869, 12)))
+                {
+                    return Optional.empty();
+                }
+                if (this.store.containsKey(shard))
+                {
+                    return Optional.of(this.store.get(shard));
+                }
+                else
+                {
+                    return Optional.empty();
+                }
+            }, new SlippyTileSharding(12), new SlippyTile(1350, 1870, 12), Rectangle.MAXIMUM);
+
     @Before
     public void prepare()
     {
@@ -77,15 +94,9 @@ public class DynamicAtlasTest
     {
         prepare(this.policySupplier.get().withDeferredLoading(true));
         this.dynamicAtlas.preemptiveLoad();
+
         final Set<Atlas> atlases = this.dynamicAtlas.getAtlasesLoaded();
         Assert.assertEquals(4, atlases.size());
-
-        final Map<Shard, Atlas> atlasMap = this.dynamicAtlas.getShardToAtlasMap();
-        Assert.assertEquals(4, atlasMap.size());
-        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1870, 12)));
-        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1869, 12)));
-        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1349, 1870, 12)));
-        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1349, 1869, 12)));
     }
 
     @Test
@@ -93,6 +104,19 @@ public class DynamicAtlasTest
     {
         Assert.assertEquals(this.policySupplier.get().getInitialShards(),
                 this.dynamicAtlas.getPolicy().getInitialShards());
+    }
+
+    @Test
+    public void testGetShardToAtlasMap()
+    {
+        prepare(this.policySupplierWithMissingAtlas.get().withDeferredLoading(true));
+        this.dynamicAtlas.preemptiveLoad();
+
+        final Map<Shard, Atlas> atlasMap = this.dynamicAtlas.getShardToAtlasMap();
+        Assert.assertEquals(3, atlasMap.size());
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1870, 12)));
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1350, 1869, 12)));
+        Assert.assertTrue(atlasMap.containsKey(new SlippyTile(1349, 1870, 12)));
     }
 
     @Test


### PR DESCRIPTION
### Description:
Expose underlying expander `Map<Shard, Atlas>` in `DynamicAtlas`. Some users of `DynamicAtlas` may want access to this to inspect what shards have been loaded, and then to fetch those atlases if necessary.

### Potential Impact:
None, other than giving users more functionality.

### Unit Test Approach:
Added a quick unit test to make sure the getter works.

### Test Results:
It works.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)