### PR TITLE
AbstractAtlasShellToolsCommand now provides API for environment and InputStream

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -140,13 +140,15 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * See {@link AbstractAtlasShellToolsCommand#setNewErrStream(PrintStream)}.
      */
     private PrintStream errStream = System.err; // NOSONAR
-
+    /**
+     * See {@link AbstractAtlasShellToolsCommand#setNewInStream(InputStream)}.
+     */
+    private InputStream inStream = System.in;
     /**
      * The default value here is {@link FileSystems#getDefault()}. See
      * {@link AbstractAtlasShellToolsCommand#setNewFileSystem(FileSystem)} for more information.
      */
     private FileSystem fileSystem = FileSystems.getDefault();
-
     /**
      * By default the command environment will be given by {@link System#getenv()}. See
      * {@link AbstractAtlasShellToolsCommand#setNewEnvironment(Map)} for more information.
@@ -170,6 +172,11 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public abstract String getCommandName();
 
     /**
+     * Get the value of an environment variable. Command implementations should always defer to this
+     * method rather than {@link System#getenv()}, since unit tests may be utilizing
+     * {@link AbstractAtlasShellToolsCommand#setNewEnvironment(Map)} to inject a custom environment
+     * for testing purposes.
+     *
      * @param name
      *            the name of the environment variable
      * @return the string value of the variable, or {@code null} if the variable is not defined in
@@ -192,6 +199,16 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public FileSystem getFileSystem()
     {
         return this.fileSystem;
+    }
+
+    /**
+     * Get the {@link InputStream} for this command.
+     * 
+     * @return the {@link InputStream} for this command.
+     */
+    public InputStream getInStream()
+    {
+        return this.inStream;
     }
 
     /**
@@ -358,6 +375,19 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public void setNewFileSystem(final FileSystem newFileSystem)
     {
         this.fileSystem = newFileSystem;
+    }
+
+    /**
+     * Set a new {@link InputStream} for this command. Implementations should respect the set
+     * {@link InputStream} when reading input from the user. This is particularly useful for
+     * unit-testing, where we may want to inject arbitrary input for testing purposes.
+     * 
+     * @param inStream
+     *            the new {@link InputStream} to use
+     */
+    public void setNewInStream(final InputStream inStream)
+    {
+        this.inStream = inStream;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -130,7 +130,8 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * System.out/err for direct messages intended for the user to read on the command line. This
      * makes it easier for users to adjust their log configuration to show the desired level of
      * diagnostics without affecting the actual command outputs. We are declaring explicit stream
-     * variables here so that downstream classes can override the streams for unit-testing purposes.
+     * variables here so that client classes (i.e. unit tests) can override the streams for testing
+     * purposes.
      */
     /**
      * See {@link AbstractAtlasShellToolsCommand#setNewOutStream(PrintStream)}.

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -148,6 +148,12 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     private FileSystem fileSystem = FileSystems.getDefault();
 
     /**
+     * By default the command environment will be given by {@link System#getenv()}. See
+     * {@link AbstractAtlasShellToolsCommand#setNewEnvironment(Map)} for more information.
+     */
+    private Map<String, String> environment = null;
+
+    /**
      * Execute the command logic. Subclasses of {@link AbstractAtlasShellToolsCommand} must
      * implement this method, but in general it should not be called directly. See
      * {@link AbstractAtlasShellToolsCommand#runSubcommandAndExit(String...)}.
@@ -162,6 +168,21 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * @return the simple name of the command
      */
     public abstract String getCommandName();
+
+    /**
+     * @param name
+     *            the name of the environment variable
+     * @return the string value of the variable, or {@code null} if the variable is not defined in
+     *         the environment
+     */
+    public String getEnvironmentValue(final String name)
+    {
+        if (this.environment == null)
+        {
+            return System.getenv(name);
+        }
+        return this.environment.getOrDefault(name, null);
+    }
 
     /**
      * Get the {@link FileSystem} for this command.
@@ -297,6 +318,20 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public void runSubcommandAndExit(final String... args)
     {
         System.exit(this.runSubcommand(args));
+    }
+
+    /**
+     * Set a new {@link Map} to act as the system environment for this command. This may be useful
+     * for various unit tests which want to inject alternate values into a command's environment
+     * variables (for example, changing the location of user.home to be independent of the machine
+     * context).
+     *
+     * @param newEnvironment
+     *            the new environment {@link Map}
+     */
+    public void setNewEnvironment(final Map<String, String> newEnvironment)
+    {
+        this.environment = newEnvironment;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.utilities.command.subcommands;
 
 import java.util.List;
+import java.util.Scanner;
 
 import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
@@ -117,10 +118,17 @@ public class AtlasShellToolsDemoCommand extends AbstractAtlasShellToolsCommand
 
     private void executeBreakfastContext()
     {
+        this.outputDelegate.printlnCommandMessage(
+                "value of HOME environment variable: " + this.getEnvironmentValue("user.home"));
         final String breakfast = this.optionAndArgumentDelegate
                 .getUnaryArgument("favoriteBreakfastFood").orElse("Default waffles :(");
         this.outputDelegate.printlnStdout("Using special breakfast mode:");
         this.outputDelegate.printlnStdout(breakfast, TTYAttribute.BOLD);
+        this.outputDelegate.printlnStdout("Now say something!");
+        this.outputDelegate.printStdout("> ");
+        final Scanner scanner = new Scanner(this.getInStream());
+        final String input = scanner.nextLine();
+        this.outputDelegate.printlnStdout("You said: " + input);
     }
 
     private void executeLunchDinnerContext()

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
@@ -126,9 +126,11 @@ public class AtlasShellToolsDemoCommand extends AbstractAtlasShellToolsCommand
         this.outputDelegate.printlnStdout(breakfast, TTYAttribute.BOLD);
         this.outputDelegate.printlnStdout("Now say something!");
         this.outputDelegate.printStdout("> ");
-        final Scanner scanner = new Scanner(this.getInStream());
-        final String input = scanner.nextLine();
-        this.outputDelegate.printlnStdout("You said: " + input);
+        try (final Scanner scanner = new Scanner(this.getInStream()))
+        {
+            final String input = scanner.nextLine();
+            this.outputDelegate.printlnStdout("You said: " + input);
+        }
     }
 
     private void executeLunchDinnerContext()

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommand.java
@@ -126,7 +126,7 @@ public class AtlasShellToolsDemoCommand extends AbstractAtlasShellToolsCommand
         this.outputDelegate.printlnStdout(breakfast, TTYAttribute.BOLD);
         this.outputDelegate.printlnStdout("Now say something!");
         this.outputDelegate.printStdout("> ");
-        try (final Scanner scanner = new Scanner(this.getInStream()))
+        try (Scanner scanner = new Scanner(this.getInStream()))
         {
             final String input = scanner.nextLine();
             this.outputDelegate.printlnStdout("You said: " + input);

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
@@ -1,12 +1,12 @@
 package org.openstreetmap.atlas.utilities.command.subcommands;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.streaming.StringInputStream;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 
 /**
@@ -19,7 +19,7 @@ public class AtlasShellToolsDemoCommandTest
     {
         final ByteArrayOutputStream outContent1 = new ByteArrayOutputStream();
         final ByteArrayOutputStream errContent1 = new ByteArrayOutputStream();
-        final InputStream inStream = new ByteArrayInputStream("hello!".getBytes());
+        final InputStream inStream = new StringInputStream("hello!");
 
         final AtlasShellToolsDemoCommand command = new AtlasShellToolsDemoCommand();
         command.setNewOutStream(new PrintStream(outContent1));

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
@@ -19,9 +19,9 @@ public class AtlasShellToolsDemoCommandTest
     {
         final ByteArrayOutputStream outContent1 = new ByteArrayOutputStream();
         final ByteArrayOutputStream errContent1 = new ByteArrayOutputStream();
+        final InputStream inStream = new ByteArrayInputStream("hello!".getBytes());
 
         final AtlasShellToolsDemoCommand command = new AtlasShellToolsDemoCommand();
-        final InputStream inStream = new ByteArrayInputStream("hello!".getBytes());
         command.setNewOutStream(new PrintStream(outContent1));
         command.setNewErrStream(new PrintStream(errContent1));
         command.setNewInStream(inStream);

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
@@ -1,0 +1,37 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+
+/**
+ * @author lcram
+ */
+public class AtlasShellToolsDemoCommandTest
+{
+    @Test
+    public void testCommand()
+    {
+        final ByteArrayOutputStream outContent1 = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errContent1 = new ByteArrayOutputStream();
+
+        final AtlasShellToolsDemoCommand command = new AtlasShellToolsDemoCommand();
+        final InputStream inStream = new ByteArrayInputStream("hello!".getBytes());
+        command.setNewOutStream(new PrintStream(outContent1));
+        command.setNewErrStream(new PrintStream(errContent1));
+        command.setNewInStream(inStream);
+        command.setNewEnvironment(Maps.hashMap("user.home", "/Users/foo"));
+        command.runSubcommand("--breakfast", "waffles");
+
+        Assert.assertEquals(
+                "Using special breakfast mode:\nwaffles\nNow say something!\n> You said: hello!\n",
+                outContent1.toString());
+        Assert.assertEquals("ast-demo: value of HOME environment variable: /Users/foo\n",
+                errContent1.toString());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShellToolsDemoCommandTest.java
@@ -6,7 +6,7 @@ import java.io.PrintStream;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openstreetmap.atlas.streaming.StringInputStream;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 
 /**
@@ -19,7 +19,7 @@ public class AtlasShellToolsDemoCommandTest
     {
         final ByteArrayOutputStream outContent1 = new ByteArrayOutputStream();
         final ByteArrayOutputStream errContent1 = new ByteArrayOutputStream();
-        final InputStream inStream = new StringInputStream("hello!");
+        final InputStream inStream = new StringResource("hello!").read();
 
         final AtlasShellToolsDemoCommand command = new AtlasShellToolsDemoCommand();
         command.setNewOutStream(new PrintStream(outContent1));


### PR DESCRIPTION
### Description:
`AbstractAtlasShellToolsCommand` now provides a way for implementing classes to access their environment variables and `InputStream` through an API. This API also allows command users to override this fields for ease of unit testing. See the unit test associated with this PR for an example.

Compliant command implementations interact with the external environment (i.e. printing output, reading input, fetching environment variables, file I/O, etc.) **only** through the provided APIs.

### Potential Impact:
Better unit testing!

### Unit Test Approach:
Added a unit test to demo the new features.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)