### PR TITLE
Make Polygonizer optional to re-construct multipolygons

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationOrAreaToMultiPolygonConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationOrAreaToMultiPolygonConverter.java
@@ -21,10 +21,19 @@ import org.openstreetmap.atlas.utilities.maps.MultiMap;
  */
 public class RelationOrAreaToMultiPolygonConverter implements Converter<AtlasEntity, MultiPolygon>
 {
-    private static final RelationToMultiPolygonMemberConverter OUTER_CONVERTER = new RelationToMultiPolygonMemberConverter(
-            Ring.OUTER);
-    private static final RelationToMultiPolygonMemberConverter INNER_CONVERTER = new RelationToMultiPolygonMemberConverter(
-            Ring.INNER);
+    private final RelationToMultiPolygonMemberConverter outerConverter;
+    private final RelationToMultiPolygonMemberConverter innerConverter;
+
+    public RelationOrAreaToMultiPolygonConverter()
+    {
+        this(false);
+    }
+
+    public RelationOrAreaToMultiPolygonConverter(final boolean usePolygonizer)
+    {
+        this.outerConverter = new RelationToMultiPolygonMemberConverter(Ring.OUTER, usePolygonizer);
+        this.innerConverter = new RelationToMultiPolygonMemberConverter(Ring.INNER, usePolygonizer);
+    }
 
     @Override
     public MultiPolygon convert(final AtlasEntity entity)
@@ -37,7 +46,7 @@ public class RelationOrAreaToMultiPolygonConverter implements Converter<AtlasEnt
                 // Loop through the relation members, extract the inners and outers, and create the
                 // outline.
                 final MultiMap<Polygon, Polygon> outerToInners = new MultiMap<>();
-                for (final Polygon outer : OUTER_CONVERTER.convert(relation))
+                for (final Polygon outer : this.outerConverter.convert(relation))
                 {
                     outerToInners.put(outer, new ArrayList<>());
                 }
@@ -45,7 +54,7 @@ public class RelationOrAreaToMultiPolygonConverter implements Converter<AtlasEnt
                 {
                     throw new CoreException("Unable to find outer polygon.");
                 }
-                for (final Polygon inner : INNER_CONVERTER.convert(relation))
+                for (final Polygon inner : this.innerConverter.convert(relation))
                 {
                     boolean added = false;
                     for (final Polygon outer : outerToInners.keySet())

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/RelationToMultiPolygonMemberConverter.java
@@ -28,13 +28,19 @@ import org.openstreetmap.atlas.utilities.conversion.Converter;
  */
 public class RelationToMultiPolygonMemberConverter implements Converter<Relation, Iterable<Polygon>>
 {
-    private static final MultiplePolyLineToPolygonsConverter MULTIPLE_POLY_LINE_TO_POLYGONS_CONVERTER = new MultiplePolyLineToPolygonsConverter();
-
+    private final MultiplePolyLineToPolygonsConverter multiplePolyLineToPolygonsConverter;
     private final Ring ring;
 
     public RelationToMultiPolygonMemberConverter(final Ring ring)
     {
+        this(ring, false);
+    }
+
+    public RelationToMultiPolygonMemberConverter(final Ring ring, final boolean usePolygonizer)
+    {
         this.ring = ring;
+        this.multiplePolyLineToPolygonsConverter = new MultiplePolyLineToPolygonsConverter(
+                usePolygonizer);
     }
 
     @Override
@@ -71,7 +77,7 @@ public class RelationToMultiPolygonMemberConverter implements Converter<Relation
             }
         }
         return new MultiIterable<>(alreadyFormed,
-                MULTIPLE_POLY_LINE_TO_POLYGONS_CONVERTER.convert(candidates));
+                this.multiplePolyLineToPolygonsConverter.convert(candidates));
     }
 
     private void processEntity(final AtlasEntity entity, final List<PolyLine> candidates,

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -93,7 +93,8 @@ public class RawAtlasSlicer
     private static final JtsPolygonConverter JTS_POLYGON_CONVERTER = new JtsPolygonConverter();
     private static final JtsPolyLineConverter JTS_POLYLINE_CONVERTER = new JtsPolyLineConverter();
     private static final JtsMultiPolygonToMultiPolygonConverter JTS_MULTIPOLYGON_CONVERTER = new JtsMultiPolygonToMultiPolygonConverter();
-    private static final RelationOrAreaToMultiPolygonConverter RELATION_TO_MULTIPOLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
+    private static final RelationOrAreaToMultiPolygonConverter RELATION_TO_MULTIPOLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter(
+            true);
     private static final Logger logger = LoggerFactory.getLogger(RawAtlasSlicer.class);
 
     private static final long SLICING_DURATION_WARN = 10;

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
@@ -350,8 +350,32 @@ public class MultiplePolyLineToPolygonsConverter
     private static final JtsPolyLineConverter JTS_POLY_LINE_CONVERTER = new JtsPolyLineConverter();
     private static final JtsPolygonConverter JTS_POLYGON_CONVERTER = new JtsPolygonConverter();
 
+    private final boolean usePolygonizer;
+
+    public MultiplePolyLineToPolygonsConverter()
+    {
+        this.usePolygonizer = false;
+    }
+
+    public MultiplePolyLineToPolygonsConverter(final boolean usePolygonizer)
+    {
+        this.usePolygonizer = usePolygonizer;
+    }
+
     @Override
     public Iterable<Polygon> convert(final Iterable<PolyLine> candidates)
+    {
+        if (this.usePolygonizer)
+        {
+            return convertAttemptPolygonizer(candidates);
+        }
+        else
+        {
+            return convertLegacy(candidates);
+        }
+    }
+
+    public Iterable<Polygon> convertAttemptPolygonizer(final Iterable<PolyLine> candidates)
     {
         final Polygonizer polygonizer = new Polygonizer();
         candidates.forEach(polyLine -> polygonizer.add(JTS_POLY_LINE_CONVERTER.convert(polyLine)));


### PR DESCRIPTION
### Description:

This is a simple followup of #697 and #690 which makes Polygonizer an option, and not the default when re-constructing multi-polygons from relations. It turns out Polygonizer is non-deterministic run over run, even with normalization. This causes a variety of issues with diff tools expecting consistency. While this issue is figured-out, we keep Polygonizer as an option we enable only when run over run determinism is not an issue.

### Potential Impact:

More determinism for the default use-case.

### Unit Test Approach:

Use existing tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
