### PR TITLE
Commands with predicate option can now control imports.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.utilities.command.subcommands;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import org.openstreetmap.atlas.geography.converters.jts.JtsPolygonConverter;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.CommandOutputDelegate;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.OptionAndArgumentDelegate;
 import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
@@ -42,6 +44,10 @@ public class SubAtlasCommand extends AtlasLoaderCommand
     private static final String PREDICATE_OPTION_DESCRIPTION = "The feature filter predicate for the subatlas. See PREDICATE section for details.";
     private static final String PREDICATE_OPTION_HINT = "groovy-code";
 
+    private static final String PREDICATE_IMPORTS_OPTION_LONG = "imports";
+    private static final String PREDICATE_IMPORTS_OPTION_DESCRIPTION = "A comma separated list of some additional package imports to include for the predicate option, if present.";
+    private static final String PREDICATE_IMPORTS_OPTION_HINT = "packages";
+
     private static final List<String> CUT_TYPE_STRINGS = Arrays.stream(AtlasCutType.values())
             .map(AtlasCutType::toString).collect(Collectors.toList());
     private static final String CUT_TYPE_OPTION_LONG = "cut-type";
@@ -54,8 +60,11 @@ public class SubAtlasCommand extends AtlasLoaderCommand
 
     private static final List<String> importsWhitelist = Arrays.asList(
             "org.openstreetmap.atlas.geography.atlas.items",
-            "org.openstreetmap.atlas.tags.annotations.validation", "org.openstreetmap.atlas.tags",
-            "org.openstreetmap.atlas.geography");
+            "org.openstreetmap.atlas.tags.annotations",
+            "org.openstreetmap.atlas.tags.annotations.validation",
+            "org.openstreetmap.atlas.tags.annotations.extraction", "org.openstreetmap.atlas.tags",
+            "org.openstreetmap.atlas.tags.names", "org.openstreetmap.atlas.geography",
+            "org.openstreetmap.atlas.utilities.collections");
 
     private final OptionAndArgumentDelegate optionAndArgumentDelegate;
     private final CommandOutputDelegate outputDelegate;
@@ -110,6 +119,9 @@ public class SubAtlasCommand extends AtlasLoaderCommand
                 OptionOptionality.OPTIONAL, POLYGON_OPTION_HINT);
         this.registerOptionWithRequiredArgument(PREDICATE_OPTION_LONG, PREDICATE_OPTION_DESCRIPTION,
                 OptionOptionality.OPTIONAL, PREDICATE_OPTION_HINT);
+        this.registerOptionWithRequiredArgument(PREDICATE_IMPORTS_OPTION_LONG,
+                PREDICATE_IMPORTS_OPTION_DESCRIPTION, OptionOptionality.OPTIONAL,
+                PREDICATE_IMPORTS_OPTION_HINT);
         this.registerOptionWithRequiredArgument(CUT_TYPE_OPTION_LONG, CUT_TYPE_OPTION_DESCRIPTION,
                 OptionOptionality.OPTIONAL, CUT_TYPE_OPTION_HINT);
         this.registerOption(SLICE_FIRST_OPTION_LONG, SLICE_FIRST_OPTION_DESCRIPTION,
@@ -243,9 +255,20 @@ public class SubAtlasCommand extends AtlasLoaderCommand
     {
         if (predicateParameter.isPresent())
         {
+            List<String> userImports = new ArrayList<>();
+            if (this.optionAndArgumentDelegate.hasOption(PREDICATE_IMPORTS_OPTION_LONG))
+            {
+                userImports = StringList
+                        .split(this.optionAndArgumentDelegate
+                                .getOptionArgument(PREDICATE_IMPORTS_OPTION_LONG)
+                                .orElseThrow(AtlasShellToolsException::new), ",")
+                        .getUnderlyingList();
+            }
+            final List<String> allImports = new ArrayList<>();
+            allImports.addAll(userImports);
+            allImports.addAll(importsWhitelist);
             return Optional.ofNullable(new StringToPredicateConverter<AtlasEntity>()
-                    .withAddedStarImportPackages(importsWhitelist)
-                    .convert(predicateParameter.get()));
+                    .withAddedStarImportPackages(allImports).convert(predicateParameter.get()));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommand.java
@@ -167,12 +167,13 @@ public class SubAtlasCommand extends AtlasLoaderCommand
             final Path concatenatedPath = Paths.get(getOutputPath().toAbsolutePath().toString(),
                     fileName);
             final File outputFile = new File(
-                    concatenatedPath.toAbsolutePath().toString() + FileSuffix.ATLAS);
+                    concatenatedPath.toAbsolutePath().toString() + FileSuffix.ATLAS,
+                    this.getFileSystem());
             subbedAtlas.get().save(outputFile);
             if (this.optionAndArgumentDelegate.hasVerboseOption())
             {
-                this.outputDelegate.printlnCommandMessage(
-                        "saved to " + outputFile.getFile().getAbsolutePath());
+                this.outputDelegate
+                        .printlnCommandMessage("saved to " + outputFile.getAbsolutePathString());
             }
         }
         else
