### PR TITLE
Removed ZipFile workaround code in command unit tests

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AnyToGeoJsonCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AnyToGeoJsonCommandTest.java
@@ -35,7 +35,7 @@ public class AnyToGeoJsonCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("--atlas=/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("--atlas=/Users/foo/test.atlas", "--verbose",
                     "--output=/Users/foo");
 
             Assert.assertTrue(outContent.toString().isEmpty());
@@ -150,9 +150,9 @@ public class AnyToGeoJsonCommandTest
         builder.addPoint(1000000L, Location.forWkt("POINT(1 1)"), Maps.hashMap("foo", "bar"));
 
         final Atlas atlas = builder.get();
-        final File atlasFile = new File("/Users/foo/test.atlas.txt", filesystem);
+        final File atlasFile = new File("/Users/foo/test.atlas", filesystem);
         assert atlas != null;
-        atlas.saveAsText(atlasFile);
+        atlas.save(atlasFile);
 
         final File boundaryFile = new File(filesystem.getPath("/Users/foo", "boundary.txt"));
         boundaryFile.writeAndClose(AnyToGeoJsonCommandTest.class

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
@@ -39,25 +39,25 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--bounding-polygon=POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "location: POINT (1 1), \n"
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    + "Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 2000000, \n" + "location: POINT (2 2), \n"
                     + "tags: {baz=bat}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((2 2, 2 2, 2 2, 2 2, 2 2)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    + "Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 3000000, \n" + "location: POINT (3 3), \n"
                     + "tags: {baz=bat, foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((3 3, 3 3, 3 3, 3 3, 3 3)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -80,17 +80,17 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
-                    "--geometry=POINT (1 1)", "--collect-matching", "--output=/Users/foo");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--geometry=POINT (1 1)",
+                    "--collect-matching", "--output=/Users/foo");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "location: POINT (1 1), \n"
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n"
                             + "find: saved to /Users/foo/collected-multi.atlas\n",
                     errContent.toString());
             Assert.assertTrue(new File("/Users/foo/collected-multi.atlas", filesystem).exists());
@@ -114,7 +114,7 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--type=ASD");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--type=ASD");
 
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
@@ -142,17 +142,16 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
-                    "--geometry=POINT (1 1)");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--geometry=POINT (1 1)");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "location: POINT (1 1), \n"
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
@@ -162,19 +161,19 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent2));
             command.setNewErrStream(new PrintStream(errContent2));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--geometry=LINESTRING (10 10, 11 11, 12 12)");
 
             Assert.assertEquals(
-                    "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
                             + "CompleteLine [\n" + "identifier: 4000000, \n"
                             + "polyLine: LINESTRING (10 10, 11 11, 12 12), \n"
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent2.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent2.toString());
 
             final ByteArrayOutputStream outContent3 = new ByteArrayOutputStream();
@@ -184,19 +183,19 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent3));
             command.setNewErrStream(new PrintStream(errContent3));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--geometry=POLYGON ((20 20, 21 20, 21 21, 20 20))");
 
             Assert.assertEquals(
-                    "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
                             + "CompleteArea [\n" + "identifier: 7000000, \n"
                             + "polygon: POLYGON ((20 20, 21 20, 21 21, 20 20)), \n"
                             + "tags: {baz=bat}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((20 20, 20 21, 21 21, 21 20, 20 20)), \n" + "]\n\n",
                     outContent3.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent3.toString());
         }
         catch (final IOException exception)
