### PR TITLE
Minor alteration to trivial geometry logic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -93,9 +93,7 @@ public class CountryBoundaryMap implements Serializable, GeoJson
     // buffer, we'll just ignore them.
     public static final double LINE_BUFFER = 0.000001;
     public static final double AREA_BUFFER = 0.0000000001;
-    // Slicing constants
-    public static final int MAXIMUM_EXPECTED_COUNTRIES_TO_SLICE_WITH = 3;
-    public static final int PRECISION_MODEL = 100_000_000;
+
     // Boundary file constants
     static final String COUNTRY_BOUNDARY_DELIMITER = "||";
     private static final long serialVersionUID = -1714710346834527699L;


### PR DESCRIPTION
### Description:

This PR fixes an issue with the trivial geometry filtration applied during slicing. Previously, the logic used a hard cutoff for geometric area or length-- i.e. if a sliced piece was under the cutoff length or area, then it was discarded. This concept is fundamentally flawed given the vast differences in size of features, so an additional check has been added that requires the feature to *also* be below a certain percentage of the original geometry's length or area. This way, any pieces that meet this criteria must also be under a certain percentage size (currently set to 5%) to be discarded. This preserves small pieces found for small features without the risk of thousands of tiny pieces for much larger features.

### Potential Impact:

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