@@ -239,7 +240,7 @@ public class SubAtlasCommand extends AtlasLoaderCommand
         {
             final Optional<Predicate<AtlasEntity>> predicate = getPredicateFromCommandLineExpression(
                     predicateParameter);
-            if (!predicate.isPresent())
+            if (predicate.isEmpty())
             {
                 this.outputDelegate.printlnErrorMessage("could not parse predicate");
                 return 1;

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/AtlasLoaderCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/AtlasLoaderCommand.java
@@ -95,6 +95,11 @@ public abstract class AtlasLoaderCommand extends MultipleOutputCommand
 
         if (this.optionAndArgumentDelegate.hasOption(COMBINE_OPTION_LONG))
         {
+            if (this.optionAndArgumentDelegate.hasVerboseOption())
+            {
+                this.outputDelegate
+                        .printlnCommandMessage("processing all atlases as one multiatlas...");
+            }
             processAtlas(
                     new MultiAtlas(
                             atlasTupleStream.map(Tuple::getSecond).collect(Collectors.toList())),
@@ -102,8 +107,21 @@ public abstract class AtlasLoaderCommand extends MultipleOutputCommand
         }
         else
         {
-            atlasTupleStream.forEach(atlasTuple -> processAtlas(atlasTuple.getSecond(),
-                    atlasTuple.getFirst().getName(), atlasTuple.getFirst()));
+            final int size = atlasTuples.size();
+            final int[] count = new int[1];
+            count[0] = 1;
+            atlasTupleStream.forEach(atlasTuple ->
+            {
+                if (this.optionAndArgumentDelegate.hasVerboseOption())
+                {
+                    this.outputDelegate.printlnCommandMessage(
+                            "processing atlas " + atlasTuple.getFirst().getAbsolutePathString()
+                                    + " (" + count[0] + "/" + size + ")");
+                }
+                processAtlas(atlasTuple.getSecond(), atlasTuple.getFirst().getName(),
+                        atlasTuple.getFirst());
+                count[0]++;
+            });
         }
 
         // return the exit code from the user's finish implementation

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandPredicateSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandPredicateSection.txt
@@ -2,6 +2,10 @@ The 'find' command supports predicate matching using Groovy integration. When yo
 code to the '--predicate' option, you are supplying a Groovy boolean expression which will be applied
 as a Predicate<AtlasEntity>. Your expression will be wrapped in some Groovy code that handles
 imports for you, as well as conversion from the expression to the Java Predicate<AtlasEntity>.
+If you need to import additional packages beyond the ones included by default, specify a comma
+separated list of package names to the '--imports' option like so:
+'--imports=com.hello.world,com.foo.bar'
+
 Note that the AtlasEntity against which you are testing is explicitly bound to a variable called
 'e'. See the following examples:
 

--- a/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandPredicateSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandPredicateSection.txt
@@ -2,6 +2,10 @@ The 'subatlas' command supports predicate slicing using Groovy integration. When
 code to the '--predicate' option, you are supplying a Groovy boolean expression which will be applied
 as a Predicate<AtlasEntity>. Your expression will be wrapped in some Groovy code that handles
 imports for you, as well as conversion from the expression to the Java Predicate<AtlasEntity>.
+If you need to import additional packages beyond the ones included by default, specify a comma
+separated list of package names to the '--imports' option like so:
+'--imports=com.hello.world,com.foo.bar'
+
 Note that the AtlasEntity against which you are testing is explicitly bound to a variable called
 'e'. See the following examples:
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
@@ -55,7 +55,10 @@ public class AtlasSearchCommandTest
                     + "tags: {baz=bat, foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((3 3, 3 3, 3 3, 3 3, 3 3)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -87,6 +90,7 @@ public class AtlasSearchCommandTest
                     outContent.toString());
             Assert.assertEquals(
                     "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
                             + "find: saved to /Users/foo/collected-multi.atlas\n",
                     errContent.toString());
             Assert.assertTrue(new File("/Users/foo/collected-multi.atlas", filesystem).exists());
@@ -146,7 +150,10 @@ public class AtlasSearchCommandTest
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
             final ByteArrayOutputStream errContent2 = new ByteArrayOutputStream();
@@ -165,7 +172,9 @@ public class AtlasSearchCommandTest
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent2.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n",
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
                     errContent2.toString());
 
             final ByteArrayOutputStream outContent3 = new ByteArrayOutputStream();
@@ -185,7 +194,9 @@ public class AtlasSearchCommandTest
                             + "tags: {baz=bat}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((20 20, 20 21, 21 21, 21 20, 20 20)), \n" + "]\n\n",
                     outContent3.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n",
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
                     errContent3.toString());
         }
         catch (final IOException exception)