@@ -218,16 +217,16 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--id=1000000");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--id=1000000");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "location: POINT (1 1), \n"
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -249,17 +248,17 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--out-edge=11000001");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--out-edge=11000001");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompleteNode [\n" + "identifier: 9000000, \n" + "location: POINT (32 32), \n"
                     + "inEdges: [11000000], \n" + "outEdges: [11000001], \n" + "tags: {baz=bat}, \n"
                     + "parentRelations: [], \n"
                     + "bounds: POLYGON ((32 32, 32 32, 32 32, 32 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
@@ -269,17 +268,17 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent2));
             command.setNewErrStream(new PrintStream(errContent2));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--in-edge=11000000");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--in-edge=11000000");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompleteNode [\n" + "identifier: 9000000, \n" + "location: POINT (32 32), \n"
                     + "inEdges: [11000000], \n" + "outEdges: [11000001], \n" + "tags: {baz=bat}, \n"
                     + "parentRelations: [], \n"
                     + "bounds: POLYGON ((32 32, 32 32, 32 32, 32 32, 32 32)), \n" + "]\n\n",
                     outContent2.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent2.toString());
         }
         catch (final IOException exception)
@@ -301,24 +300,25 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--osmid=11");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--osmid=11");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000000, \n"
-                    + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n" + "startNode: 8000000, \n"
-                    + "endNode: 9000000, \n" + "tags: {foo=bar}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000001, \n"
-                    + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n" + "startNode: 9000000, \n"
-                    + "endNode: 10000000, \n" + "tags: {baz=bat}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
+            Assert.assertEquals(
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000000, \n"
+                            + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n"
+                            + "startNode: 8000000, \n" + "endNode: 9000000, \n"
+                            + "tags: {foo=bar}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n"
+                            + "\n" + "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000001, \n"
+                            + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n"
+                            + "startNode: 9000000, \n" + "endNode: 10000000, \n"
+                            + "tags: {baz=bat}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -340,25 +340,26 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--parent-relations=12000000");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000000, \n"
-                    + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n" + "startNode: 8000000, \n"
-                    + "endNode: 9000000, \n" + "tags: {foo=bar}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000001, \n"
-                    + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n" + "startNode: 9000000, \n"
-                    + "endNode: 10000000, \n" + "tags: {baz=bat}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
+            Assert.assertEquals(
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000000, \n"
+                            + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n"
+                            + "startNode: 8000000, \n" + "endNode: 9000000, \n"
+                            + "tags: {foo=bar}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n"
+                            + "\n" + "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000001, \n"
+                            + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n"
+                            + "startNode: 9000000, \n" + "endNode: 10000000, \n"
+                            + "tags: {baz=bat}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -380,26 +381,27 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--predicate=!e.relations().isEmpty() && e.relations().collect { it.getIdentifier() }.containsAll(Sets.hashSet(12000000L))",
                     "--imports=org.openstreetmap.atlas.utilities.command.parsing");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000000, \n"
-                    + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n" + "startNode: 8000000, \n"
-                    + "endNode: 9000000, \n" + "tags: {foo=bar}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
-                    + "CompleteEdge [\n" + "identifier: 11000001, \n"
-                    + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n" + "startNode: 9000000, \n"
-                    + "endNode: 10000000, \n" + "tags: {baz=bat}, \n"
-                    + "parentRelations: [12000000], \n"
-                    + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
+            Assert.assertEquals(
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000000, \n"
+                            + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n"
+                            + "startNode: 8000000, \n" + "endNode: 9000000, \n"
+                            + "tags: {foo=bar}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n"
+                            + "\n" + "Found entity matching criteria in /Users/foo/test.atlas:\n"
+                            + "CompleteEdge [\n" + "identifier: 11000001, \n"
+                            + "polyLine: LINESTRING (32 32, 32 33, 34 34), \n"
+                            + "startNode: 9000000, \n" + "endNode: 10000000, \n"
+                            + "tags: {baz=bat}, \n" + "parentRelations: [12000000], \n"
+                            + "bounds: POLYGON ((32 32, 32 34, 34 34, 34 32, 32 32)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -421,11 +423,11 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--start-node=8000000",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--start-node=8000000",
                     "--end-node=9000000");
 
             Assert.assertEquals(
-                    "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
                             + "CompleteEdge [\n" + "identifier: 11000000, \n"
                             + "polyLine: LINESTRING (30 30, 31 30, 32 32), \n"
                             + "startNode: 8000000, \n" + "endNode: 9000000, \n"
@@ -433,8 +435,8 @@ public class AtlasSearchCommandTest
                             + "bounds: POLYGON ((30 30, 30 32, 32 32, 32 30, 30 30)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -457,17 +459,17 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--sub-geometry=POINT (1 1)");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "location: POINT (1 1), \n"
                     + "tags: {foo=bar}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
 
             final ByteArrayOutputStream outContent2 = new ByteArrayOutputStream();
