### PR TITLE
Bumped log in CountryBoundaryMap down to debug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -363,7 +363,7 @@ public class CountryBoundaryMap implements Serializable, GeoJson
                 // Trying to override an existing value - this shouldn't happen!
                 if (!Objects.equals(existingValue, value))
                 {
-                    logger.error(
+                    logger.debug(
                             "Trying to override existing '{}' key's value of '{}' with '{}' for geometry {}",
                             key, existingValue, value, geometry.toString());
                 }

--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -361,11 +361,11 @@ public class CountryBoundaryMap implements Serializable, GeoJson
             else
             {
                 // Trying to override an existing value - this shouldn't happen!
-                if (!Objects.equals(existingValue, value))
+                if (!Objects.equals(existingValue, value) && logger.isDebugEnabled())
                 {
                     logger.debug(
                             "Trying to override existing '{}' key's value of '{}' with '{}' for geometry {}",
-                            key, existingValue, value, geometry.toString());
+                            key, existingValue, value, geometry);
                 }
             }
         }


### PR DESCRIPTION
### Description:
This log message does not need to be `ERROR` level.

### Potential Impact:
Less log noise.

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)