### PR TITLE
Sort relation members for multipolygon conversion

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverter.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.items.complex;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -45,7 +46,10 @@ public class RelationToMultiPolygonMemberConverter implements Converter<Relation
         {
             throw new CoreException("Not a MultiPolygon: {}", relation);
         }
-        for (final RelationMember member : relation.members())
+        final ArrayList<RelationMember> members = new ArrayList<>();
+        relation.members().iterator().forEachRemaining(members::add);
+        Collections.sort(members);
+        for (final RelationMember member : members)
         {
             final AtlasEntity entity = member.getEntity();
             switch (this.ring)

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverterTest.java
@@ -83,6 +83,10 @@ public class RelationToMultiPolygonMemberConverterTest
     public void testRings()
     {
         final List<Polygon> outers = Iterables.asList(OUTER.convert(this.atlas.relation(0)));
+        final Location first = outers.get(0).first();
+        final Location last = outers.get(outers.size() - 1).first();
+        Assert.assertEquals("POINT (-122.028932 37.332451)", first.toString());
+        Assert.assertEquals("POINT (-122.033948 37.32544)", last.toString());
         Assert.assertTrue(outers.contains(OUTER_LOOP));
         Assert.assertTrue(outers.contains(INNER_LOOP));
         Assert.assertEquals(INNER_LOOP, INNER.convert(this.atlas.relation(0)).iterator().next());


### PR DESCRIPTION
### Description:

Sort relation members before being converted to multipolygon members. This will reduce noise in geometry changes due to different starting and ending points of multipolygon geometry.

### Potential Impact:

Multipolygons now have a consistent start and end point to their geometry.

### Unit Test Approach:

Added an order assertion to the existing unit test.

### Test Results:

Unit tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