@@ -214,7 +225,10 @@ public class AtlasSearchCommandTest
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -243,7 +257,10 @@ public class AtlasSearchCommandTest
                     + "parentRelations: [], \n"
                     + "bounds: POLYGON ((32 32, 32 32, 32 32, 32 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
             final ByteArrayOutputStream errContent2 = new ByteArrayOutputStream();
@@ -260,7 +277,9 @@ public class AtlasSearchCommandTest
                     + "parentRelations: [], \n"
                     + "bounds: POLYGON ((32 32, 32 32, 32 32, 32 32, 32 32)), \n" + "]\n\n",
                     outContent2.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n",
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
                     errContent2.toString());
         }
         catch (final IOException exception)
@@ -297,7 +316,10 @@ public class AtlasSearchCommandTest
                     + "parentRelations: [12000000], \n"
                     + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -334,7 +356,10 @@ public class AtlasSearchCommandTest
                     + "parentRelations: [12000000], \n"
                     + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -372,7 +397,10 @@ public class AtlasSearchCommandTest
                     + "parentRelations: [12000000], \n"
                     + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -404,7 +432,10 @@ public class AtlasSearchCommandTest
                             + "tags: {foo=bar}, \n" + "parentRelations: [12000000], \n"
                             + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -434,7 +465,10 @@ public class AtlasSearchCommandTest
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
             final ByteArrayOutputStream errContent2 = new ByteArrayOutputStream();
@@ -453,7 +487,9 @@ public class AtlasSearchCommandTest
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent2.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n",
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
                     errContent2.toString());
 
             final ByteArrayOutputStream outContent3 = new ByteArrayOutputStream();
@@ -473,7 +509,9 @@ public class AtlasSearchCommandTest
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent3.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n",
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
                     errContent3.toString());
         }
         catch (final IOException exception)
@@ -509,7 +547,10 @@ public class AtlasSearchCommandTest
                     + "tags: {another=tag1, hello=world}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((16 16, 16 18, 18 18, 18 16, 16 16)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {
