### PR TITLE
CompleteRelation.changeMemberRole should list old role as explicitly excluded

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -162,10 +162,13 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
                 member.getType());
         if (oldItem.isPresent())
         {
-            this.members.removeItem(oldItem.get());
+            final RelationBeanItem old = oldItem.get();
+            this.members.removeItem(old);
             final RelationBeanItem newItem = new RelationBeanItem(member.getIdentifier(), role,
                     member.getType());
             this.members.addItem(newItem);
+            this.members.addItemExplicitlyExcluded(member.getIdentifier(), old.getRole(),
+                    member.getType());
         }
         return this;
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelationTest.java
@@ -176,6 +176,24 @@ public class CompleteRelationTest
     }
 
     @Test
+    public void testMemberIsExplicitlyRemovedWhenRoleSwapped()
+    {
+        final String newRole = "newRole";
+        final String originalRole = "originalRole";
+        final RelationBean members = new RelationBean();
+        final RelationBeanItem originalRelationBeanItem = new RelationBeanItem(1L, originalRole,
+                ItemType.AREA);
+        members.add(originalRelationBeanItem);
+        final CompleteRelation completeRelation = new CompleteRelation(123L, null, null, members,
+                null, null, null, null);
+        completeRelation.changeMemberRole(new CompleteArea(1L, null, null, null), newRole);
+        Assert.assertEquals(1, completeRelation.members().size());
+        Assert.assertEquals(newRole, completeRelation.members().get(0).getRole());
+        Assert.assertTrue(completeRelation.members().asBean().getExplicitlyExcluded()
+                .contains(originalRelationBeanItem));
+    }
+
+    @Test
     public void testNonFullRelationCopy()
     {
         this.expectedException.expect(CoreException.class);


### PR DESCRIPTION
### Description:

Changing the role of a member should be the same as removing the member and adding it back with a new role. As such, it also needs to add the old role as explicitly excluded, which was an omission here.

### Potential Impact:

There used to be duplicate member roles when doing multi-atlas operations on top of ChangeAtlas objects, since the neighboring Atlas still had the old role present. Now with the explicitly excluded mention, this should not happen anymore.

### Unit Test Approach:

Added one unit test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