@@ -477,19 +479,19 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent2));
             command.setNewErrStream(new PrintStream(errContent2));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--sub-geometry=POINT (10 10)");
 
             Assert.assertEquals(
-                    "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
                             + "CompleteLine [\n" + "identifier: 4000000, \n"
                             + "polyLine: LINESTRING (10 10, 11 11, 12 12), \n"
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent2.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent2.toString());
 
             final ByteArrayOutputStream outContent3 = new ByteArrayOutputStream();
@@ -499,19 +501,19 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent3));
             command.setNewErrStream(new PrintStream(errContent3));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--sub-geometry=LINESTRING (10 10, 11 11)");
 
             Assert.assertEquals(
-                    "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    "Found entity matching criteria in /Users/foo/test.atlas:\n"
                             + "CompleteLine [\n" + "identifier: 4000000, \n"
                             + "polyLine: LINESTRING (10 10, 11 11, 12 12), \n"
                             + "tags: {this_is=a_line}, \n" + "parentRelations: [], \n"
                             + "bounds: POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)), \n" + "]\n\n",
                     outContent3.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent3.toString());
         }
         catch (final IOException exception)
@@ -533,23 +535,23 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--taggable-filter=another->*");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompleteNode [\n" + "identifier: 10000000, \n"
                     + "location: POINT (34 34), \n" + "inEdges: [11000001], \n" + "outEdges: [], \n"
                     + "tags: {another=tag2}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((34 34, 34 34, 34 34, 34 34, 34 34)), \n" + "]\n" + "\n"
-                    + "Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+                    + "Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompleteLine [\n" + "identifier: 6000000, \n"
                     + "polyLine: LINESTRING (16 16, 17 17, 18 18), \n"
                     + "tags: {another=tag1, hello=world}, \n" + "parentRelations: [], \n"
                     + "bounds: POLYGON ((16 16, 16 18, 18 18, 18 16, 16 16)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -571,9 +573,9 @@ public class AtlasSearchCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--type=RELATION");
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--type=RELATION");
 
-            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas.txt:\n"
+            Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompleteRelation [\n" + "identifier: 12000000, \n"
                     + "bounds: POLYGON ((30 30, 30 34, 34 34, 34 30, 30 30)), \n"
                     + "members: RelationBean [[[EDGE, 11000000, role0], [EDGE, 11000001, role1]]], \n"
@@ -581,8 +583,8 @@ public class AtlasSearchCommandTest
                     + "bounds: POLYGON ((30 30, 30 34, 34 34, 34 30, 30 30)), \n" + "]\n\n",
                     outContent.toString());
             Assert.assertEquals(
-                    "find: loading /Users/foo/test.atlas.txt\n"
-                            + "find: processing atlas /Users/foo/test.atlas.txt (1/1)\n",
+                    "find: loading /Users/foo/test.atlas\n"
+                            + "find: processing atlas /Users/foo/test.atlas (1/1)\n",
                     errContent.toString());
         }
         catch (final IOException exception)
@@ -626,8 +628,8 @@ public class AtlasSearchCommandTest
         builder.addRelation(12000000L, 12L, bean, Maps.hashMap("route", "bike"));
 
         final Atlas atlas = builder.get();
-        final File atlasFile = new File("/Users/foo/test.atlas.txt", filesystem);
+        final File atlasFile = new File("/Users/foo/test.atlas", filesystem);
         assert atlas != null;
