### PR TITLE
StringToPredicateConverter and ConfiguredFilter now support speedups

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
@@ -23,21 +23,26 @@ import com.google.common.collect.Lists;
  */
 public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializable
 {
+    public static final String CONFIGURATION_GLOBAL = "global";
     public static final String DEFAULT = "default";
     public static final ConfiguredFilter NO_FILTER = new ConfiguredFilter();
+    public static final String CONFIGURATION_ROOT = CONFIGURATION_GLOBAL + ".filters";
+
     private static final long serialVersionUID = 7503301238426719144L;
     private static final Logger logger = LoggerFactory.getLogger(ConfiguredFilter.class);
-    private static final String CONFIGURATION_GLOBAL = "global";
-    public static final String CONFIGURATION_ROOT = CONFIGURATION_GLOBAL + ".filters";
     private static final String CONFIGURATION_PREDICATE_COMMAND = "predicate.command";
+    private static final String CONFIGURATION_PREDICATE_UNSAFE_COMMAND = "predicate.unsafeCommand";
     private static final String CONFIGURATION_PREDICATE_IMPORTS = "predicate.imports";
     private static final String CONFIGURATION_TAGGABLE_FILTER = "taggableFilter";
+    private static final String CONFIGURATION_HINT_NO_EXPANSION = "hint.noExpansion";
+
     private final String name;
     private final String predicate;
+    private final String unsafePredicate;
+    private transient Predicate<AtlasEntity> filter;
     private final List<String> imports;
     private final String taggableFilter;
-    private transient Predicate<AtlasEntity> filter;
-    private boolean unsafe;
+    private final boolean noExpansion;
 
     public static ConfiguredFilter from(final String name, final Configuration configuration)
     {
@@ -80,11 +85,19 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
         final ConfigurationReader reader = new ConfigurationReader(CONFIGURATION_ROOT + "." + name);
         this.predicate = reader.configurationValue(configuration, CONFIGURATION_PREDICATE_COMMAND,
                 "");
+        this.unsafePredicate = reader.configurationValue(configuration,
+                CONFIGURATION_PREDICATE_UNSAFE_COMMAND, "");
         this.imports = reader.configurationValue(configuration, CONFIGURATION_PREDICATE_IMPORTS,
                 Lists.newArrayList());
         this.taggableFilter = reader.configurationValue(configuration,
                 CONFIGURATION_TAGGABLE_FILTER, "");
-        this.unsafe = false;
+        this.noExpansion = readBoolean(configuration, reader, CONFIGURATION_HINT_NO_EXPANSION,
+                false);
+    }
+
+    public boolean isNoExpansion()
+    {
+        return this.noExpansion;
     }
 
     @Override
@@ -99,29 +112,24 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
         return this.name;
     }
 
