### PR TITLE
CountryBoundaryMap: Do not override polygon ID key

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/boundary/CountryBoundaryMap.java
@@ -362,8 +362,8 @@ public class CountryBoundaryMap implements Serializable, GeoJson
                 if (!Objects.equals(existingValue, value) && logger.isDebugEnabled())
                 {
                     logger.debug(
-                            "Trying to override existing '{}' key's value of '{}' with '{}' for geometry {}",
-                            key, existingValue, value, geometry);
+                            "Trying to override existing '{}' key's value of '{}' with '{}' for geometry with values {}",
+                            key, existingValue, value, propertyMap);
                 }
             }
         }
@@ -437,6 +437,17 @@ public class CountryBoundaryMap implements Serializable, GeoJson
         {
             setGeometryProperty(polygon, ISOCountryTag.KEY, country);
             setGeometryProperty(polygon, POLYGON_ID_KEY, "0");
+            this.rawIndex.insert(polygon.getEnvelopeInternal(), polygon);
+        }
+    }
+
+    public void addCountryWithoutPolygonIdKey(final String country, final Polygon polygon)
+    {
+        this.countryNameToBoundaryMap.add(country, polygon);
+
+        if (this.envelope.intersects(polygon.getEnvelopeInternal()))
+        {
+            setGeometryProperty(polygon, ISOCountryTag.KEY, country);
             this.rawIndex.insert(polygon.getEnvelopeInternal(), polygon);
         }
     }
@@ -1030,7 +1041,7 @@ public class CountryBoundaryMap implements Serializable, GeoJson
                                 setGeometryProperty(geometry, POLYGON_ID_KEY,
                                         String.valueOf(identifier + 1));
                             }
-                            this.addCountry(country, (Polygon) geometry);
+                            this.addCountryWithoutPolygonIdKey(country, (Polygon) geometry);
                         }
                         else if (geometry instanceof org.locationtech.jts.geom.MultiPolygon)
                         {


### PR DESCRIPTION
### Description:

When reading a country boundary map from text, the tool would be assigning each polygon's PID key twice. The second attempt would be blocked and a debug log would be printed.  This fixes this issue.

### Potential Impact:

Get rid of extra log statements.

### Unit Test Approach:

Already covered, since there are no logic changes, but just a path change.

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