-        atlas.saveAsText(atlasFile);
+        atlas.save(atlasFile);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasShardingConverterCommandTest.java
@@ -78,16 +78,8 @@ public class AtlasShardingConverterCommandTest
             final File franceAtlas1 = output.child("FRA_gbsf.atlas");
             final File franceAtlas2 = output.child("FRA_gbsg.atlas");
             Assert.assertEquals(2, output.listFilesRecursively().size());
-            Assert.assertEquals(5,
-                    new AtlasResourceLoader()
-                            .load(new InputStreamResource(franceAtlas1::read)
-                                    .withName(franceAtlas1.getAbsolutePathString()))
-                            .numberOfEdges());
-            Assert.assertEquals(8,
-                    new AtlasResourceLoader()
-                            .load(new InputStreamResource(franceAtlas2::read)
-                                    .withName(franceAtlas2.getAbsolutePathString()))
-                            .numberOfEdges());
+            Assert.assertEquals(5, new AtlasResourceLoader().load(franceAtlas1).numberOfEdges());
+            Assert.assertEquals(8, new AtlasResourceLoader().load(franceAtlas2).numberOfEdges());
         }
         catch (final IOException exception)
         {
@@ -120,9 +112,7 @@ public class AtlasShardingConverterCommandTest
         command.runSubcommand(args);
 
         final File outputAtlasFile = new File("/Users/foo/FRA_shardingConverter.atlas", filesystem);
-        final Atlas outputAtlas = new AtlasResourceLoader()
-                .load(new InputStreamResource(outputAtlasFile::read)
-                        .withName(outputAtlasFile.getAbsolutePathString()));
+        final Atlas outputAtlas = new AtlasResourceLoader().load(outputAtlasFile);
         final File input = new File("/Users/foo/input", filesystem);
         input.mkdirs();
         final SlippyTile tile1 = SlippyTile.forName("11-998-708");

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/ConcatenateAtlasCommandTest.java
@@ -13,7 +13,6 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.streaming.resource.File;
-import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 
 import com.google.common.jimfs.Configuration;
@@ -37,21 +36,19 @@ public class ConcatenateAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "/Users/foo/test2.atlas.txt",
-                    "--verbose", "--output=/Users/foo");
+            command.runSubcommand("/Users/foo/test.atlas", "/Users/foo/test2.atlas", "--verbose",
+                    "--output=/Users/foo");
 
             Assert.assertTrue(outContent.toString().isEmpty());
             Assert.assertEquals(
-                    "fatlas: loading /Users/foo/test.atlas.txt\n"
-                            + "fatlas: loading /Users/foo/test2.atlas.txt\n"
-                            + "fatlas: processing atlas /Users/foo/test.atlas.txt (1/2)\n"
-                            + "fatlas: processing atlas /Users/foo/test2.atlas.txt (2/2)\n"
+                    "fatlas: loading /Users/foo/test.atlas\n"
+                            + "fatlas: loading /Users/foo/test2.atlas\n"
+                            + "fatlas: processing atlas /Users/foo/test.atlas (1/2)\n"
+                            + "fatlas: processing atlas /Users/foo/test2.atlas (2/2)\n"
                             + "fatlas: cloning...\n" + "fatlas: saved to /Users/foo/output.atlas\n",
                     errContent.toString());
             final File outputAtlasFile = new File("/Users/foo/output.atlas", filesystem);
-            final Atlas outputAtlas = new AtlasResourceLoader()
-                    .load(new InputStreamResource(outputAtlasFile::read)
-                            .withName(outputAtlasFile.getAbsolutePathString()));
+            final Atlas outputAtlas = new AtlasResourceLoader().load(outputAtlasFile);
             Assert.assertEquals(2, outputAtlas.numberOfPoints());
         }
         catch (final IOException exception)
@@ -65,15 +62,15 @@ public class ConcatenateAtlasCommandTest
         final PackedAtlasBuilder builder = new PackedAtlasBuilder();
         builder.addPoint(1000000L, Location.forWkt("POINT(1 1)"), Maps.hashMap("foo", "bar"));
         final Atlas atlas = builder.get();
