### PR TITLE
Catch way-sectioning errors

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessor.java
@@ -939,14 +939,21 @@ public class WaySectionProcessor
         changeSet.getLinesThatBecomeEdges().forEach(lineIdentifier ->
         {
             final Line line = this.rawAtlas.line(lineIdentifier);
-            final List<TemporaryEdge> edges;
-            if (line.isClosed())
+            List<TemporaryEdge> edges = new ArrayList<>();
+            try
             {
-                edges = splitRingLineIntoEdges(changeSet, line);
+                if (line.isClosed())
+                {
+                    edges = splitRingLineIntoEdges(changeSet, line);
+                }
+                else
+                {
+                    edges = splitNonRingLineIntoEdges(changeSet, line);
+                }
             }
-            else
+            catch (final CoreException e)
             {
-                edges = splitNonRingLineIntoEdges(changeSet, line);
+                logger.error("Could not way-section Line {}. Dropping...", line.getIdentifier(), e);
             }
             changeSet.createLineToEdgeMapping(line, edges);
         });
@@ -1101,7 +1108,8 @@ public class WaySectionProcessor
         }
         catch (final Exception e)
         {
-            throw new CoreException("Failed to way-section line {}", line.getIdentifier(), e);
+            throw new CoreException("Failed to way-section non-ring line {}", line.getIdentifier(),
+                    e);
         }
         return newEdgesForLine;
     }
@@ -1129,7 +1137,7 @@ public class WaySectionProcessor
         final PolyLine polyline = line.asPolyLine();
         if (polyline.size() < MINIMUM_POINTS_TO_QUALIFY_AS_A_LINE)
         {
-            logger.error("Line {} hass less than {} points, cannot be sectioned!",
+            logger.error("Line {} has less than {} points, cannot be sectioned!",
                     line.getIdentifier(), MINIMUM_POINTS_TO_QUALIFY_AS_A_LINE);
             return newEdgesForLine;
         }
@@ -1294,7 +1302,7 @@ public class WaySectionProcessor
         }
         catch (final Exception e)
         {
-            throw new CoreException("Failed to way-section line {}", line.getIdentifier(), e);
+            throw new CoreException("Failed to way-section ring line {}", line.getIdentifier(), e);
         }
         return newEdgesForLine;
     }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -89,6 +89,24 @@ public class WaySectionProcessorTest
     }
 
     @Test
