### PR TITLE
Make Relation ID generator deterministic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/builder/RelationBean.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.geography.atlas.builder;
 import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -11,6 +12,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -27,7 +30,7 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     /**
      * @author matthieun
      */
-    public static class RelationBeanItem implements Serializable
+    public static class RelationBeanItem implements Serializable, Comparable<RelationBeanItem>
     {
         private static final long serialVersionUID = 441160361936498695L;
 
@@ -47,6 +50,21 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
             this.identifier = item.identifier;
             this.role = item.role;
             this.type = item.type;
+        }
+
+        @Override
+        public int compareTo(final RelationBeanItem other)
+        {
+            int result = this.getType().compareTo(other.getType());
+            if (result == 0)
+            {
+                result = Long.compare(this.getIdentifier(), other.getIdentifier());
+            }
+            if (result == 0)
+            {
+                result = this.getRole().compareTo(other.getRole());
+            }
+            return result;
         }
 
         @Override
@@ -227,6 +245,30 @@ public class RelationBean extends AbstractCollection<RelationBeanItem> implement
     public Set<RelationBeanItem> asSet()
     {
         return new HashSet<>(this.asMap().keySet());
+    }
+
+    /**
+     * Get this {@link RelationBean} as a sorted {@link List} of its {@link RelationBeanItem}s.
+     *
+     * @return the item list representing this bean
+     */
+    public List<RelationBeanItem> asSortedList()
+    {
+        final List<RelationBeanItem> result = asList();
+        Collections.sort(result);
+        return result;
+    }
+
+    /**
+     * Get this {@link RelationBean} as a {@link SortedSet} from its constituent
+     * {@link RelationBeanItem}s. This will ignore the fact that a {@link RelationBean} can
+     * technically contain duplicate items.
+     *
+     * @return the set representing this bean
+     */
+    public SortedSet<RelationBeanItem> asSortedSet()
+    {
+        return new TreeSet<>(this.asMap().keySet());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGenerator.java
@@ -109,7 +109,8 @@ public class EntityIdentifierGenerator
             {
                 final RelationBean bean = relation.members().asBean();
                 builder.append("RelationBean[");
-                for (final RelationBean.RelationBeanItem beanItem : bean)
+                // Here use sorted list to ensure determinism
+                for (final RelationBean.RelationBeanItem beanItem : bean.asSortedList())
                 {
                     builder.append("(");
                     builder.append(beanItem.getType());

--- a/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/identifiers/EntityIdentifierGeneratorTest.java
@@ -45,16 +45,26 @@ public class EntityIdentifierGeneratorTest
     @Test
     public void testGetTypeSpecificPropertyStringForRelation()
     {
-        final RelationBean bean = new RelationBean();
-        bean.addItem(1L, "role", ItemType.POINT);
-        bean.addItem(10L, "role", ItemType.AREA);
+        final RelationBean bean1 = new RelationBean();
+        bean1.addItem(1L, "role", ItemType.POINT);
+        bean1.addItem(10L, "role", ItemType.AREA);
 
-        final CompleteRelation relation = new CompleteRelation(1L, Maps.hashMap("a", "b", "c", "d"),
-                Rectangle.MINIMUM, bean, null, null, null, Sets.hashSet());
+        final RelationBean bean2 = new RelationBean();
+        bean2.addItem(10L, "role", ItemType.AREA);
+        bean2.addItem(1L, "role", ItemType.POINT);
 
-        final String goldenPropertyString = ";RelationBean[(POINT,1,role)(AREA,10,role)]";
+        final CompleteRelation relation1 = new CompleteRelation(1L,
+                Maps.hashMap("a", "b", "c", "d"), Rectangle.MINIMUM, bean1, null, null, null,
+                Sets.hashSet());
+        final CompleteRelation relation2 = new CompleteRelation(1L,
+                Maps.hashMap("a", "b", "c", "d"), Rectangle.MINIMUM, bean2, null, null, null,
+                Sets.hashSet());
+
+        final String goldenPropertyString = ";RelationBean[(AREA,10,role)(POINT,1,role)]";
         Assert.assertEquals(goldenPropertyString,
-                new EntityIdentifierGenerator().getTypeSpecificPropertyString(relation));
+                new EntityIdentifierGenerator().getTypeSpecificPropertyString(relation1));
+        Assert.assertEquals(goldenPropertyString,
+                new EntityIdentifierGenerator().getTypeSpecificPropertyString(relation2));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Make sure `EntityIdentifierGenerator` is deterministic when generating IDs for relations that might have a different order of members but ultimately have the same.

### Potential Impact:

More determinism, less meaningless diffs.

### Unit Test Approach:

Updated existing unit test for the id generator

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
