### PR TITLE
MultiplePolyLineToPolygonsConverter OpenPolygonException Pass Open Locations

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
@@ -404,7 +404,7 @@ public class MultiplePolyLineToPolygonsConverter
             {
                 throw new OpenPolygonException(
                         "Failed second legacy attempt. JTS Exception was: \"{}\"",
-                        new ArrayList<>(), jtsException.getMessage(), e);
+                        jtsException.getOpenLocations(), jtsException.getMessage(), e);
             }
         }
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverterTest.java
@@ -258,11 +258,18 @@ public class MultiplePolyLineToPolygonsConverterTest
         Assert.assertEquals(1, Iterables.size(CONVERTER.convert(list)));
     }
 
-    @Test(expected = OpenPolygonException.class)
+    @Test
     public void testSingleOpenPolyLine()
     {
         final List<PolyLine> list = new ArrayList<>();
         list.add(new PolyLine(ONE, TWO));
-        CONVERTER.convert(list);
+        try
+        {
+            CONVERTER.convert(list);
+        }
+        catch (final OpenPolygonException openPolygonException)
+        {
+            Assert.assertEquals(2, openPolygonException.getOpenLocations().size());
+        }
     }
 }


### PR DESCRIPTION
### Description:

InvalidMultiPolygonRelationCheck in Atlas Checks is reliant on having open locations in OpenPolygonExceptions from MultiplePolyLineToPolygonsConverter. This was no longer the case for the new exception that's thrown in the case both the jts and legacy conversions fail. 

### Potential Impact:

OpenPolygonExceptions from MultiplePolyLineToPolygonsConverter will again include the open locations.

### Unit Test Approach:

Updated a unit test to check for the open locations.

### Test Results:

Loaded a local build into Atlas Checks and ensured InvalidMultiPolygonRelationCheck is functional again. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
