### PR TITLE
Add Equals to IsoLanguage

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/locale/IsoLanguage.java
+++ b/src/main/java/org/openstreetmap/atlas/locale/IsoLanguage.java
@@ -142,6 +142,12 @@ public final class IsoLanguage implements Comparable<IsoLanguage>, Serializable
         return this.languageCode.compareTo(other.getLanguageCode());
     }
 
+    @Override
+    public boolean equals(final Object other)
+    {
+        return other instanceof IsoLanguage && this.compareTo((IsoLanguage) other) == 0;
+    }
+
     /**
      * Provides the display language for this IsoLanguage
      *
@@ -160,5 +166,11 @@ public final class IsoLanguage implements Comparable<IsoLanguage>, Serializable
     public String getLanguageCode()
     {
         return this.languageCode;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.getLanguageCode().hashCode();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/locale/IsoLanguageTest.java
+++ b/src/test/java/org/openstreetmap/atlas/locale/IsoLanguageTest.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.locale;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
@@ -14,6 +16,18 @@ import org.openstreetmap.atlas.exception.CoreException;
  */
 public class IsoLanguageTest
 {
+    @Test
+    public void testEquals()
+    {
+        final Set<IsoLanguage> isoLanguages = IsoLanguage.all().collect(Collectors.toSet());
+        IsoLanguage.forLanguageCode("en").ifPresent(isoLanguage ->
+        {
+            final IsoLanguage clone = SerializationUtils
+                    .deserialize(SerializationUtils.serialize(isoLanguage));
+            Assert.assertTrue(isoLanguages.contains(clone));
+        });
+    }
+
     @Test
     public void testLanguage()
     {


### PR DESCRIPTION
### Description:
Adding an equals method to IsoLanguage, for easier comparison of collections of IsoLanguage objects. This is especially useful in instances where there has been serialization and deserialization. 
Also had to add an override hashCode method to make sonar happy. 

### Potential Impact:

Allow for easier comparisons. It will break anything that relies on deserialized objects not being equal. 

### Unit Test Approach:

Added a test for the equals method.

### Test Results:

None

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
