### PR TITLE
Do not use extend indefinitely to decide geometry operations in DynamicAtlasExpander

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
@@ -183,8 +183,7 @@ class DynamicAtlasExpander
     {
         StreamIterable<V> result = Iterables.stream(entitiesSupplier.get())
                 .filter(Objects::nonNull);
-        final boolean shouldStopExploring = this.policy.isDeferLoading()
-                && !this.policy.isExtendIndefinitely() && this.preemptiveLoadDone;
+        final boolean shouldStopExploring = this.policy.isDeferLoading() && this.preemptiveLoadDone;
         while (!shouldStopExploring && !entitiesCovered(result, entityCoveredPredicate))
         {
             result = Iterables.stream(entitiesSupplier.get()).filter(Objects::nonNull);


### PR DESCRIPTION
### Description:

When a DynamicAtlas is preemptively loaded, one of the benefits is that every subsequent feature request will not trigger geometry checks with the shard boundaries. This PR makes sure this is always true, even when the policy is to extend indefinitely.

### Potential Impact:

Mostly performance gains when the policy is to extend indefinitely

### Unit Test Approach:

Added one unit test to make sure geometry checks are capped.

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
