### PR TITLE
Made getTTYStringBuilder public and added toJson to ConfiguredFilter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -193,6 +193,16 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     }
 
     /**
+     * Get the {@link PrintStream} for this command's err stream.
+     *
+     * @return the {@link PrintStream} for this command's err stream.
+     */
+    public PrintStream getErrStream()
+    {
+        return this.errStream;
+    }
+
+    /**
      * Get the {@link FileSystem} for this command.
      *
      * @return the {@link FileSystem} for this command.
@@ -204,12 +214,22 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
 
     /**
      * Get the {@link InputStream} for this command.
-     * 
+     *
      * @return the {@link InputStream} for this command.
      */
     public InputStream getInStream()
     {
         return this.inStream;
+    }
+
+    /**
+     * Get the {@link PrintStream} for this command's out stream.
+     *
+     * @return the {@link PrintStream} for this command's out stream.
+     */
+    public PrintStream getOutStream()
+    {
+        return this.outStream;
     }
 
     /**
@@ -219,26 +239,6 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * @return the description
      */
     public abstract String getSimpleDescription();
-
-    /**
-     * Get the {@link PrintStream} for this command's err stream.
-     *
-     * @return the {@link PrintStream} for this command's err stream.
-     */
-    public PrintStream getStderrStream()
-    {
-        return this.errStream;
-    }
-
-    /**
-     * Get the {@link PrintStream} for this command's out stream.
-     *
-     * @return the {@link PrintStream} for this command's out stream.
-     */
-    public PrintStream getStdoutStream()
-    {
-        return this.outStream;
-    }
 
     /**
      * Get a {@link TTYStringBuilder} that is configured to respect the color settings of stderr.

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -221,6 +221,26 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public abstract String getSimpleDescription();
 
     /**
+     * Get a {@link TTYStringBuilder} that is configured to respect the color settings of stderr.
+     *
+     * @return the configured {@link TTYStringBuilder}
+     */
+    public TTYStringBuilder getTTYStringBuilderForStderr()
+    {
+        return new TTYStringBuilder(this.useColorStderr);
+    }
+
+    /**
+     * Get a {@link TTYStringBuilder} that is configured to respect the color settings of stdout.
+     *
+     * @return the configured {@link TTYStringBuilder}
+     */
+    public TTYStringBuilder getTTYStringBuilderForStdout()
+    {
+        return new TTYStringBuilder(this.useColorStdout);
+    }
+
+    /**
      * Register any desired manual page sections. An OPTIONS section will be automatically
      * generated, so it is recommended that you register at least a DESCRIPTION and EXAMPLES section
      * with some appropriate documentation. See other {@link AbstractAtlasShellToolsCommand}
@@ -382,7 +402,7 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * Set a new {@link InputStream} for this command. Implementations should respect the set
      * {@link InputStream} when reading input from the user. This is particularly useful for
      * unit-testing, where we may want to inject arbitrary input for testing purposes.
-     * 
+     *
      * @param inStream
      *            the new {@link InputStream} to use
      */
