### PR TITLE
Capped Rectangle expansion at geographic poles

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
@@ -348,7 +348,7 @@ public final class Rectangle extends Polygon
     public Rectangle expandVertically(final Distance distance)
     {
         final double degreesLatitudeToShift = distance.asMeters()
-                / Distance.DISTANCE_PER_DEGREE_LATITUDE.asMeters();
+                / Distance.APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR.asMeters();
         final long meterBuffer = 1;
 
         final Location oldLowerLeft = this.lowerLeft;
@@ -357,15 +357,15 @@ public final class Rectangle extends Polygon
         if (oldLowerLeft.getLatitude().asDegrees() - degreesLatitudeToShift <= Latitude.MINIMUM
                 .asDegrees())
         {
-            logger.error(
+            logger.warn(
                     "Provided distance {} would have shifted past the South Pole, truncating southward expansion...",
                     distance);
             final double degreesToHitMinimum = -1
                     * (Latitude.MINIMUM.asDegrees() - oldLowerLeft.getLatitude().asDegrees());
             // subtract a small buffer off the distance to just miss the pole.
             southShiftDistance = Distance
-                    .meters((Distance.DISTANCE_PER_DEGREE_LATITUDE.asMeters() * degreesToHitMinimum)
-                            - meterBuffer);
+                    .meters((Distance.APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR.asMeters()
+                            * degreesToHitMinimum) - meterBuffer);
         }
         final Location lowerLeftShiftedSouth = oldLowerLeft.shiftAlongGreatCircle(Heading.SOUTH,
                 southShiftDistance);
@@ -376,15 +376,15 @@ public final class Rectangle extends Polygon
         if (oldUpperRight.getLatitude().asDegrees() + degreesLatitudeToShift >= Latitude.MAXIMUM
                 .asDegrees())
         {
-            logger.error(
+            logger.warn(
                     "Provided distance {} would have shifted past the North Pole, truncating northward expansion...",
                     distance);
             final double degreesToHitMaximum = Latitude.MAXIMUM.asDegrees()
                     - oldUpperRight.getLatitude().asDegrees();
             // subtract a small buffer off the distance to just miss the pole.
             northShiftDistance = Distance
-                    .meters((Distance.DISTANCE_PER_DEGREE_LATITUDE.asMeters() * degreesToHitMaximum)
-                            - meterBuffer);
+                    .meters((Distance.APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR.asMeters()
+                            * degreesToHitMaximum) - meterBuffer);
         }
         final Location upperRightShiftedNorth = oldUpperRight.shiftAlongGreatCircle(Heading.NORTH,
                 northShiftDistance);

--- a/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
@@ -23,8 +23,6 @@ import com.google.gson.JsonPrimitive;
  */
 public final class Rectangle extends Polygon
 {
-    private static final long serialVersionUID = 6940095569975683891L;
-
     public static final Rectangle MAXIMUM = forCorners(
             new Location(Latitude.MINIMUM, Longitude.MINIMUM),
             new Location(Latitude.MAXIMUM, Longitude.MAXIMUM));
@@ -33,7 +31,7 @@ public final class Rectangle extends Polygon
             "37.328167,-122.031905:37.330394,-122.029051");
     public static final Rectangle TEST_RECTANGLE_2 = forString(
             "37.325194,-122.034281:37.325683,-122.033500");
-
+    private static final long serialVersionUID = 6940095569975683891L;
     // A rectangle stores only two locations, despite being a 4 location Polygon.
     private final Location lowerLeft;
     private final Location upperRight;
@@ -318,11 +316,20 @@ public final class Rectangle extends Polygon
      */
     public Rectangle expand(final Distance distance)
     {
-        final Location newLowerLeft = this.lowerLeft.shiftAlongGreatCircle(Heading.SOUTH, distance)
+        final Location oldLowerLeft = this.lowerLeft;
+        final Location lowerLeftShiftedSouth = oldLowerLeft.shiftAlongGreatCircle(Heading.SOUTH,
+                distance);
+        final Location lowerLeftShiftedSouthAndWest = lowerLeftShiftedSouth
                 .shiftAlongGreatCircle(Heading.WEST, distance);
-        final Location newUpperRight = this.upperRight
-                .shiftAlongGreatCircle(Heading.NORTH, distance)
+        final Location newLowerLeft = lowerLeftShiftedSouthAndWest;
+
+        final Location oldUpperRight = this.upperRight;
+        final Location upperRightShiftedNorth = oldUpperRight.shiftAlongGreatCircle(Heading.NORTH,
+                distance);
+        final Location upperRightShiftedNorthAndEast = upperRightShiftedNorth
                 .shiftAlongGreatCircle(Heading.EAST, distance);
+        final Location newUpperRight = upperRightShiftedNorthAndEast;
+
         return forCorners(newLowerLeft, newUpperRight);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Rectangle.java
@@ -323,12 +323,20 @@ public final class Rectangle extends Polygon
                 .shiftAlongGreatCircle(Heading.WEST, distance);
         final Location newLowerLeft = lowerLeftShiftedSouthAndWest;
 
+        System.err.println("oldLowerLeft: " + oldLowerLeft.toWkt());
+        System.err.println("lowerLeftShiftedSouth: " + lowerLeftShiftedSouth.toWkt());
+        System.err.println("newLowerLeft: " + newLowerLeft.toWkt());
+
         final Location oldUpperRight = this.upperRight;
         final Location upperRightShiftedNorth = oldUpperRight.shiftAlongGreatCircle(Heading.NORTH,
                 distance);
         final Location upperRightShiftedNorthAndEast = upperRightShiftedNorth
                 .shiftAlongGreatCircle(Heading.EAST, distance);
         final Location newUpperRight = upperRightShiftedNorthAndEast;
+
+        System.err.println("oldUpperRight: " + oldUpperRight.toWkt());
+        System.err.println("upperRightShiftedNorth: " + upperRightShiftedNorth.toWkt());
+        System.err.println("newUpperRight: " + newUpperRight.toWkt());
 
         return forCorners(newLowerLeft, newUpperRight);
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
@@ -29,7 +29,6 @@ public final class Distance implements Serializable
     public static final long FEET_PER_MILE = 5280;
     public static final double METERS_PER_FOOT = 0.3048;
     public static final double METERS_PER_KILOMETER = 1000;
-    public static final long MINUTES_PER_DEGREE = 60;
     public static final long MILLIMETERS_PER_METER = 1000;
     public static final long METERS_PER_NAUTICAL_MILE = 1852;
 
@@ -39,8 +38,15 @@ public final class Distance implements Serializable
     public static final Distance TEN_MILES = Distance.miles(10);
     public static final Distance FIFTEEN_HUNDRED_FEET = Distance.feet(1500);
     public static final Distance ONE_METER = Distance.meters(1);
-    public static final Distance DISTANCE_PER_DEGREE_LONGITUDE_AT_EQUATOR = Distance.meters(111321);
-    public static final Distance DISTANCE_PER_DEGREE_LATITUDE = Distance.meters(111120);
+    /**
+     * This value approximates the distance for 1 degree of latitude or longitude near the equator.
+     * The distance per degree latitude should not change anywhere on the earth, barring slight
+     * variations due to earth's true oblate spheroid shape. To calculate the distance per degree
+     * longitude far from the equator, please see
+     * {@link Distance#distancePerDegreeLongitudeAt(Location)}.
+     */
+    public static final Distance APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR = Angle.degrees(1)
+            .onEarth();
     /**
      * @see "https://en.wikipedia.org/wiki/Territorial_waters"
      */
@@ -53,7 +59,7 @@ public final class Distance implements Serializable
 
     public static Distance distancePerDegreeLongitudeAt(final Location location)
     {
-        return Distance.meters(DISTANCE_PER_DEGREE_LONGITUDE_AT_EQUATOR.asMeters()
+        return Distance.meters(APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR.asMeters()
                 * Math.cos(location.getLatitude().asRadians()));
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/scalars/Distance.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.utilities.scalars;
 import java.io.Serializable;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.Location;
 
 /**
  * A class providing conversion between different length units like feet, kilometers, miles etc.
@@ -11,8 +12,6 @@ import org.openstreetmap.atlas.exception.CoreException;
  */
 public final class Distance implements Serializable
 {
-    private static final long serialVersionUID = 3728783948477892064L;
-
     /**
      * An enum for distance unit abbreviations.
      */
@@ -26,29 +25,37 @@ public final class Distance implements Serializable
 
     public static final String FEET_NOTATION = "'";
     public static final String INCHES_NOTATION = "\"";
+    public static final long INCHES_PER_FOOT = 12L;
+    public static final long FEET_PER_MILE = 5280;
+    public static final double METERS_PER_FOOT = 0.3048;
+    public static final double METERS_PER_KILOMETER = 1000;
+    public static final long MINUTES_PER_DEGREE = 60;
+    public static final long MILLIMETERS_PER_METER = 1000;
+    public static final long METERS_PER_NAUTICAL_MILE = 1852;
 
-    protected static final long INCHES_PER_FOOT = 12L;
-    protected static final long FEET_PER_MILE = 5280;
-    protected static final double METERS_PER_FOOT = 0.3048;
-    protected static final double METERS_PER_KILOMETER = 1000;
-    protected static final long MILLIMETERS_PER_METER = 1000;
-    protected static final long METERS_PER_NAUTICAL_MILE = 1852;
-
-    public static final Distance AVERAGE_EARTH_RADIUS = Distance.kilometers(6371);
     public static final Distance ZERO = Distance.millimeters(0);
+    public static final Distance MAXIMUM = Distance.millimeters(Long.MAX_VALUE);
+    public static final Distance AVERAGE_EARTH_RADIUS = Distance.kilometers(6371);
     public static final Distance TEN_MILES = Distance.miles(10);
     public static final Distance FIFTEEN_HUNDRED_FEET = Distance.feet(1500);
     public static final Distance ONE_METER = Distance.meters(1);
-    public static final Distance MAXIMUM = Distance.millimeters(Long.MAX_VALUE);
-
+    public static final Distance DISTANCE_PER_DEGREE_LONGITUDE_AT_EQUATOR = Distance.meters(111321);
+    public static final Distance DISTANCE_PER_DEGREE_LATITUDE = Distance.meters(111120);
     /**
      * @see "https://en.wikipedia.org/wiki/Territorial_waters"
      */
     public static final Distance SEA_TERRITORY_ZONE = Distance.nauticalMiles(12);
 
+    private static final long serialVersionUID = 3728783948477892064L;
     private static final int DISTANCE_PRINTING_METERS_THRESHOLD = 1000;
 
     private final double millimeters;
+
+    public static Distance distancePerDegreeLongitudeAt(final Location location)
+    {
+        return Distance.meters(DISTANCE_PER_DEGREE_LONGITUDE_AT_EQUATOR.asMeters()
+                * Math.cos(location.getLatitude().asRadians()));
+    }
 
     public static Distance feet(final double feet)
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
@@ -143,17 +143,27 @@ public class RectangleTest
     }
 
     @Test
-    public void testExpansionNearPoles()
+    public void testExpansionAcrossPoles()
     {
         final long kilometersPerDegreeLatitude = 111L;
 
         Rectangle closeToSouthPole = Rectangle.forCorners(Location.forWkt("POINT(0 -87)"),
                 Location.forWkt("POINT(1 -84)"));
-        System.err.println(closeToSouthPole.toWkt());
-
+        // this should cross the south pole
         closeToSouthPole = closeToSouthPole
-                .expand(Distance.kilometers(kilometersPerDegreeLatitude * 3));
-        System.err.println(closeToSouthPole.toWkt());
+                .expand(Distance.kilometers(kilometersPerDegreeLatitude * 4));
+        Assert.assertEquals(
+                "POLYGON ((-89.9709113 -86.0070115, -89.9709113 -79.2463163, 22.9131203 -79.2463163, 22.9131203 -86.0070115, -89.9709113 -86.0070115))",
+                closeToSouthPole.toWkt());
+
+        Rectangle closeToNorthPole = Rectangle.forCorners(Location.forWkt("POINT(0 84)"),
+                Location.forWkt("POINT(1 87)"));
+        // this should cross the north pole
+        closeToNorthPole = closeToNorthPole
+                .expand(Distance.kilometers(kilometersPerDegreeLatitude * 4));
+        Assert.assertEquals(
+                "POLYGON ((-21.9131203 79.2463163, -21.9131203 86.0070115, 90.9709113 86.0070115, 90.9709113 79.2463163, -21.9131203 79.2463163))",
+                closeToNorthPole.toWkt());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
@@ -143,9 +143,35 @@ public class RectangleTest
     }
 
     @Test
+    public void testExpansionAcrossMeridians()
+    {
+        final long kilometersPerDegreeLongitudeNearNorthPole = Math.round(Distance
+                .distancePerDegreeLongitudeAt(Location.forWkt("POINT(178 87)")).asKilometers());
+        final long kilometersPerDegreeLongitudeNearSouthPole = Math.round(Distance
+                .distancePerDegreeLongitudeAt(Location.forWkt("POINT(-178 87)")).asKilometers());
+
+        Rectangle closeToNorthPole = Rectangle.forCorners(Location.forWkt("POINT(178 84)"),
+                Location.forWkt("POINT(179 87)"));
+        closeToNorthPole = closeToNorthPole.expandHorizontally(
+                Distance.kilometers(kilometersPerDegreeLongitudeNearNorthPole * 100));
+        Assert.assertEquals(
+                "POLYGON ((135.8977545 81.937154, 135.8977545 83.8283367, 179.9999999 83.8283367, 179.9999999 81.937154, 135.8977545 81.937154))",
+                closeToNorthPole.toWkt());
+
+        Rectangle closeToSouthPole = Rectangle.forCorners(Location.forWkt("POINT(-179 84)"),
+                Location.forWkt("POINT(-178 87)"));
+        closeToSouthPole = closeToSouthPole.expandHorizontally(
+                Distance.kilometers(kilometersPerDegreeLongitudeNearSouthPole * 100));
+        Assert.assertEquals(
+                "POLYGON ((-180 81.937154, -180 83.8283367, -116.9898158 83.8283367, -116.9898158 81.937154, -180 81.937154))",
+                closeToSouthPole.toWkt());
+    }
+
+    @Test
     public void testExpansionAcrossPoles()
     {
-        final long kilometersPerDegreeLatitude = 111L;
+        final long kilometersPerDegreeLatitude = Math
+                .round(Distance.APPROXIMATE_DISTANCE_PER_DEGREE_AT_EQUATOR.asKilometers());
 
         Rectangle closeToSouthPole = Rectangle.forCorners(Location.forWkt("POINT(0 -87)"),
                 Location.forWkt("POINT(1 -84)"));
@@ -153,7 +179,7 @@ public class RectangleTest
         closeToSouthPole = closeToSouthPole
                 .expand(Distance.kilometers(kilometersPerDegreeLatitude * 4));
         Assert.assertEquals(
-                "POLYGON ((-89.9709113 -86.0070115, -89.9709113 -79.2463163, 22.9131203 -79.2463163, 22.9131203 -86.0070115, -89.9709113 -86.0070115))",
+                "POLYGON ((-89.9998709 -86.0070121, -89.9998709 -79.2463163, 22.9131203 -79.2463163, 22.9131203 -86.0070121, -89.9998709 -86.0070121))",
                 closeToSouthPole.toWkt());
 
         Rectangle closeToNorthPole = Rectangle.forCorners(Location.forWkt("POINT(0 84)"),
@@ -162,7 +188,7 @@ public class RectangleTest
         closeToNorthPole = closeToNorthPole
                 .expand(Distance.kilometers(kilometersPerDegreeLatitude * 4));
         Assert.assertEquals(
-                "POLYGON ((-21.9131203 79.2463163, -21.9131203 86.0070115, 90.9709113 86.0070115, 90.9709113 79.2463163, -21.9131203 79.2463163))",
+                "POLYGON ((-21.9131203 79.2463163, -21.9131203 86.0070121, 90.9998709 86.0070121, 90.9998709 79.2463163, -21.9131203 79.2463163))",
                 closeToNorthPole.toWkt());
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/RectangleTest.java
@@ -143,6 +143,20 @@ public class RectangleTest
     }
 
     @Test
+    public void testExpansionNearPoles()
+    {
+        final long kilometersPerDegreeLatitude = 111L;
+
+        Rectangle closeToSouthPole = Rectangle.forCorners(Location.forWkt("POINT(0 -87)"),
+                Location.forWkt("POINT(1 -84)"));
+        System.err.println(closeToSouthPole.toWkt());
+
+        closeToSouthPole = closeToSouthPole
+                .expand(Distance.kilometers(kilometersPerDegreeLatitude * 3));
+        System.err.println(closeToSouthPole.toWkt());
+    }
+
+    @Test
     public void testIntersection()
     {
         Assert.assertEquals(Rectangle.forLocations(this.location2),

--- a/src/test/java/org/openstreetmap/atlas/utilities/scalars/DistanceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/scalars/DistanceTest.java
@@ -53,9 +53,24 @@ public class DistanceTest
     }
 
     @Test
+    public void testDistancePerDegreeLongitudeAt()
+    {
+        Assert.assertEquals(111195L, Math.round(
+                Distance.distancePerDegreeLongitudeAt(Location.forWkt("POINT(0 0)")).asMeters()));
+        Assert.assertEquals(1941L, Math.round(
+                Distance.distancePerDegreeLongitudeAt(Location.forWkt("POINT(0 -89)")).asMeters()));
+        Assert.assertEquals(1941L, Math.round(
+                Distance.distancePerDegreeLongitudeAt(Location.forWkt("POINT(0 89)")).asMeters()));
+        Assert.assertEquals(0L, Math.round(
+                Distance.distancePerDegreeLongitudeAt(Location.forWkt("POINT(0 -90)")).asMeters()));
+        Assert.assertEquals(0L, Math.round(
+                Distance.distancePerDegreeLongitudeAt(Location.forWkt("POINT(0 90)")).asMeters()));
+    }
+
+    @Test
     public void testEquals()
     {
-        Assert.assertTrue(Distance.meters(1000.001).equals(Distance.meters(1000.001)));
-        Assert.assertFalse(Distance.meters(1000.001).equals(Distance.meters(1000.002)));
+        Assert.assertEquals(Distance.meters(1000.001), Distance.meters(1000.001));
+        Assert.assertNotEquals(Distance.meters(1000.001), Distance.meters(1000.002));
     }
 }


### PR DESCRIPTION
### Description:
`Rectangle#expand` and `Rectangle#expandVertically` are now capped at the North and South Poles. This prevents the expansion code from failing when large distances are applied to rectangles near the poles. The expansion capping uses a 1 meter buffer from the pole, so this fix will fail if the original rectangle has a corner already within 1 meter of a pole.

### Potential Impact:
Rectangle users no longer need to worry about latitude of rectangle corners when expanding.

### Unit Test Approach:
Added a unit test.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)