-        final File atlasFile = new File("/Users/foo/test.atlas.txt", filesystem);
+        final File atlasFile = new File("/Users/foo/test.atlas", filesystem);
         assert atlas != null;
-        atlas.saveAsText(atlasFile);
+        atlas.save(atlasFile);
 
         final PackedAtlasBuilder builder2 = new PackedAtlasBuilder();
         builder2.addPoint(2000000L, Location.forWkt("POINT(2 2)"), Maps.hashMap("baz", "bat"));
         final Atlas atlas2 = builder2.get();
-        final File atlasFile2 = new File("/Users/foo/test2.atlas.txt", filesystem);
+        final File atlasFile2 = new File("/Users/foo/test2.atlas", filesystem);
         assert atlas2 != null;
-        atlas2.saveAsText(atlasFile2);
+        atlas2.save(atlasFile2);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/PackedToTextAtlasCommandTest.java
@@ -109,17 +109,17 @@ public class PackedToTextAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/text.atlas.txt", "--verbose", "--output=/Users/foo",
+            command.runSubcommand("/Users/foo/binary.atlas", "--verbose", "--output=/Users/foo",
                     "--ldgeojson");
 
             Assert.assertTrue(outContent.toString().isEmpty());
             Assert.assertEquals(
-                    "packed2text: loading /Users/foo/text.atlas.txt\n"
-                            + "packed2text: processing atlas /Users/foo/text.atlas.txt (1/1)\n"
-                            + "packed2text: converting /Users/foo/text.atlas.txt...\n"
-                            + "packed2text: saved to /Users/foo/text.geojson\n",
+                    "packed2text: loading /Users/foo/binary.atlas\n"
+                            + "packed2text: processing atlas /Users/foo/binary.atlas (1/1)\n"
+                            + "packed2text: converting /Users/foo/binary.atlas...\n"
+                            + "packed2text: saved to /Users/foo/binary.geojson\n",
                     errContent.toString());
-            final File outputFile = new File("/Users/foo/text.geojson", filesystem);
+            final File outputFile = new File("/Users/foo/binary.geojson", filesystem);
             Assert.assertEquals(
                     "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[1.0,1.0]},"
                             + "\"properties\":{\"foo\":\"bar\",\"identifier\":1000000,\"osmIdentifier\":1,\"itemType\":\"POINT\"}}",
@@ -144,16 +144,16 @@ public class PackedToTextAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/text.atlas.txt", "--verbose", "--output=/Users/foo");
+            command.runSubcommand("/Users/foo/binary.atlas", "--verbose", "--output=/Users/foo");
 
             Assert.assertTrue(outContent.toString().isEmpty());
             Assert.assertEquals(
-                    "packed2text: loading /Users/foo/text.atlas.txt\n"
-                            + "packed2text: processing atlas /Users/foo/text.atlas.txt (1/1)\n"
-                            + "packed2text: converting /Users/foo/text.atlas.txt...\n"
-                            + "packed2text: saved to /Users/foo/text.atlas.txt\n",
+                    "packed2text: loading /Users/foo/binary.atlas\n"
+                            + "packed2text: processing atlas /Users/foo/binary.atlas (1/1)\n"
+                            + "packed2text: converting /Users/foo/binary.atlas...\n"
+                            + "packed2text: saved to /Users/foo/binary.atlas.txt\n",
                     errContent.toString());
-            final File outputAtlasFile = new File("/Users/foo/text.atlas.txt", filesystem);
+            final File outputAtlasFile = new File("/Users/foo/binary.atlas.txt", filesystem);
             Assert.assertEquals(
                     "# Nodes\n" + "# Edges\n" + "# Areas\n" + "# Lines\n" + "# Points\n"
                             + "1000000 && 1.0,1.0 && foo -> bar\n" + "# Relations",
@@ -171,7 +171,9 @@ public class PackedToTextAtlasCommandTest
         builder.addPoint(1000000L, Location.forWkt("POINT(1 1)"), Maps.hashMap("foo", "bar"));
         final Atlas atlas = builder.get();
         final File atlasTextFile = new File("/Users/foo/text.atlas.txt", filesystem);
+        final File atlasBinaryFile = new File("/Users/foo/binary.atlas", filesystem);
         assert atlas != null;
         atlas.saveAsText(atlasTextFile);
+        atlas.save(atlasBinaryFile);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/RelationToMultiPolygonCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/RelationToMultiPolygonCommandTest.java
@@ -33,7 +33,7 @@ public class RelationToMultiPolygonCommandTest
             command.setNewFileSystem(filesystem);
 
             int returnVal = command.runSubcommand("--id=1", "--wkt",
-                    "/Users/foo/invalidMultiPolygonAtlas.txt");
+                    "/Users/foo/invalidMultiPolygonAtlas.atlas");
             Assert.assertEquals(1, returnVal);
             Assert.assertFalse(new File("/work/1.wkt", filesystem).exists());
             Assert.assertFalse(new File("/work/1.atlas", filesystem).exists());
@@ -41,7 +41,7 @@ public class RelationToMultiPolygonCommandTest
             command = new RelationToMultiPolygonCommand();
             command.setNewFileSystem(filesystem);
             returnVal = command.runSubcommand("--id=1", "--wkt",
-                    "/Users/foo/invalidMultiPolygonAtlas2.txt");
+                    "/Users/foo/invalidMultiPolygonAtlas2.atlas");
             Assert.assertEquals(1, returnVal);
             Assert.assertFalse(new File("/work/1.wkt", filesystem).exists());
             Assert.assertFalse(new File("/work/1.atlas", filesystem).exists());