@@ -539,7 +580,10 @@ public class AtlasSearchCommandTest
                     + "tags: {route=bike}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((30 30, 30 34, 34 34, 34 30, 30 30)), \n" + "]\n\n",
                     outContent.toString());
-            Assert.assertEquals("find: loading /Users/foo/test.atlas.txt\n", errContent.toString());
+            Assert.assertEquals(
+                    "find: loading /Users/foo/test.atlas.txt\n"
+                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    errContent.toString());
         }
         catch (final IOException exception)
         {

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
@@ -356,7 +356,8 @@ public class AtlasSearchCommandTest
             command.setNewErrStream(new PrintStream(errContent));
 
             command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
-                    "--predicate=!e.relations().isEmpty()");
+                    "--predicate=!e.relations().isEmpty() && e.relations().collect { it.getIdentifier() }.containsAll(Sets.hashSet(12000000L))",
+                    "--imports=org.openstreetmap.atlas.utilities.command.parsing");
 
             Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
                     + "CompleteEdge [\n" + "identifier: 11000000, \n"

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
@@ -1,38 +1,110 @@
 package org.openstreetmap.atlas.utilities.command.subcommands;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.FileSystem;
 
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.customizers.SecureASTCustomizer;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.Maps;
 
-import groovy.lang.GroovyShell;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 
 /**
- * @author Yazad Khambata
+ * @author lcram
  */