@@ -801,16 +821,6 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     int getParserContext()
     {
         return this.parser.getContext();
-    }
-
-    TTYStringBuilder getTTYStringBuilderForStderr()
-    {
-        return new TTYStringBuilder(this.useColorStderr);
-    }
-
-    TTYStringBuilder getTTYStringBuilderForStdout()
-    {
-        return new TTYStringBuilder(this.useColorStdout);
     }
 
     Optional<String> getUnaryArgument(final String hint)

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -221,6 +221,26 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public abstract String getSimpleDescription();
 
     /**
+     * Get the {@link PrintStream} for this command's err stream.
+     *
+     * @return the {@link PrintStream} for this command's err stream.
+     */
+    public PrintStream getStderrStream()
+    {
+        return this.errStream;
+    }
+
+    /**
+     * Get the {@link PrintStream} for this command's out stream.
+     *
+     * @return the {@link PrintStream} for this command's out stream.
+     */
+    public PrintStream getStdoutStream()
+    {
+        return this.outStream;
+    }
+
+    /**
      * Get a {@link TTYStringBuilder} that is configured to respect the color settings of stderr.
      *
      * @return the configured {@link TTYStringBuilder}

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
@@ -19,6 +19,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 /**
  * This class reads in a configuration file with a specific schema and creates filters based on the
@@ -33,6 +36,13 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public static final String DEFAULT = "default";
     public static final ConfiguredFilter NO_FILTER = new ConfiguredFilter();
     public static final String CONFIGURATION_ROOT = CONFIGURATION_GLOBAL + ".filters";
+    public static final String TYPE_JSON_PROPERTY_VALUE = "_filter";
+    public static final String NAME_JSON_PROPERTY = "name";
+    public static final String PREDICATE_JSON_PROPERTY = "predicate";
+    public static final String UNSAFE_PREDICATE_JSON_PROPERTY = "unsafePredicate";
+    public static final String IMPORTS_JSON_PROPERTY = "imports";
+    public static final String TAGGABLE_FILTER_JSON_PROPERTY = "taggableFilter";
+    public static final String NO_EXPANSION_JSON_PROPERTY = "noExpansion";
 
     private static final long serialVersionUID = 7503301238426719144L;
     private static final Logger logger = LoggerFactory.getLogger(ConfiguredFilter.class);
@@ -176,6 +186,11 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
         return new ArrayList<>(this.geometryBasedFilters);
     }
 
+    public String getName()
+    {
+        return this.name;
+    }
+
     public boolean isNoExpansion()
     {
         return this.noExpansion;
@@ -185,6 +200,37 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public boolean test(final AtlasEntity atlasEntity)
     {
         return getFilter().test(atlasEntity);
+    }
+
+    public JsonObject toJson()
+    {
+        final JsonObject filterObject = new JsonObject();
+        filterObject.addProperty("type", TYPE_JSON_PROPERTY_VALUE);
+        filterObject.addProperty(NAME_JSON_PROPERTY, this.name);
+        if (!this.predicate.isEmpty())
+        {
+            filterObject.addProperty(PREDICATE_JSON_PROPERTY, this.predicate);
+        }
+        if (!this.unsafePredicate.isEmpty())
+        {
+            filterObject.addProperty(UNSAFE_PREDICATE_JSON_PROPERTY, this.unsafePredicate);
+        }
+        final JsonArray importsArray = new JsonArray();
+        if (!this.imports.isEmpty())
+        {
+            for (final String importString : this.imports)
+            {
+                importsArray.add(new JsonPrimitive(importString));
+            }
+            filterObject.add(IMPORTS_JSON_PROPERTY, importsArray);
+        }
+        if (!this.taggableFilter.isEmpty())
+        {
+            filterObject.addProperty(TAGGABLE_FILTER_JSON_PROPERTY, this.taggableFilter);
+        }
+        filterObject.addProperty(NO_EXPANSION_JSON_PROPERTY, this.noExpansion);
+
+        return filterObject;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
@@ -36,13 +36,6 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public static final String DEFAULT = "default";
     public static final ConfiguredFilter NO_FILTER = new ConfiguredFilter();
     public static final String CONFIGURATION_ROOT = CONFIGURATION_GLOBAL + ".filters";
-    public static final String TYPE_JSON_PROPERTY_VALUE = "_filter";
-    public static final String NAME_JSON_PROPERTY = "name";
-    public static final String PREDICATE_JSON_PROPERTY = "predicate";
-    public static final String UNSAFE_PREDICATE_JSON_PROPERTY = "unsafePredicate";
-    public static final String IMPORTS_JSON_PROPERTY = "imports";
-    public static final String TAGGABLE_FILTER_JSON_PROPERTY = "taggableFilter";
-    public static final String NO_EXPANSION_JSON_PROPERTY = "noExpansion";
 
     private static final long serialVersionUID = 7503301238426719144L;
     private static final Logger logger = LoggerFactory.getLogger(ConfiguredFilter.class);
@@ -205,15 +198,15 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public JsonObject toJson()
     {
         final JsonObject filterObject = new JsonObject();
-        filterObject.addProperty("type", TYPE_JSON_PROPERTY_VALUE);
-        filterObject.addProperty(NAME_JSON_PROPERTY, this.name);
+        filterObject.addProperty("type", "_filter");
+        filterObject.addProperty("name", this.name);
         if (!this.predicate.isEmpty())
         {
-            filterObject.addProperty(PREDICATE_JSON_PROPERTY, this.predicate);
+            filterObject.addProperty("predicate", this.predicate);
         }
         if (!this.unsafePredicate.isEmpty())
         {
-            filterObject.addProperty(UNSAFE_PREDICATE_JSON_PROPERTY, this.unsafePredicate);
+            filterObject.addProperty("unsafePredicate", this.unsafePredicate);
         }
         final JsonArray importsArray = new JsonArray();
         if (!this.imports.isEmpty())
@@ -222,13 +215,13 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
             {
                 importsArray.add(new JsonPrimitive(importString));
             }
-            filterObject.add(IMPORTS_JSON_PROPERTY, importsArray);
+            filterObject.add("imports", importsArray);
         }
         if (!this.taggableFilter.isEmpty())
         {
-            filterObject.addProperty(TAGGABLE_FILTER_JSON_PROPERTY, this.taggableFilter);
+            filterObject.addProperty("taggableFilter", this.taggableFilter); // NOSONAR
         }
-        filterObject.addProperty(NO_EXPANSION_JSON_PROPERTY, this.noExpansion);
+        filterObject.addProperty("noExpansion", this.noExpansion);
 
         return filterObject;
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilter.java
@@ -37,6 +37,18 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public static final ConfiguredFilter NO_FILTER = new ConfiguredFilter();
     public static final String CONFIGURATION_ROOT = CONFIGURATION_GLOBAL + ".filters";
 
+    /*
+     * JSON constants for the toJson method. We should probably handle this better so that we do not
+     * duplicate String literals.
+     */
+    public static final String TYPE_JSON_PROPERTY_VALUE = "_filter";
+    public static final String NAME_JSON_PROPERTY = "name";
+    public static final String PREDICATE_JSON_PROPERTY = "predicate";
+    public static final String UNSAFE_PREDICATE_JSON_PROPERTY = "unsafePredicate";
+    public static final String IMPORTS_JSON_PROPERTY = "imports";
+    public static final String TAGGABLE_FILTER_JSON_PROPERTY = "taggableFilter";
+    public static final String NO_EXPANSION_JSON_PROPERTY = "noExpansion";
+
     private static final long serialVersionUID = 7503301238426719144L;
     private static final Logger logger = LoggerFactory.getLogger(ConfiguredFilter.class);
     private static final String CONFIGURATION_PREDICATE_COMMAND = "predicate.command";
