### PR TITLE
Revert to using jts 1.16.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ project.ext.versions = [
     opencsv: '2.3',
     gson: '2.2.4',
     http: '4.5.1',
-    jts: '1.17.0',
+    jts: '1.16.1',
     spatial4j: '0.7',
     geotools: '20.2',
     osmosis: '0.44.1',


### PR DESCRIPTION
### Description:

This PR reverts the jts version to 1.16.1

JTS was recently bumped to version 1.17.0: https://github.com/osmlab/atlas/pull/656

It turns out that GeoTools, another Atlas dependency, relies on JTS v. 1.16.0 (the latest version of GeoTools depends on only 1.16.1 as well). Here is the list of dependencies for the latest Atlas version that include jts itself, and GeoTools' transitive dependency on jts 

```
+--- org.locationtech.jts:jts-core:1.17.0
+--- org.locationtech.spatial4j:spatial4j:0.7
+--- org.geotools:gt-shapefile:20.2
|    +--- org.geotools:gt-data:20.2
|    |    +--- org.geotools:gt-main:20.2
|    |    |    +--- org.geotools:gt-api:20.2
|    |    |    |    +--- org.locationtech.jts:jts-core:1.16.0 -> 1.17.0
```

1.17.0 has breaking changes. Using jts 1.17.0, we run into version clashes where certain classes in the GeoTools package expect the jts 1.16.0 versions of methods, not 1.17.0, leading to NoSuchMethodErrors

### Potential Impact:

We shouldn't run into the GeoTools/jts version clash anymore. 

### Unit Test Approach:

Tested some methods that were previously failing with NoSuchMethodErrors

### Test Results:

Method calls worked

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