-public class SubAtlasCommandTest extends Object
+public class SubAtlasCommandTest
 {
-    // GROOVY-8135
     @Test
-    public void testStarImportsWhiteListWithIndirectImportCheckEnabled()
+    public void testPredicate()
     {
-        final SecureASTCustomizer customizer = new SecureASTCustomizer();
-        customizer.setIndirectImportCheckEnabled(true);
+        try (FileSystem filesystem = Jimfs.newFileSystem(Configuration.osX()))
+        {
+            setupFilesystem1(filesystem);
+            final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+            final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+            final SubAtlasCommand command = new SubAtlasCommand();
+            command.setNewFileSystem(filesystem);
+            command.setNewOutStream(new PrintStream(outContent));
+            command.setNewErrStream(new PrintStream(errContent));
 
-        final List<String> starImportsWhitelist = new ArrayList<>();
-        starImportsWhitelist.add("java.lang");
-        customizer.setStarImportsWhitelist(starImportsWhitelist);
+            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+                    "--predicate=!e.relations().isEmpty()", "--output=/Users/foo", "--verbose");
 
-        final CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
-        compilerConfiguration.addCompilationCustomizers(customizer);
+            Assert.assertEquals("", outContent.toString());
+            Assert.assertEquals(
+                    "subatlas: loading /Users/foo/test.atlas.txt\n"
+                            + "subatlas: saved to /Users/foo/sub_test.atlas\n",
+                    errContent.toString());
 
-        final ClassLoader parent = getClass().getClassLoader();
-        final GroovyShell shell = new GroovyShell(parent, compilerConfiguration);
-        final String hello = (String) shell
-                .evaluate("Object object = new Object(); return 'hello'");
-        Assert.assertEquals("hello", hello);
+            final File subAtlasFile = new File("/Users/foo/sub_test.atlas", filesystem);
+            final Atlas subAtlas = new AtlasResourceLoader()
+                    .load(new InputStreamResource(subAtlasFile::read)
+                            .withName(subAtlasFile.getAbsolutePathString()));
+            Assert.assertEquals(5, Iterables.size(subAtlas.entities()));
+            Assert.assertNotNull(subAtlas.node(8000000L));
+            Assert.assertNotNull(subAtlas.node(9000000L));
+            Assert.assertNotNull(subAtlas.node(10000000L));
+            Assert.assertNotNull(subAtlas.edge(11000000L));
+            Assert.assertNotNull(subAtlas.edge(11000001L));
+        }
+        catch (final IOException exception)
+        {
+            throw new CoreException("FileSystem operation failed", exception);
+        }
+    }
+
+    private void setupFilesystem1(final FileSystem filesystem)
+    {
+        final PackedAtlasBuilder builder = new PackedAtlasBuilder();
+
+        builder.addPoint(1000000L, Location.forWkt("POINT(1 1)"), Maps.hashMap("foo", "bar"));
+        builder.addPoint(2000000L, Location.forWkt("POINT(2 2)"), Maps.hashMap("baz", "bat"));
+        builder.addPoint(3000000L, Location.forWkt("POINT(3 3)"),
+                Maps.hashMap("foo", "bar", "baz", "bat"));
+
+        builder.addLine(4000000L, PolyLine.wkt("LINESTRING(10 10, 11 11, 12 12)"),
+                Maps.hashMap("this_is", "a_line"));
+        builder.addLine(5000000L, PolyLine.wkt("LINESTRING(13 13, 14 14, 15 15)"),
+                Maps.hashMap("this_is", "a_line", "foo", "bar"));
+        builder.addLine(6000000L, PolyLine.wkt("LINESTRING(16 16, 17 17, 18 18)"),
+                Maps.hashMap("hello", "world", "another", "tag1"));
+
+        builder.addArea(7000000L, Polygon.wkt("POLYGON((20 20, 21 20, 21 21, 20 20))"),
+                Maps.hashMap("baz", "bat"));
+
+        builder.addNode(8000000L, Location.forWkt("POINT(30 30)"), Maps.hashMap("foo", "bar"));
+        builder.addNode(9000000L, Location.forWkt("POINT(32 32)"), Maps.hashMap("baz", "bat"));
+        builder.addNode(10000000L, Location.forWkt("POINT(34 34)"),
+                Maps.hashMap("another", "tag2"));
+
+        builder.addEdge(11000000L, PolyLine.wkt("LINESTRING(30 30, 31 30, 32 32)"),
+                Maps.hashMap("foo", "bar"));
+        builder.addEdge(11000001L, PolyLine.wkt("LINESTRING(32 32, 32 33, 34 34)"),
+                Maps.hashMap("baz", "bat"));
+
+        final RelationBean bean = new RelationBean();
+        bean.addItem(11000000L, "role0", ItemType.EDGE);
+        bean.addItem(11000001L, "role1", ItemType.EDGE);
+        builder.addRelation(12000000L, 12L, bean, Maps.hashMap("route", "bike"));
+
+        final Atlas atlas = builder.get();
+        final File atlasFile = new File("/Users/foo/test.atlas.txt", filesystem);
+        assert atlas != null;
+        atlas.saveAsText(atlasFile);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
@@ -50,6 +50,7 @@ public class SubAtlasCommandTest
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
                     "subatlas: loading /Users/foo/test.atlas.txt\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 
@@ -88,6 +89,7 @@ public class SubAtlasCommandTest
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
                     "subatlas: loading /Users/foo/test.atlas.txt\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 
@@ -125,6 +127,7 @@ public class SubAtlasCommandTest
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
                     "subatlas: loading /Users/foo/test.atlas.txt\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/AtlasLoaderCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/AtlasLoaderCommandTest.java
@@ -91,7 +91,9 @@ public class AtlasLoaderCommandTest
             errExpected.append("test: loading /Users/foo/atlas1.atlas.txt\n")
                     .append("test: loading /Users/foo/atlas2.atlas.txt\n")
                     .append("test: warn: skipping directory: /Users/foo\n")
+                    .append("test: processing atlas /Users/foo/atlas1.atlas.txt (1/2)\n")
                     .append("test: POINT (1 1)\n").append("test: POINT (2 2)\n")
+                    .append("test: processing atlas /Users/foo/atlas2.atlas.txt (2/2)\n")
                     .append("test: POINT (1 1)\n").append("test: POINT (2 2)\n");
             Assert.assertEquals(errExpected.toString(), errContent.toString());
         }


### PR DESCRIPTION
### Description:
Commands with `--predicate` option can now specify imports. Meant to include this in #666 .

### Potential Impact:
Better command control.

### Unit Test Approach:
Modified a test to check this.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