@@ -63,7 +63,7 @@ public class RelationToMultiPolygonCommandTest
             command.setNewFileSystem(filesystem);
 
             final int returnVal = command.runSubcommand("--id=3", "--wkt",
-                    "/Users/foo/invalidMultiPolygonAtlas.txt");
+                    "/Users/foo/invalidMultiPolygonAtlas.atlas");
             Assert.assertEquals(1, returnVal);
             Assert.assertFalse(new File("/work/1.wkt", filesystem).exists());
             Assert.assertFalse(new File("/work/1.atlas", filesystem).exists());
@@ -84,7 +84,7 @@ public class RelationToMultiPolygonCommandTest
             command.setNewFileSystem(filesystem);
 
             final int returnVal = command.runSubcommand("--id=1",
-                    "/Users/foo/validMultiPolygonAtlas.txt");
+                    "/Users/foo/validMultiPolygonAtlas.atlas");
             Assert.assertEquals(0, returnVal);
             Assert.assertTrue(new File("/work/1.wkt", filesystem).exists());
             Assert.assertTrue(MultiPolygon.wkt(
@@ -108,7 +108,7 @@ public class RelationToMultiPolygonCommandTest
             command.setNewFileSystem(filesystem);
 
             final int returnVal = command.runSubcommand("--id=1", "--wkt",
-                    "/Users/foo/validMultiPolygonAtlas.txt");
+                    "/Users/foo/validMultiPolygonAtlas.atlas");
             Assert.assertEquals(0, returnVal);
             Assert.assertTrue(new File("/work/1.wkt", filesystem).exists());
             Assert.assertTrue(MultiPolygon.wkt(
@@ -126,18 +126,18 @@ public class RelationToMultiPolygonCommandTest
     {
         final Atlas validMultiPolygonAtlas = this.setup.getSimpleMultiPolygonAtlas();
         final File validMultiPolygonAtlasFile = new File(
-                filesystem.getPath("/Users/foo", "validMultiPolygonAtlas.txt"));
-        validMultiPolygonAtlas.saveAsText(validMultiPolygonAtlasFile);
+                filesystem.getPath("/Users/foo", "validMultiPolygonAtlas.atlas"));
+        validMultiPolygonAtlas.save(validMultiPolygonAtlasFile);
 
         final Atlas invalidMultiPolygonAtlas = this.setup.getOpenMultiPolygonInOneCountryAtlas();
         final File invalidMultiPolygonAtlasFile = new File(
-                filesystem.getPath("/Users/foo", "invalidMultiPolygonAtlas.txt"));
-        invalidMultiPolygonAtlas.saveAsText(invalidMultiPolygonAtlasFile);
+                filesystem.getPath("/Users/foo", "invalidMultiPolygonAtlas.atlas"));
+        invalidMultiPolygonAtlas.save(invalidMultiPolygonAtlasFile);
 
         final Atlas invalidMultiPolygonAtlas2 = this.setup
                 .getSelfIntersectingOuterMemberRelationAtlas();
         final File invalidMultiPolygonAtlasFile2 = new File(
-                filesystem.getPath("/Users/foo", "invalidMultiPolygonAtlas2.txt"));
-        invalidMultiPolygonAtlas2.saveAsText(invalidMultiPolygonAtlasFile2);
+                filesystem.getPath("/Users/foo", "invalidMultiPolygonAtlas2.atlas"));
+        invalidMultiPolygonAtlas2.save(invalidMultiPolygonAtlasFile2);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/SubAtlasCommandTest.java
@@ -42,15 +42,15 @@ public class SubAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose", "--imports=java.util",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose", "--imports=java.util",
                     "--predicate=!e.relations().isEmpty()",
                     "--polygon=POLYGON((33 33, 35 33, 35 35, 33 35, 33 33))", "--slice-first",
                     "--cut-type=SOFT_CUT", "--output=/Users/foo", "--verbose");
 
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
-                    "subatlas: loading /Users/foo/test.atlas.txt\n"
-                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
+                    "subatlas: loading /Users/foo/test.atlas\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 
@@ -82,14 +82,14 @@ public class SubAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--polygon=POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))", "--output=/Users/foo",
                     "--verbose");
 
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
-                    "subatlas: loading /Users/foo/test.atlas.txt\n"
-                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
+                    "subatlas: loading /Users/foo/test.atlas\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 
@@ -121,13 +121,13 @@ public class SubAtlasCommandTest
             command.setNewOutStream(new PrintStream(outContent));
             command.setNewErrStream(new PrintStream(errContent));
 
