### PR TITLE
Minor fix for slicing determinism

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -661,11 +661,11 @@ public class RawAtlasSlicer
         {
             final org.locationtech.jts.geom.Polygon geometry = (org.locationtech.jts.geom.Polygon) newMultiPolygon
                     .getGeometryN(polygonIndex);
-            Geometry remainderExterior = geometry.getExteriorRing();
+            Geometry remainderExterior = geometry.getExteriorRing().norm();
             if (newRelation.members() != null)
             {
-                remainderExterior = cutOutExistingMembers(newRelation, geometry.getExteriorRing(),
-                        true);
+                remainderExterior = cutOutExistingMembers(newRelation,
+                        geometry.getExteriorRing().norm(), true);
             }
             else
             {
@@ -727,7 +727,16 @@ public class RawAtlasSlicer
                 }
             }
         }
-        return remainder;
+        final LineMerger merger = new LineMerger();
+        merger.add(remainder);
+        final Geometry[] mergedGeometryCollection = (Geometry[]) merger.getMergedLineStrings()
+                .toArray(new Geometry[merger.getMergedLineStrings().size()]);
+        for (final Geometry geom : mergedGeometryCollection)
+        {
+            geom.normalize();
+        }
+        return new GeometryCollection(mergedGeometryCollection,
+                JtsPrecisionManager.getGeometryFactory());
     }
 
     /**


### PR DESCRIPTION
### Description:

This PR updates the slicing logic to be more deterministic in certain cases. *Extremely* rarely (I couldn't even really find a good unit test for this, since it's so rare!) slicing will return different results based on the ordering of coordinates in a MultiPolygon's shape definition. This fix converts the logic that cuts out existing sliced Atlas entities from using the raw shape to using the normal form, which guarantees a consistent ordering run-over-run. The result is deterministic.

### Potential Impact:

Limited to none, this is just more consistent data. I doubt many cases of nondeterminism were ever encountered in practice.

### Unit Test Approach:

None, but I did find an isolated case of this that happened once. I was able to reproduce it very occasionally when rerunning on infinite loop; after this fix, that same loop never showed this nondeterministic behavior.

### Test Results:

N/A
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
