### PR TITLE
Added reverse functionality to packed2text command

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommand.java
@@ -20,6 +20,10 @@ public class PackedToTextAtlasCommand extends AtlasLoaderCommand
 {
     private static final String SAVED_TO = "saved to ";
 
+    private static final String REVERSE_OPTION_LONG = "reverse";
+    private static final Character REVERSE_OPTION_SHORT = 'R';
+    private static final String REVERSE_OPTION_DESCRIPTION = "Convert a text atlas in TextAtlas format (i.e. not GeoJSON) back into a PackedAtlas.";
+
     private static final String GEOJSON_OPTION_LONG = "geojson";
     private static final Character GEOJSON_OPTION_SHORT = 'g';
     private static final String GEOJSON_OPTION_DESCRIPTION = "Save atlas as GeoJSON.";
@@ -71,7 +75,8 @@ public class PackedToTextAtlasCommand extends AtlasLoaderCommand
     @Override
     public void registerOptionsAndArguments()
     {
-        registerEmptyContext(AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT);
+        registerOption(REVERSE_OPTION_LONG, REVERSE_OPTION_SHORT, REVERSE_OPTION_DESCRIPTION,
+                OptionOptionality.OPTIONAL);
         registerOption(GEOJSON_OPTION_LONG, GEOJSON_OPTION_SHORT, GEOJSON_OPTION_DESCRIPTION,
                 OptionOptionality.REQUIRED, GEOJSON_CONTEXT);
         registerOption(LDGEOJSON_OPTION_LONG, LDGEOJSON_OPTION_SHORT, LDGEOJSON_OPTION_DESCRIPTION,
@@ -94,7 +99,7 @@ public class PackedToTextAtlasCommand extends AtlasLoaderCommand
         }
         catch (final Exception exception)
         {
-            this.outputDelegate.printlnErrorMessage("failed to save text file for "
+            this.outputDelegate.printlnErrorMessage("failed to save file for "
                     + atlasResource.getPath() + ": " + exception.getMessage());
         }
     }
@@ -109,9 +114,18 @@ public class PackedToTextAtlasCommand extends AtlasLoaderCommand
         if (this.optionAndArgumentDelegate
                 .getParserContext() == AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT)
         {
-            outputFile = new File(concatenatedPath.toAbsolutePath().toString() + FileSuffix.ATLAS
-                    + FileSuffix.TEXT);
-            outputAtlas.saveAsText(outputFile);
+            if (this.optionAndArgumentDelegate.hasOption(REVERSE_OPTION_LONG))
+            {
+                outputFile = new File(
+                        concatenatedPath.toAbsolutePath().toString() + FileSuffix.ATLAS);
+                outputAtlas.save(outputFile);
+            }
+            else
+            {
+                outputFile = new File(concatenatedPath.toAbsolutePath().toString()
+                        + FileSuffix.ATLAS + FileSuffix.TEXT);
+                outputAtlas.saveAsText(outputFile);
+            }
         }
         else if (this.optionAndArgumentDelegate.getParserContext() == GEOJSON_CONTEXT)
         {

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandDescriptionSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandDescriptionSection.txt
@@ -7,3 +7,9 @@ To save as GeoJSON instead of using the TextAtlas format, use the '--geojson' op
 You can use line-delimited GeoJSON instead with '--ldgeojson'. Line-delimited GeoJSON
 is much easier to read, since the regular GeoJSON format is all on one line. When using
 GeoJSON, the new text atlas files will be created with the extension '.geojson'.
+
+Additionally, by using the '--reverse' option this command can transform text-based atlases
+in TextAtlas format back into PackedAtlases (GeoJSON format conversion is not supported). The
+names of the new binary atlas files are created by taking the extension-less names of the TextAtlas
+files and appending '.atlas' extensions. So if a TextAtlas was named 'myatlas.atlas.txt', the
+resulting binary PackedAtlas will be called 'myatlas.atlas'.

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandExamplesSection.txt
@@ -10,3 +10,5 @@ Transform an atlas to GeoJSON:
 Transform an atlas to line-delimited GeoJSON, and fail fast if 
 it does not exist:
 #$ packed2text file.atlas -l --strict
+Transform a TextAtlas back into a PackedAtlas:
+#$ packed2text --reverse file.atlas.txt


### PR DESCRIPTION
### Description:
Using the new `--reverse` option, users can now convert a `TextAtlas` into a `PackedAtlas`

### Potential Impact:
More functionality.

### Unit Test Approach:
Local testing.

### Test Results:
Working!

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)