+    public void testLineWithInvalidOverlappingGeometry()
+    {
+        // Based on https://www.openstreetmap.org/way/858888726
+        final Atlas slicedRawAtlas = this.setup.getLineWithInvalidOverlappingGeometry();
+        final Atlas finalAtlas = new WaySectionProcessor(slicedRawAtlas,
+                AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
+
+        Assert.assertEquals("Two edges, each having a reverse counterpart", 4,
+                finalAtlas.numberOfEdges());
+
+        // Explicit check for expected identifiers
+        Assert.assertTrue(finalAtlas.edge(858888719000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(-858888719000001L) != null);
+        Assert.assertTrue(finalAtlas.edge(858888719000002L) != null);
+        Assert.assertTrue(finalAtlas.edge(-858888719000002L) != null);
+    }
+
+    @Test
     public void testLineWithLoopAtEnd()
     {
         // Based on https://www.openstreetmap.org/way/461101743

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTest.java
@@ -1,10 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.raw.sectioning;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -58,10 +56,10 @@ public class WaySectionProcessorTest
         Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
 
         // Explicit check for expected identifiers
-        Assert.assertTrue(finalAtlas.edge(317579533000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(-317579533000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(317579533000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(-317579533000002L) != null);
+        Assert.assertNotNull(finalAtlas.edge(317579533000001L));
+        Assert.assertNotNull(finalAtlas.edge(-317579533000001L));
+        Assert.assertNotNull(finalAtlas.edge(317579533000002L));
+        Assert.assertNotNull(finalAtlas.edge(-317579533000002L));
     }
 
     @Test
@@ -100,10 +98,10 @@ public class WaySectionProcessorTest
                 finalAtlas.numberOfEdges());
 
         // Explicit check for expected identifiers
-        Assert.assertTrue(finalAtlas.edge(858888719000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(-858888719000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(858888719000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(-858888719000002L) != null);
+        Assert.assertNotNull(finalAtlas.edge(858888719000001L));
+        Assert.assertNotNull(finalAtlas.edge(-858888719000001L));
+        Assert.assertNotNull(finalAtlas.edge(858888719000002L));
+        Assert.assertNotNull(finalAtlas.edge(-858888719000002L));
     }
 
     @Test
@@ -121,10 +119,10 @@ public class WaySectionProcessorTest
         Assert.assertEquals(2, finalAtlas.node(4566499619000000L).connectedEdges().size());
 
         // Explicit check for expected identifiers
-        Assert.assertTrue(finalAtlas.edge(461101743000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(-461101743000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(461101743000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(-461101743000002L) != null);
+        Assert.assertNotNull(finalAtlas.edge(461101743000001L));
+        Assert.assertNotNull(finalAtlas.edge(-461101743000001L));
+        Assert.assertNotNull(finalAtlas.edge(461101743000002L));
+        Assert.assertNotNull(finalAtlas.edge(-461101743000002L));
     }
 
     @Test
@@ -143,12 +141,12 @@ public class WaySectionProcessorTest
         Assert.assertEquals(4, finalAtlas.node(4560902693000000L).connectedEdges().size());
 
         // Explicit check for expected identifiers
-        Assert.assertTrue(finalAtlas.edge(460419987000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(460419987000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(460419987000003L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
+        Assert.assertNotNull(finalAtlas.edge(460419987000001L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000001L));
+        Assert.assertNotNull(finalAtlas.edge(460419987000002L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000002L));
+        Assert.assertNotNull(finalAtlas.edge(460419987000003L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000003L));
     }
 
     @Test
@@ -169,14 +167,14 @@ public class WaySectionProcessorTest
         Assert.assertEquals(6, finalAtlas.node(4560902689000000L).connectedEdges().size());
 
         // Explicit check for expected identifiers
-        Assert.assertTrue(finalAtlas.edge(460419987000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000001L) != null);
-        Assert.assertTrue(finalAtlas.edge(460419987000002L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
-        Assert.assertTrue(finalAtlas.edge(460419987000003L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000003L) != null);
-        Assert.assertTrue(finalAtlas.edge(460419987000004L) != null);
-        Assert.assertTrue(finalAtlas.edge(-460419987000004L) != null);
+        Assert.assertNotNull(finalAtlas.edge(460419987000001L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000001L));
+        Assert.assertNotNull(finalAtlas.edge(460419987000002L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000003L));
+        Assert.assertNotNull(finalAtlas.edge(460419987000003L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000003L));
+        Assert.assertNotNull(finalAtlas.edge(460419987000004L));
+        Assert.assertNotNull(finalAtlas.edge(-460419987000004L));
     }
 
     @Test
@@ -190,8 +188,8 @@ public class WaySectionProcessorTest
         Assert.assertEquals("Four edges, each having a reverse counterpart", 4,
                 finalAtlas.numberOfEdges());
         Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
-        Assert.assertTrue("This way got sectioned 4 times, with reverse edges", Iterables
-                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)) == 4);
+        Assert.assertEquals("This way got sectioned 4 times, with reverse edges", 4,
+                Iterables.size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)));
     }
 
     @Test
@@ -206,10 +204,10 @@ public class WaySectionProcessorTest
         Assert.assertEquals("Four edges, each having a reverse counterpart", 8,
                 finalAtlas.numberOfEdges());
         Assert.assertEquals("Four nodes", 4, finalAtlas.numberOfNodes());
-        Assert.assertTrue("This way got sectioned 3 times, with reverse edges", Iterables
-                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540517L)) == 6);
-        Assert.assertTrue("This edge got sectioned once, with reverse edges", Iterables
-                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540519L)) == 2);
+        Assert.assertEquals("This way got sectioned 3 times, with reverse edges", 6,
+                Iterables.size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540517L)));
+        Assert.assertEquals("This edge got sectioned once, with reverse edges", 2,
+                Iterables.size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 310540519L)));
     }
 
     @Test
@@ -224,8 +222,8 @@ public class WaySectionProcessorTest
         Assert.assertEquals("Four edges, each having a reverse counterpart", 4,
                 finalAtlas.numberOfEdges());
         Assert.assertEquals("Two nodes", 2, finalAtlas.numberOfNodes());
-        Assert.assertTrue("This way got sectioned once, with a reverse edge", Iterables
-                .size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)) == 2);
+        Assert.assertEquals("This way got sectioned once, with a reverse edge", 2,
+                Iterables.size(finalAtlas.edges(edge -> edge.getOsmIdentifier() == 488453376L)));
     }
 
     @Test
@@ -412,9 +410,7 @@ public class WaySectionProcessorTest
         final Atlas slicedRawAtlas = this.setup.getWayExceedingSectioningLimitAtlas();
 
         // Create a dummy country boundary map that contains these ways and call it Afghanistan