@@ -46,11 +58,9 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     private static final String CONFIGURATION_WKT_FILTER = "geometry.wkt";
     private static final String CONFIGURATION_WKB_FILTER = "geometry.wkb";
     private static final String CONFIGURATION_HINT_NO_EXPANSION = "hint.noExpansion";
-
     private static final WktMultiPolygonConverter WKT_MULTI_POLYGON_CONVERTER = new WktMultiPolygonConverter();
     private static final WkbMultiPolygonConverter WKB_MULTI_POLYGON_CONVERTER = new WkbMultiPolygonConverter();
     private static final HexStringByteArrayConverter HEX_STRING_BYTE_ARRAY_CONVERTER = new HexStringByteArrayConverter();
-
     private final String name;
     private final String predicate;
     private final String unsafePredicate;
@@ -198,15 +208,15 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
     public JsonObject toJson()
     {
         final JsonObject filterObject = new JsonObject();
-        filterObject.addProperty("type", "_filter");
-        filterObject.addProperty("name", this.name);
+        filterObject.addProperty("type", TYPE_JSON_PROPERTY_VALUE);
+        filterObject.addProperty(NAME_JSON_PROPERTY, this.name);
         if (!this.predicate.isEmpty())
         {
-            filterObject.addProperty("predicate", this.predicate);
+            filterObject.addProperty(PREDICATE_JSON_PROPERTY, this.predicate);
         }
         if (!this.unsafePredicate.isEmpty())
         {
-            filterObject.addProperty("unsafePredicate", this.unsafePredicate);
+            filterObject.addProperty(UNSAFE_PREDICATE_JSON_PROPERTY, this.unsafePredicate);
         }
         final JsonArray importsArray = new JsonArray();
         if (!this.imports.isEmpty())
@@ -215,13 +225,13 @@ public final class ConfiguredFilter implements Predicate<AtlasEntity>, Serializa
             {
                 importsArray.add(new JsonPrimitive(importString));
             }
-            filterObject.add("imports", importsArray);
+            filterObject.add(IMPORTS_JSON_PROPERTY, importsArray);
         }
         if (!this.taggableFilter.isEmpty())
         {
-            filterObject.addProperty("taggableFilter", this.taggableFilter); // NOSONAR
+            filterObject.addProperty(TAGGABLE_FILTER_JSON_PROPERTY, this.taggableFilter); // NOSONAR
         }
