### PR TITLE
Attach cause to final thread pool error message

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/Pool.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/Pool.java
@@ -97,8 +97,9 @@ public class Pool implements Closeable
         if (!this.errors.isEmpty())
         {
             this.errors.forEach(error -> logger.error("Unhandled error in {}!", this.name, error));
-            throw new CoreException("{} tasks in {} had uncaught errors!", this.errors.size(),
-                    this.name);
+            throw new CoreException(
+                    "{} tasks in {} had uncaught errors! Attaching one of those as cause.",
+                    this.errors.size(), this.name, this.errors.iterator().next());
         }
     }
 


### PR DESCRIPTION
### Description:

In case one or more threads fail, make sure that the final thread pool error message contains at least one of those errors as a cause of the exception.

### Potential Impact:

Better error handling and error detection

### Unit Test Approach:

Already covered

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
