### PR TITLE
Removed connectivity from EntityIdentifierGenerator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -10,9 +10,9 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
-import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
 /**
@@ -91,8 +91,7 @@ public class EntityIdentifierGenerator
 
     /**
      * Given some {@link CompleteEntity}, compute a string made up of concatenated type specific
-     * entity properties (e.g. for a {@link CompleteNode} this would be the in/out {@link Edge}
-     * identifiers).
+     * entity properties. Currently this is only relevant for {@link Relation}s.
      *
      * @param entity
      *            the {@link CompleteEntity} to string-ify
@@ -104,32 +103,6 @@ public class EntityIdentifierGenerator
         builder.append(";");
         switch (entity.getType())
         {
-            case EDGE:
-                final CompleteEdge edge = (CompleteEdge) entity;
-                if (edge.start() != null)
-                {
-                    builder.append(edge.start().getIdentifier());
-                }
-                builder.append(";");
-                if (edge.end() != null)
-                {
-                    builder.append(edge.end().getIdentifier());
-                }
-                return builder.toString();
-            case NODE:
-                final CompleteNode node = (CompleteNode) entity;
-                if (node.inEdges() != null)
-                {
-                    node.inEdges().stream().map(Edge::getIdentifier)
-                            .forEach(identifier -> builder.append(identifier + ","));
-                }
-                builder.append(";");
-                if (node.outEdges() != null)
-                {
-                    node.outEdges().stream().map(Edge::getIdentifier)
-                            .forEach(identifier -> builder.append(identifier + ","));
-                }
-                return builder.toString();
             case RELATION:
                 final CompleteRelation relation = (CompleteRelation) entity;
                 if (relation.members() != null)

--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
@@ -101,30 +102,30 @@ public class EntityIdentifierGenerator
     {
         final StringBuilder builder = new StringBuilder();
         builder.append(";");
-        switch (entity.getType())
+        if (entity.getType() == ItemType.RELATION)
         {
-            case RELATION:
-                final CompleteRelation relation = (CompleteRelation) entity;
-                if (relation.members() != null)
+            final CompleteRelation relation = (CompleteRelation) entity;
+            if (relation.members() != null)
+            {
+                final RelationBean bean = relation.members().asBean();
+                builder.append("RelationBean[");
+                for (final RelationBean.RelationBeanItem beanItem : bean)
                 {
-                    final RelationBean bean = relation.members().asBean();
-                    builder.append("RelationBean[");
-                    for (final RelationBean.RelationBeanItem beanItem : bean)
-                    {
-                        builder.append("(");
-                        builder.append(beanItem.getType());
-                        builder.append(",");
-                        builder.append(beanItem.getIdentifier());
-                        builder.append(",");
-                        builder.append(beanItem.getRole());
-                        builder.append(")");
-                    }
-                    builder.append("]");
+                    builder.append("(");
+                    builder.append(beanItem.getType());
+                    builder.append(",");
+                    builder.append(beanItem.getIdentifier());
+                    builder.append(",");
+                    builder.append(beanItem.getRole());
+                    builder.append(")");
                 }
-                return builder.toString();
-            default:
-                return "";
+                builder.append("]");
+            }
+            return builder.toString();
         }
+
+        // Otherwise no extra data
+        return "";
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
@@ -7,7 +7,6 @@ import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
-import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.complete.CompletePoint;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
@@ -25,7 +24,7 @@ public class EntityIdentifierGeneratorTest
         final CompleteEdge edge = new CompleteEdge(1L, PolyLine.SIMPLE_POLYLINE,
                 Maps.hashMap("a", "b", "c", "d"), 2L, 3L, Sets.hashSet());
 
-        final String goldenPropertyString = "LINESTRING (1 1, 2 2);a=b,c=d;2;3";
+        final String goldenPropertyString = "LINESTRING (1 1, 2 2);a=b,c=d";
 
         Assert.assertEquals(goldenPropertyString,
                 new EntityIdentifierGenerator().getBasicPropertyString(edge)
@@ -41,29 +40,6 @@ public class EntityIdentifierGeneratorTest
         final String goldenPropertyString = "POINT (0 0);a=b,c=d";
         Assert.assertEquals(goldenPropertyString,
                 new EntityIdentifierGenerator().getBasicPropertyString(point));
-    }
-
-    @Test
-    public void testGetTypeSpecificPropertyStringForEdge()
-    {
-        final CompleteEdge edge = new CompleteEdge(1L, PolyLine.SIMPLE_POLYLINE,
-                Maps.hashMap("a", "b", "c", "d"), 2L, 3L, Sets.hashSet());
-
-        final String goldenPropertyString = ";2;3";
-        Assert.assertEquals(goldenPropertyString,
-                new EntityIdentifierGenerator().getTypeSpecificPropertyString(edge));
-    }
-
-    @Test
-    public void testGetTypeSpecificPropertyStringForNode()
-    {
-        final CompleteNode node = new CompleteNode(1L, Location.CENTER,
-                Maps.hashMap("a", "b", "c", "d"), Sets.treeSet(1L, 2L), Sets.treeSet(3L, 4L),
-                Sets.hashSet());
-
-        final String goldenPropertyString = ";1,2,;3,4,";
-        Assert.assertEquals(goldenPropertyString,
-                new EntityIdentifierGenerator().getTypeSpecificPropertyString(node));
     }
 
     @Test
@@ -87,8 +63,8 @@ public class EntityIdentifierGeneratorTest
         final CompleteEdge edge = new CompleteEdge(1L, PolyLine.SIMPLE_POLYLINE,
                 Maps.hashMap("a", "b", "c", "d"), 2L, 3L, Sets.hashSet());
 
-        final long goldenHash = 5515319119996140692L;
-        Assert.assertEquals(5515319119996140692L,
+        final long goldenHash = 6463671242943641314L;
+        Assert.assertEquals(goldenHash,
                 new EntityIdentifierGenerator().generatePositiveIdentifierForEdge(edge));
     }
 }


### PR DESCRIPTION
### Description:
`EntityIdentifierGenerator` no longer relies on connectivity for `Node`s and `Edge`s. I think this is better, since it ensures better compatibility across shards. Also, users who want to make new `Node`s and `Edge`s will no longer run into a bootstrapping problem where they can't generate IDs for their `Node`s until they know the connected `Edge` IDs, but they can't generate `Edge` IDs until they know the start/end `Node` IDs.

### Potential Impact:
Some previously stable IDs will change.

### Unit Test Approach:
Updated unit tests to reflect changes.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
