### PR TITLE
File parent method no longer throws NullPointerException

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/File.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/File.java
@@ -788,7 +788,7 @@ public class File extends AbstractWritableResource implements Comparable<File>
      */
     public File parent()
     {
-        return new File(this.path.getParent());
+        return new File(this.toAbsolutePath().getParent());
     }
 
     /**


### PR DESCRIPTION
### Description:
Previously, `File#parent` would throw a `NullPointerException` in cases where a single relative path component was supplied, like `new File("some-folder", fs)`. This is because in that case, the `File`'s underlying `Path` object did not have a parent. The `parent` method now computes the absolutized version of the underlying `Path` to use when constructing the parent `File` object.

### Potential Impact:
There were some places in the code (e.g. in `CountryBoundaryMapPrinterCommand`) that would sometimes generate a `NullPointerException` when provided with a single component relative path. This will no longer occur. No regressions are expected.

### Unit Test Approach:
Ran full atlas test suite.

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)