### PR TITLE
Construction related date tags

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/CheckDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/CheckDateTag.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM check_date tag
+ *
+ * @author brianjor
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/check_date#values", osm= "https://wiki.openstreetmap.org/wiki/Key:check_date")
+public interface CheckDateTag
+{
+    @TagKey
+    String KEY = "check_date";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/CheckDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/CheckDateTag.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
  *
  * @author brianjor
  */
-@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/check_date#values", osm= "https://wiki.openstreetmap.org/wiki/Key:check_date")
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/check_date#values", osm = "https://wiki.openstreetmap.org/wiki/Key:check_date")
 public interface CheckDateTag
 {
     @TagKey

--- a/src/main/java/org/openstreetmap/atlas/tags/ConstructionDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ConstructionDateTag.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM construction:date tag
+ *
+ * @author brianjor
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/construction:date#values", osm= "https://wiki.openstreetmap.org/wiki/Item:Q9553")
+public interface ConstructionDateTag
+{
+    @TagKey
+    String KEY = "construction:date";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/ConstructionDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/ConstructionDateTag.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
  *
  * @author brianjor
  */
-@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/construction:date#values", osm= "https://wiki.openstreetmap.org/wiki/Item:Q9553")
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/construction:date#values", osm = "https://wiki.openstreetmap.org/wiki/Item:Q9553")
 public interface ConstructionDateTag
 {
     @TagKey

--- a/src/main/java/org/openstreetmap/atlas/tags/OpenDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/OpenDateTag.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM open_date tag
+ *
+ * @author brianjor
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/open_date#values")
+public interface OpenDateTag
+{
+    @TagKey
+    String KEY = "open_date";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/OpeningDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/OpeningDateTag.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM opening_date tag
+ *
+ * @author brianjor
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/opening_date#values", osm= "https://wiki.openstreetmap.org/wiki/Key:opening_date")
+public interface OpeningDateTag
+{
+    @TagKey
+    String KEY = "opening_date";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/OpeningDateTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/OpeningDateTag.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
  *
  * @author brianjor
  */
-@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/opening_date#values", osm= "https://wiki.openstreetmap.org/wiki/Key:opening_date")
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/opening_date#values", osm = "https://wiki.openstreetmap.org/wiki/Key:opening_date")
 public interface OpeningDateTag
 {
     @TagKey

--- a/src/main/java/org/openstreetmap/atlas/tags/TemporaryDateOnTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TemporaryDateOnTag.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM temporary:date_on tag
+ *
+ * @author brianjor
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/temporary:date_on#values", osm= "https://wiki.openstreetmap.org/wiki/Item:Q15233")
+public interface TemporaryDateOnTag
+{
+    @TagKey
+    String KEY = "temporary:date_on";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/TemporaryDateOnTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/TemporaryDateOnTag.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.tags.annotations.TagKey;
  *
  * @author brianjor
  */
-@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/temporary:date_on#values", osm= "https://wiki.openstreetmap.org/wiki/Item:Q15233")
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/temporary:date_on#values", osm = "https://wiki.openstreetmap.org/wiki/Item:Q15233")
 public interface TemporaryDateOnTag
 {
     @TagKey

--- a/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
  * Test for @{CheckDateTag}
+ *
+ * @author brianjor
  */
 public class CheckDateTagTestCase
 {

--- a/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+public class CheckDateTagTestCase
+{
+    @Test
+    public void testCheckDateTag()
+    {
+        final TestTaggable taggable = new TestTaggable(CheckDateTag.KEY, "2020");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, CheckDateTag.class));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/CheckDateTagTestCase.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
+/**
+ * Test for @{CheckDateTag}
+ */
 public class CheckDateTagTestCase
 {
     @Test

--- a/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
+/**
+ * Test for @{ConstructionDateTag}
+ */
 public class ConstructionDateTagTestCase
 {
     @Test

--- a/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+public class ConstructionDateTagTestCase
+{
+    @Test
+    public void testConstructionDateTag()
+    {
+        final TestTaggable taggable = new TestTaggable(ConstructionDateTag.KEY, "2020");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, ConstructionDateTag.class));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/ConstructionDateTagTestCase.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
  * Test for @{ConstructionDateTag}
+ *
+ * @author brianjor
  */
 public class ConstructionDateTagTestCase
 {

--- a/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
  * Test for @{OpenDateTag}
+ *
+ * @author brianjor
  */
 public class OpenDateTagTestCase
 {

--- a/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
+/**
+ * Test for @{OpenDateTag}
+ */
 public class OpenDateTagTestCase
 {
     @Test

--- a/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/OpenDateTagTestCase.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+public class OpenDateTagTestCase
+{
+    @Test
+    public void testOpenDateTag()
+    {
+        final TestTaggable taggable = new TestTaggable(OpenDateTag.KEY, "2020");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, OpenDateTag.class));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/OpeningDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/OpeningDateTagTestCase.java
@@ -1,0 +1,22 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+/**
+ * Tests
+ * for #{OpeningDateTag}
+ *
+ * @author brianjor
+ */
+public class OpeningDateTagTestCase
+{
+    @Test
+    public void testOpeningDateTag()
+    {
+        final TestTaggable taggable = new TestTaggable(OpeningDateTag.KEY, "2020");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, OpeningDateTag.class));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/OpeningDateTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/OpeningDateTagTestCase.java
@@ -6,8 +6,7 @@ import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
- * Tests
- * for #{OpeningDateTag}
+ * Test for #{OpeningDateTag}
  *
  * @author brianjor
  */

--- a/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
+/**
+ * Test for @{TemporaryDateOnTag}
+ */
 public class TemporaryDateOnTagTestCase
 {
     @Test

--- a/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
@@ -1,0 +1,16 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.testing.TestTaggable;
+
+public class TemporaryDateOnTagTestCase
+{
+    @Test
+    public void testTemporaryDateOnTag()
+    {
+        final TestTaggable taggable = new TestTaggable(TemporaryDateOnTag.KEY, "2020");
+        Assert.assertTrue(Validators.hasValuesFor(taggable, TemporaryDateOnTag.class));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/TemporaryDateOnTagTestCase.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
 /**
  * Test for @{TemporaryDateOnTag}
+ *
+ * @author brianjor
  */
 public class TemporaryDateOnTagTestCase
 {


### PR DESCRIPTION
### Description:

Added the following tags: "opening_date", "open_date", "construction:date", "temporary:date_on", and "check_date".

This was as suggestion by @Bentleysb in https://github.com/osmlab/atlas-checks/pull/358#discussion_r490417963 

### Potential Impact:

More tags

### Unit Test Approach:

Testing that the tag was created correctly and behavior matches similar tags.