-        final Set<String> countries = new HashSet<>();
         final String afghanistan = "AFG";
-        countries.add(afghanistan);
         final Map<String, MultiPolygon> boundaries = new HashMap<>();
         final Polygon fakePolygon = new Polygon(Location.forString("34.15102284294,66.22764518738"),
                 Location.forString("34.1515910819,66.53388908386"),

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -41,6 +41,9 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "lineWithBarrier.atlas.txt")
     private Atlas lineWithBarrier;
 
+    @TestAtlas(loadFromTextResource = "lineWithInvalidOverlappingGeometry.atlas.txt")
+    private Atlas lineWithInvalidOverlappingGeometry;
+
     @TestAtlas(loadFromTextResource = "simpleBiDirectionalLine.atlas.txt")
     private Atlas simpleBiDirectionalLine;
 
@@ -82,6 +85,11 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     public Atlas getLineWithBarrierAtlas()
     {
         return this.lineWithBarrier;
+    }
+
+    public Atlas getLineWithInvalidOverlappingGeometry()
+    {
+        return this.lineWithInvalidOverlappingGeometry;
     }
 
     public Atlas getLineWithLoopAtEndAtlas()

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithInvalidOverlappingGeometry.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithInvalidOverlappingGeometry.atlas.txt
@@ -1,0 +1,23 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+858888719000000 && 14.9039776,49.992244:14.9046362,49.9925557:14.9051264,49.9927792:14.9054263,49.9929567:14.9058701,49.9930323 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || highway -> living_street || last_edit_version -> 1
+858888726000000 && 14.9056073,49.9933986:14.9053719,49.9933775:14.9054263,49.9929567:14.9053719,49.9933775:14.9056073,49.9933986:14.9053719,49.9933775:14.9056073,49.9933986 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || surface -> ground || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || highway -> living_street || last_edit_version -> 1
+# Points
+8006501246000000 && 14.9039776,49.992244 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+5540849673000000 && 14.9040683,49.9924772 && last_edit_user_name -> حبيشان || last_edit_changeset -> 73438683 || last_edit_time -> 1566060322000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || amenity -> place_of_worship || name -> مسجد الفتح || last_edit_version -> 2 || building -> mosque || religion -> muslim
+8006501224000000 && 14.9042206,49.9927927 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+1301207571000000 && 14.9044997,49.9928754 && last_edit_user_name -> حبيشان || last_edit_changeset -> 87219479 || last_edit_time -> 1593267072000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 2
+8006501226000000 && 14.9046362,49.9925557 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+1301206445000000 && 14.9047924,49.9921897 && last_edit_user_name -> حبيشان || last_edit_changeset -> 87219479 || last_edit_time -> 1593267072000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 3
+8006501234000000 && 14.9049684,49.9931234 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+8006501238000000 && 14.9051264,49.9927792 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+8006501218000000 && 14.9053719,49.9933775 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+8006501219000000 && 14.9054263,49.9929567 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || synthetic_duplicate_osm_node -> YES || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+1301203138000000 && 14.905509,49.9925236 && last_edit_user_name -> brogo || last_edit_changeset -> 23380038 || last_edit_time -> 1404154677000 || last_edit_user_id -> 63107 || iso_country_code -> YEM || last_edit_version -> 2
+8006501230000000 && 14.9056073,49.9933986 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+1301204598000000 && 14.9056374,49.9922284 && last_edit_user_name -> Nautic || last_edit_changeset -> 8257313 || last_edit_time -> 1306443298000 || last_edit_user_id -> 449569 || iso_country_code -> YEM || last_edit_version -> 1
+7575126277000000 && 14.9056697,49.9921604 && last_edit_user_name -> حبيشان || last_edit_changeset -> 86008411 || last_edit_time -> 1590955714000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+8006501235000000 && 14.9058701,49.9930323 && last_edit_user_name -> حبيشان || last_edit_changeset -> 92471276 || last_edit_time -> 1602676511000 || last_edit_user_id -> 1147414 || iso_country_code -> YEM || last_edit_version -> 1
+# Relations


### PR DESCRIPTION
### Description:

This is to catch way-sectioning errors that might come from corrupted data, before a whole way-sectioning process has to fail. The Lines that cannot be way-sectioned are logged and then dropped.

### Potential Impact:

More way-sectioning jobs can go through without failing. However that increases the risk of dropping large amounts of data in case a future underlying bug is introduced and the way-sectioning process does not fail.

### Unit Test Approach:

Added new test, with specific OSM data.

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
