### PR TITLE
Make FeatureChange Constructor Public

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -141,19 +141,6 @@ public class FeatureChange implements Located, Taggable, Serializable, Comparabl
     }
 
     /**
-     * Create a new {@link FeatureChange} with a given type and after view.
-     *
-     * @param changeType
-     *            the type, either ADD or REMOVE.
-     * @param afterView
-     *            the after view of the changed entity
-     */
-    FeatureChange(final ChangeType changeType, final AtlasEntity afterView)
-    {
-        this(changeType, afterView, null);
-    }
-
-    /**
      * Create a new {@link FeatureChange} with a given type, after view, and before view. This
      * constructor is provided for exact control over the before view of a change. It is kept
      * package private, and is used for testing purposes only.
@@ -165,7 +152,7 @@ public class FeatureChange implements Located, Taggable, Serializable, Comparabl
      * @param beforeView
      *            the before entity
      */
-    FeatureChange(final ChangeType changeType, final AtlasEntity afterView,
+    public FeatureChange(final ChangeType changeType, final AtlasEntity afterView,
             final AtlasEntity beforeView)
     {
         if (afterView == null)
@@ -206,6 +193,19 @@ public class FeatureChange implements Located, Taggable, Serializable, Comparabl
 
         this.validateNotShallow();
         this.metaData = new HashMap<>();
+    }
+
+    /**
+     * Create a new {@link FeatureChange} with a given type and after view.
+     *
+     * @param changeType
+     *            the type, either ADD or REMOVE.
+     * @param afterView
+     *            the after view of the changed entity
+     */
+    FeatureChange(final ChangeType changeType, final AtlasEntity afterView)
+    {
+        this(changeType, afterView, null);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChange.java
@@ -141,6 +141,19 @@ public class FeatureChange implements Located, Taggable, Serializable, Comparabl
     }
 
     /**
+     * Create a new {@link FeatureChange} with a given type and after view.
+     *
+     * @param changeType
+     *            the type, either ADD or REMOVE.
+     * @param afterView
+     *            the after view of the changed entity
+     */
+    public FeatureChange(final ChangeType changeType, final AtlasEntity afterView)
+    {
+        this(changeType, afterView, null);
+    }
+
+    /**
      * Create a new {@link FeatureChange} with a given type, after view, and before view. This
      * constructor is provided for exact control over the before view of a change. It is kept
      * package private, and is used for testing purposes only.
@@ -193,19 +206,6 @@ public class FeatureChange implements Located, Taggable, Serializable, Comparabl
 
         this.validateNotShallow();
         this.metaData = new HashMap<>();
-    }
-
-    /**
-     * Create a new {@link FeatureChange} with a given type and after view.
-     *
-     * @param changeType
-     *            the type, either ADD or REMOVE.
-     * @param afterView
-     *            the after view of the changed entity
-     */
-    FeatureChange(final ChangeType changeType, final AtlasEntity afterView)
-    {
-        this(changeType, afterView, null);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/change/FeatureChangeTest.java
@@ -1,11 +1,13 @@
 package org.openstreetmap.atlas.geography.atlas.change;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -19,6 +21,9 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.builder.RelationBean.RelationBeanItem;
 import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescription;
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptor;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.TagChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteArea;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteLine;
@@ -27,6 +32,7 @@ import org.openstreetmap.atlas.geography.atlas.complete.CompletePoint;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.validators.FeatureChangeUsefulnessValidator;
+import org.openstreetmap.atlas.tags.names.NameTag;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.Sets;
 
@@ -299,6 +305,21 @@ public class FeatureChangeTest
                 + "TAG(REMOVE, key0, value0)\n" + "]";
 
         Assert.assertEquals(goldenString, description.toString());
+    }
+
+    @Test
+    public void testExplicitBeforeView()
+    {
+        final Supplier<CompletePoint> completePointGenerator = () -> new CompletePoint(1000000L,
+                Location.CENTER, Collections.emptyMap(), Collections.emptySet());
+        final List<ChangeDescriptor> changeDescriptors = new FeatureChange(ChangeType.ADD,
+                completePointGenerator.get().withAddedTag(NameTag.KEY, "test"),
+                completePointGenerator.get()).explain().getChangeDescriptors();
+
+        Assert.assertEquals(1, changeDescriptors.size());
+        Assert.assertTrue(changeDescriptors.get(0) instanceof TagChangeDescriptor);
+        Assert.assertEquals(ChangeDescriptorType.ADD,
+                changeDescriptors.get(0).getChangeDescriptorType());
     }
 
     @Test


### PR DESCRIPTION
### Description:

This makes `FeatureChange(ChangeType, AtlasEntity, AtlasEntity)` public, allowing FeatureChanges to be created with explicit before views.
This is going to be used to deserialize json change descriptions as part of a CheckFlag deserialized in AtlasChecks. This is part of a larger effort to add fix suggestions to MapRoulette tasks created from Atlas Checks. 

### Potential Impact:

Allows creating FeatureChanges with an explicit before view. 

### Unit Test Approach:

Added a unit test for the constructor. 

### Test Results:

No other testing other than the unit test. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