-    public ConfiguredFilter withUnsafePredicate(final boolean unsafe)
-    {
-        this.unsafe = unsafe;
-        return this;
-    }
-
     private Predicate<AtlasEntity> getFilter()
     {
         if (this.filter == null)
         {
             Predicate<AtlasEntity> localTemporaryPredicate = atlasEntity -> true;
+            final StringToPredicateConverter<AtlasEntity> predicateReader = new StringToPredicateConverter<>();
+            predicateReader.withAddedStarImportPackages(this.imports);
+            if (!this.predicate.isEmpty() && !this.unsafePredicate.isEmpty())
+            {
+                throw new CoreException("Cannot specify both 'command' and 'unsafeCommand'");
+            }
             if (!this.predicate.isEmpty())
             {
-                final StringToPredicateConverter<AtlasEntity> predicateReader = new StringToPredicateConverter<>();
-                predicateReader.withAddedStarImportPackages(this.imports);
-                if (this.unsafe)
-                {
-                    localTemporaryPredicate = predicateReader.convertUnsafe(this.predicate);
-                }
-                else
-                {
-                    localTemporaryPredicate = predicateReader.convert(this.predicate);
-                }
+                localTemporaryPredicate = predicateReader.convert(this.predicate);
+            }
+            if (!this.unsafePredicate.isEmpty())
+            {
+                localTemporaryPredicate = predicateReader.convertUnsafe(this.unsafePredicate);
             }
             final Predicate<AtlasEntity> localPredicate = localTemporaryPredicate;
             final TaggableFilter localTaggablefilter = TaggableFilter

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -81,10 +81,10 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
     /**
      * Similar to {@link StringToPredicateConverter#convert(String)}, but uses some hacks to improve
      * runtime in certain cases. This version is EXTREMELY INSECURE and should never be used. Please
-     * use {@link StringToPredicateConverter#convert(String)} unless you are extremely sure you want
-     * unsafe conversion and understand what security features you are sacrificing. Note also that
-     * due to the limitations of the improvement hacks, this conversion only supports single
-     * statement expressions.
+     * use {@link StringToPredicateConverter#convert(String)} unless you are sure you want unsafe
+     * conversion and understand what security features you are sacrificing. Note also that due to
+     * the limitations of the improvement hacks, this conversion only supports single statement
+     * expressions.
      *
      * @param booleanExpressionString
      *            a boolean expression involving the object 'e' under consideration
@@ -109,7 +109,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         }
         final String fullScript = String.format(SCRIPT, importsBuilder.toString(),
                 booleanExpressionString);
-        logger.error("Acquiring predicate with unsafe script: {}", fullScript);
+        logger.trace("Acquiring predicate with unsafe script: {}", fullScript);
 
         return (Predicate<T>) shell.evaluate(fullScript);
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -109,7 +109,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         }
         final String fullScript = String.format(SCRIPT, importsBuilder.toString(),
                 booleanExpressionString);
-        logger.trace("Acquiring predicate with unsafe script: {}", fullScript);
+        logger.error("Acquiring predicate with unsafe script: {}", fullScript);
 
         return (Predicate<T>) shell.evaluate(fullScript);
     }
@@ -123,6 +123,10 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
      */
     public StringToPredicateConverter<T> withAddedStarImportPackages(final List<String> whitelist)
     {
+        for (final String importString : whitelist)
+        {
+            checkImportStringFormat(importString);
+        }
         this.additionalWhitelistPackages.addAll(whitelist);
         return this;
     }
@@ -136,13 +140,17 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
      */
     public StringToPredicateConverter<T> withAddedStarImportPackages(final String... whitelist)
     {
+        for (final String importString : whitelist)
+        {
+            checkImportStringFormat(importString);
+        }
         this.additionalWhitelistPackages.addAll(Arrays.asList(whitelist));
         return this;
     }
 
     /**
      * Clear any previously added imports.
-     * 
+     *
      * @return the updated converter
      */
     public StringToPredicateConverter<T> withClearedStarImportPackages()
@@ -182,6 +190,17 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         {
             throw new CoreException("Unable to parse {} into a predicate.", booleanExpressionString,
                     exception);
+        }
+    }
+
+    /*
+     * Attempt some basic checks to make sure imports are not trying to sneak in extra code.
+     */
+    private void checkImportStringFormat(final String importString)
+    {
+        if (!importString.matches("^[a-zA-Z0-9\\\\.]+$"))
+        {
+            throw new CoreException("Invalid import '{}'", importString);
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -109,7 +109,7 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
         }
         final String fullScript = String.format(SCRIPT, importsBuilder.toString(),
                 booleanExpressionString);
-        logger.error("Acquiring predicate with unsafe script: {}", fullScript);
+        logger.warn("Acquiring predicate with unsafe script: {}", fullScript);
 
         return (Predicate<T>) shell.evaluate(fullScript);
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverter.java
@@ -32,7 +32,7 @@ import groovy.lang.Script;
 public class StringToPredicateConverter<T> implements Converter<String, Predicate<T>>
 {
     private static final Logger logger = LoggerFactory.getLogger(StringToPredicateConverter.class);
-    private static final String SCRIPT = "%s Predicate predicate = { e -> return %s; }; return predicate;";
+    private static final String SCRIPT = "%s Predicate predicate = { e -> return (%s); }; return predicate;";
     private static final List<String> DEFAULT_IMPORTS = Arrays.asList("java.lang", "groovy.lang",
             "java.util.function");
 
@@ -46,13 +46,12 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
     /**
      * Convert a {@link String} representing a boolean condition into a {@link Predicate} that
      * checks for the condition's validity. The binding assumes the variable under consideration is
-     * named 'e'. For example, to get a predicate that checks if a given string has the contents
-     * "foo", one could supply "e.equals(\"foo\")" as an argument. This would generate a predicate
-     * that looks approximately like: <code>
+     * named 'e'. Multi-statement expressions are supported. For example, to get a predicate that
+     * checks if a given string has the contents "foo", one could supply "e.equals(\"foo\")" as an
+     * argument. This would generate a predicate that looks approximately like:
      * <p>
-     * Predicate&lt;T&gt; predicate = e -> { return e.equals("foo"); };
+     * <code>Predicate predicate = e -&gt; { return (e.equals("foo")); };</code>
      * </p>
-     * </code>
      *
      * @param booleanExpressionString
      *            a boolean expression involving the object 'e' under consideration
@@ -83,7 +82,9 @@ public class StringToPredicateConverter<T> implements Converter<String, Predicat
      * Similar to {@link StringToPredicateConverter#convert(String)}, but uses some hacks to improve
      * runtime in certain cases. This version is EXTREMELY INSECURE and should never be used. Please
      * use {@link StringToPredicateConverter#convert(String)} unless you are extremely sure you want
-     * unsafe conversion and understand what security features you are sacrificing.
+     * unsafe conversion and understand what security features you are sacrificing. Note also that
+     * due to the limitations of the improvement hacks, this conversion only supports single
+     * statement expressions.
      *
      * @param booleanExpressionString
      *            a boolean expression involving the object 'e' under consideration

--- a/src/test/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.java
@@ -1,0 +1,53 @@
+package org.openstreetmap.atlas.utilities.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.collections.Maps;
+
+/**
+ * @author lcram
+ * @author matthieun
+ */
+public class ConfiguredFilterTest
+{
+    private static final String NAMESAKE_JSON = ConfiguredFilterTest.class.getSimpleName()
+            + FileSuffix.JSON;
+
+    @Test
+    public void testFilter()
+    {
+        final ConfiguredFilter junctionRoundaboutFilter = get("junctionRoundaboutFilter");
+        final ConfiguredFilter dummyFilter = get("dummyFilter");
+        final ConfiguredFilter tagFilterOnly = get("tagFilterOnly");
+        final ConfiguredFilter defaultFilter = get("I am not there");
+        final ConfiguredFilter nothingGoesThroughFilter = get("nothingGoesThroughFilter");
+        final ConfiguredFilter unsafePredicateFilter = get("unsafePredicateFilter");
+
+        final Edge edge = new CompleteEdge(123L, null, Maps.hashMap("junction", "roundabout"), null,
+                null, null);
+
+        Assert.assertTrue(junctionRoundaboutFilter.test(edge));
+        Assert.assertFalse(dummyFilter.test(edge));
+        Assert.assertTrue(tagFilterOnly.test(edge));
+        Assert.assertTrue(defaultFilter.test(edge));
+        Assert.assertFalse(nothingGoesThroughFilter.test(edge));
+        Assert.assertTrue(unsafePredicateFilter.test(edge));
+    }
+
+    @Test
+    public void testIsNoExpansion()
+    {
+        Assert.assertTrue(get("nothingGoesThroughFilter").isNoExpansion());
+    }
+
+    private ConfiguredFilter get(final String name)
+    {
+        final Configuration configuration = new StandardConfiguration(new InputStreamResource(
+                () -> ConfiguredFilterTest.class.getResourceAsStream(NAMESAKE_JSON)));
+        return ConfiguredFilter.from(name, configuration);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -68,6 +68,17 @@ public class StringToPredicateConverterTest
     }
 
     @Test
+    public void testComplexExpressionFail2()
+    {
+        /*
+         * Another complex expression which should fail.
+         */
+        final String complexExpression = "e.equals(\"foo\"); e.equals(\"foo\")";
+        this.expectedException.expect(MultipleCompilationErrorsException.class);
+        new StringToPredicateConverter<String>().convertUnsafe(complexExpression);
+    }
+
+    @Test
     public void testConvert()
     {
         final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
@@ -120,9 +131,6 @@ public class StringToPredicateConverterTest
                 .withAddedStarImportPackages(
                         Collections.singletonList("org.openstreetmap.atlas.utilities.random"))
                 .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
-
-        final Predicate<String> predicateZ = new StringToPredicateConverter<String>()
-                .convertUnsafe("e.equals(\"foo\"); e.equals(\"foo\")");
 
         Assert.assertTrue(predicate1.test("foo"));
         Assert.assertFalse(predicate1.test("bar"));

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory;
  */
 public class StringToPredicateConverterTest
 {
-    private static final Logger logger = LoggerFactory.getLogger(StringToPredicateConverterTest.class);
+    private static final Logger logger = LoggerFactory
+            .getLogger(StringToPredicateConverterTest.class);
 
     @Rule
     public StringToPredicateConverterTestRule rule = new StringToPredicateConverterTestRule();

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -12,7 +12,6 @@ import org.junit.rules.ExpectedException;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
-import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,29 +172,5 @@ public class StringToPredicateConverterTest
         new StringToPredicateConverter<Integer>()
                 .withAddedStarImportPackages(Collections.singletonList("System.out.println()"))
                 .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
-    }
-
-    private void speedTest()
-    {
-        final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
-                .convert("e.equals(\"foo\")");
-        final Predicate<String> predicate1Unsafe = new StringToPredicateConverter<String>()
-                .convertUnsafe("e.equals(\"foo\")");
-
-        final int num = 1000000;
-
-        Time start = Time.now();
-        for (int i = 0; i < num; i++)
-        {
-            predicate1.test("foo");
-        }
-        logger.trace("safe runtime: " + start.elapsedSince().asMilliseconds());
-
-        start = Time.now();
-        for (int i = 0; i < num; i++)
-        {
-            predicate1Unsafe.test("foo");
-        }
-        logger.trace("unsafe runtime: " + start.elapsedSince().asMilliseconds());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -12,12 +12,17 @@ import org.junit.rules.ExpectedException;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author lcram
  */
 public class StringToPredicateConverterTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(StringToPredicateConverterTest.class);
+
     @Rule
     public StringToPredicateConverterTestRule rule = new StringToPredicateConverterTestRule();
 
@@ -167,5 +172,29 @@ public class StringToPredicateConverterTest
         new StringToPredicateConverter<Integer>()
                 .withAddedStarImportPackages(Collections.singletonList("System.out.println()"))
                 .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+    }
+
+    private void speedTest()
+    {
+        final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
+                .convert("e.equals(\"foo\")");
+        final Predicate<String> predicate1Unsafe = new StringToPredicateConverter<String>()
+                .convertUnsafe("e.equals(\"foo\")");
+
+        final int num = 1000000;
+
+        Time start = Time.now();
+        for (int i = 0; i < num; i++)
+        {
+            predicate1.test("foo");
+        }
+        logger.trace("safe runtime: " + start.elapsedSince().asMilliseconds());
+
+        start = Time.now();
+        for (int i = 0; i < num; i++)
+        {
+            predicate1Unsafe.test("foo");
+        }
+        logger.trace("unsafe runtime: " + start.elapsedSince().asMilliseconds());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.time.Time;
 
 /**
  * @author lcram
@@ -51,5 +52,31 @@ public class StringToPredicateConverterTest
 
         Assert.assertTrue(predicate5.test(5));
         Assert.assertTrue(predicate6.test(5));
+    }
+
+    @Test
+    public void testEfficiency()
+    {
+        final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
+                .convert("e.equals(\"foo\")");
+        final Time start = Time.now();
+        final int iterations = 100000;
+        for (int i = 0; i < iterations; i++)
+        {
+            Assert.assertTrue(predicate1.test("foo"));
+        }
+        System.out.println("(1) " + iterations + " iterations took: "
+                + start.elapsedSince().asMilliseconds() + " ms");
+
+        // TODO implement a convert2 that uses old-school way
+        final Predicate<String> predicate2 = new StringToPredicateConverter<String>()
+                .convertUnsafe("e.equals(\"foo\")");
+        final Time start2 = Time.now();
+        for (int i = 0; i < iterations; i++)
+        {
+            Assert.assertTrue(predicate2.test("foo"));
+        }
+        System.out.println("(2) " + iterations + " iterations took: "
+                + start2.elapsedSince().asMilliseconds() + " ms");
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -9,7 +9,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
-import org.openstreetmap.atlas.utilities.time.Time;
 
 /**
  * @author lcram
@@ -20,7 +19,7 @@ public class StringToPredicateConverterTest
     public StringToPredicateConverterTestRule rule = new StringToPredicateConverterTestRule();
 
     @Test
-    public void testConversion()
+    public void testConvert()
     {
         final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
                 .convert("e.equals(\"foo\")");
@@ -55,28 +54,37 @@ public class StringToPredicateConverterTest
     }
 
     @Test
-    public void testEfficiency()
+    public void testConvertUnsafe()
     {
         final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
-                .convert("e.equals(\"foo\")");
-        final Time start = Time.now();
-        final int iterations = 100000;
-        for (int i = 0; i < iterations; i++)
-        {
-            Assert.assertTrue(predicate1.test("foo"));
-        }
-        System.out.println("(1) " + iterations + " iterations took: "
-                + start.elapsedSince().asMilliseconds() + " ms");
-
-        // TODO implement a convert2 that uses old-school way
-        final Predicate<String> predicate2 = new StringToPredicateConverter<String>()
                 .convertUnsafe("e.equals(\"foo\")");
-        final Time start2 = Time.now();
-        for (int i = 0; i < iterations; i++)
-        {
-            Assert.assertTrue(predicate2.test("foo"));
-        }
-        System.out.println("(2) " + iterations + " iterations took: "
-                + start2.elapsedSince().asMilliseconds() + " ms");
+        final Predicate<Map<String, String>> predicate2 = new StringToPredicateConverter<Map<String, String>>()
+                .convertUnsafe("e.containsKey(\"foo\")");
+        final Predicate<Integer> predicate3 = new StringToPredicateConverter<Integer>()
+                .convertUnsafe("e == 3");
+        final Predicate<AtlasEntity> predicate4 = new StringToPredicateConverter<AtlasEntity>()
+                .convertUnsafe("e.getTags().containsKey(\"mat\")");
+        final Predicate<Integer> predicate5 = new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages("org.openstreetmap.atlas.utilities.random")
+                .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+        final Predicate<Integer> predicate6 = new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages(
+                        Arrays.asList("org.openstreetmap.atlas.utilities.random"))
+                .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+
+        Assert.assertTrue(predicate1.test("foo"));
+        Assert.assertFalse(predicate1.test("bar"));
+
+        Assert.assertTrue(predicate2.test(Maps.hashMap("foo", "bar", "baz", "bat")));
+        Assert.assertFalse(predicate2.test(Maps.hashMap("baz", "bat", "bar", "mat")));
+
+        Assert.assertTrue(predicate3.test(3));
+        Assert.assertFalse(predicate3.test(10));
+
+        Assert.assertTrue(predicate4.test(this.rule.getAtlas().point(3)));
+        Assert.assertFalse(predicate4.test(this.rule.getAtlas().point(1)));
+
+        Assert.assertTrue(predicate5.test(5));
+        Assert.assertTrue(predicate6.test(5));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -12,7 +12,6 @@ import org.junit.rules.ExpectedException;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.utilities.collections.Maps;
-import org.openstreetmap.atlas.utilities.time.Time;
 
 /**
  * @author lcram
@@ -139,30 +138,5 @@ public class StringToPredicateConverterTest
 
         Assert.assertTrue(predicate5.test(5));
         Assert.assertTrue(predicate6.test(5));
-    }
-
-    @Test
-    public void zTimeTest()
-    {
-        final Predicate<String> predicate1 = new StringToPredicateConverter<String>()
-                .convert("e.equals(\"foo\")");
-        final Predicate<String> predicate1Unsafe = new StringToPredicateConverter<String>()
-                .convertUnsafe("e.equals(\"foo\")");
-
-        final int num = 1000000;
-
-        Time start = Time.now();
-        for (int i = 0; i < num; i++)
-        {
-            predicate1.test("foo");
-        }
-        System.out.println("safe: " + start.elapsedSince().asMilliseconds());
-
-        start = Time.now();
-        for (int i = 0; i < num; i++)
-        {
-            predicate1Unsafe.test("foo");
-        }
-        System.out.println("unsafe: " + start.elapsedSince().asMilliseconds());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/conversion/StringToPredicateConverterTest.java
@@ -147,4 +147,25 @@ public class StringToPredicateConverterTest
         Assert.assertTrue(predicate5.test(5));
         Assert.assertTrue(predicate6.test(5));
     }
+
+    @Test
+    public void testImportInjectionProtection1()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("Invalid import");
+        new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages(Collections.singletonList(
+                        "org.openstreetmap.atlas.utilities.random.*;System.out.println(\"INJECTED\");import org.openstreetmap.atlas"))
+                .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+    }
+
+    @Test
+    public void testImportInjectionProtection2()
+    {
+        this.expectedException.expect(CoreException.class);
+        this.expectedException.expectMessage("Invalid import");
+        new StringToPredicateConverter<Integer>()
+                .withAddedStarImportPackages(Collections.singletonList("System.out.println()"))
+                .convertUnsafe("e.intValue() == RandomTagsSupplier.randomTags(5).size()");
+    }
 }

--- a/src/test/resources/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.json
+++ b/src/test/resources/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.json
@@ -1,0 +1,51 @@
+{
+    "global":
+    {
+        "filters":
+        {
+            "junctionRoundaboutFilter":
+            {
+                "predicate":
+                {
+                    "imports": [
+                        "org.openstreetmap.atlas.geography.atlas.items"
+                    ],
+                    "command": "e instanceof Node || e instanceof Edge"
+                },
+                "taggableFilter": "junction->roundabout"
+            },
+            "dummyFilter":
+            {
+                "predicate":
+                {
+                    "imports": [
+                        "org.openstreetmap.atlas.geography.atlas.items"
+                    ],
+                    "command": "\"yes\".equals(e.getTag(\"dummy\"))"
+                }
+            },
+            "tagFilterOnly":
+            {
+                "taggableFilter": "junction->roundabout"
+            },
+            "nothingGoesThroughFilter":
+            {
+                "predicate":
+                {
+                    "command": "false"
+                },
+                "hint.noExpansion": true
+            },
+            "unsafePredicateFilter":
+            {
+                "predicate":
+                {
+                    "imports": [
+                        "org.openstreetmap.atlas.geography.atlas.items"
+                    ],
+                    "unsafeCommand": "e instanceof Edge"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description:
The two classes mentioned in the title now support some optimizations for faster predicates. These optimizations come at the cost of decreased code security. They should only be used in very limited cases.

### Potential Impact:
Performance boost in limited cases.

### Unit Test Approach:
Added test class for ConfiguredFilter, also added more StringToPredicate tests.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
