### PR TITLE
Bumped down level of ComplexWaterEntityFinder logs

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/finder/ComplexWaterEntityFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/finder/ComplexWaterEntityFinder.java
@@ -125,8 +125,8 @@ public class ComplexWaterEntityFinder implements Finder<ComplexWaterEntity>
                     .map(ComplexWaterEntity::getWaterType).map(WaterType::toString)
                     .collect(Collectors.joining(","));
 
-            logger.error("Skipping AtlasEnity : {} as it got mapped to {}", atlasEntity,
-                    matchedWaterBodies);
+            logger.error("Skipping AtlasEnity : {} as it got mapped to multiple types: {}",
+                    atlasEntity, matchedWaterBodies);
             return Optional.empty();
         }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/finder/ComplexWaterEntityFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/finder/ComplexWaterEntityFinder.java
@@ -113,7 +113,7 @@ public class ComplexWaterEntityFinder implements Finder<ComplexWaterEntity>
 
         if (complexWaterEntities.isEmpty())
         {
-            logger.error("AtlasEntity: {} did not match any water type filters", atlasEntity);
+            logger.trace("AtlasEntity: {} did not match any water type filters", atlasEntity);
             return Optional.empty();
         }
         else if (complexWaterEntities.size() > 1)


### PR DESCRIPTION
### Description:
Some of the logs here do not need to be `ERROR`.

### Potential Impact:
Less log noise.

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