-            command.runSubcommand("/Users/foo/test.atlas.txt", "--verbose",
+            command.runSubcommand("/Users/foo/test.atlas", "--verbose",
                     "--predicate=!e.relations().isEmpty()", "--output=/Users/foo", "--verbose");
 
             Assert.assertEquals("", outContent.toString());
             Assert.assertEquals(
-                    "subatlas: loading /Users/foo/test.atlas.txt\n"
-                            + "subatlas: processing atlas /Users/foo/test.atlas.txt (1/1)\n"
+                    "subatlas: loading /Users/foo/test.atlas\n"
+                            + "subatlas: processing atlas /Users/foo/test.atlas (1/1)\n"
                             + "subatlas: saved to /Users/foo/sub_test.atlas\n",
                     errContent.toString());
 
@@ -183,8 +183,8 @@ public class SubAtlasCommandTest
         builder.addRelation(12000000L, 12L, bean, Maps.hashMap("route", "bike"));
 
         final Atlas atlas = builder.get();
-        final File atlasFile = new File("/Users/foo/test.atlas.txt", filesystem);
+        final File atlasFile = new File("/Users/foo/test.atlas", filesystem);
         assert atlas != null;
-        atlas.saveAsText(atlasFile);
+        atlas.save(atlasFile);
     }
 }


### PR DESCRIPTION
### Description:
Many unit tests contained work-around code to deal with the fact that our ZipFile handling previously did not support non-default file systems. Now that #704 fixed that, we can remove this extra code.

### Potential Impact:
No impact. Simpler code.

### Unit Test Approach:
Changes are to unit tests.

### Test Results:
Unit tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