-        filterObject.addProperty("noExpansion", this.noExpansion);
+        filterObject.addProperty(NO_EXPANSION_JSON_PROPERTY, this.noExpansion);
 
         return filterObject;
     }

--- a/src/test/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/configuration/ConfiguredFilterTest.java
@@ -13,6 +13,8 @@ import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.testing.TestAtlasHandler;
 
+import com.google.gson.GsonBuilder;
+
 /**
  * @author lcram
  * @author matthieun
@@ -122,6 +124,31 @@ public class ConfiguredFilterTest
     public void testIsNoExpansion()
     {
         Assert.assertTrue(get("nothingGoesThroughFilter").isNoExpansion());
+    }
+
+    @Test
+    public void testToJson()
+    {
+        final ConfiguredFilter tagFilterOnly = get("tagFilterOnly");
+        final String jsonString1 = new GsonBuilder().disableHtmlEscaping().create()
+                .toJson(tagFilterOnly.toJson());
+        Assert.assertEquals(
+                "{\"type\":\"_filter\",\"name\":\"tagFilterOnly\",\"taggableFilter\":\"junction->roundabout\",\"noExpansion\":false}",
+                jsonString1);
+
+        final ConfiguredFilter unsafePredicateFilter = get("unsafePredicateFilter");
+        final String jsonString2 = new GsonBuilder().disableHtmlEscaping().create()
+                .toJson(unsafePredicateFilter.toJson());
+        Assert.assertEquals(
+                "{\"type\":\"_filter\",\"name\":\"unsafePredicateFilter\",\"unsafePredicate\":\"e instanceof Edge\",\"imports\":[\"org.openstreetmap.atlas.geography.atlas.items\"],\"noExpansion\":false}",
+                jsonString2);
+
+        final ConfiguredFilter dummyFilter = get("dummyFilter");
+        final String jsonString3 = new GsonBuilder().disableHtmlEscaping().create()
+                .toJson(dummyFilter.toJson());
+        Assert.assertEquals(
+                "{\"type\":\"_filter\",\"name\":\"dummyFilter\",\"predicate\":\"\\\"yes\\\".equals(e.getTag(\\\"dummy\\\"))\",\"imports\":[\"org.openstreetmap.atlas.geography.atlas.items\"],\"noExpansion\":false}",
+                jsonString3);
     }
 
     private ConfiguredFilter get(final String name)


### PR DESCRIPTION
### Description:
Made the `getTTYStringBuilderX` methods in `AbstractAtlasShellToolsCommand` public so that other classes can easily get configured string builders. Also added a `toJson` method to `ConfiguredFilter`.

### Potential Impact:
More methods available to atlas users.

### Unit Test Approach:
Unit tests included for the toJson method!

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)