### PR TITLE
Make distinct polyline list for MultiPolyLine

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/MultiPolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/MultiPolyLine.java
@@ -1,12 +1,10 @@
 package org.openstreetmap.atlas.geography;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
@@ -24,7 +22,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /**
- * A MultiPolyLine is a set of {@link PolyLine}s in a specific order
+ * A MultiPolyLine is a set of distinct {@link PolyLine}s in a specific order
  *
  * @author yalimu
  */
@@ -57,7 +55,7 @@ public class MultiPolyLine
         {
             throw new CoreException("Cannot have an empty list of PolyLine or Polygon.");
         }
-        this.polyLineList = new ArrayList<>(polyLines);
+        this.polyLineList = polyLines.stream().distinct().collect(Collectors.toList());
     }
 
     public MultiPolyLine(final PolyLine... polyLines)
@@ -98,10 +96,7 @@ public class MultiPolyLine
             return false;
         }
         final MultiPolyLine otherItem = (MultiPolyLine) other;
-        final Set<PolyLine> polyLineSet = new HashSet<>(this.polyLineList);
-        final Set<PolyLine> otherPolyLineSet = new HashSet<>(otherItem.getPolyLineList());
-        return otherItem.getPolyLineList().size() == this.getPolyLineList().size()
-                && new HashSet<>(polyLineSet).equals(new HashSet<>(otherPolyLineSet));
+        return new HashSet<>(this.polyLineList).equals(new HashSet<>(otherItem.getPolyLineList()));
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
@@ -29,8 +29,14 @@ public class JtsMultiPolyLineConverter implements TwoWayConverter<MultiPolyLine,
         for (int i = 0; i < multiLineString.getNumGeometries(); i++)
         {
             final LineString lineString = (LineString) multiLineString.getGeometryN(i);
-            polyLineList.add(new PolyLine(COORDINATE_ARRAY_CONVERTER
-                    .backwardConvert(lineString.getCoordinateSequence())));
+            final PolyLine polyLine = new PolyLine(
+                    COORDINATE_ARRAY_CONVERTER.backwardConvert(lineString.getCoordinateSequence()));
+            // No duplicated polyline is allowed to add.
+            if (!polyLineList.contains(polyLine))
+            {
+                polyLineList.add(new PolyLine(COORDINATE_ARRAY_CONVERTER
+                        .backwardConvert(lineString.getCoordinateSequence())));
+            }
         }
         return new MultiPolyLine(polyLineList);
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/jts/JtsMultiPolyLineConverter.java
@@ -34,8 +34,7 @@ public class JtsMultiPolyLineConverter implements TwoWayConverter<MultiPolyLine,
             // No duplicated polyline is allowed to add.
             if (!polyLineList.contains(polyLine))
             {
-                polyLineList.add(new PolyLine(COORDINATE_ARRAY_CONVERTER
-                        .backwardConvert(lineString.getCoordinateSequence())));
+                polyLineList.add(polyLine);
             }
         }
         return new MultiPolyLine(polyLineList);

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.geography;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -137,6 +138,24 @@ public class MultiPolyLineTest
         multiPolyLine.iterator().forEachRemaining(polyLines::add);
         Assert.assertTrue(polyLines.contains(polyLine1));
         Assert.assertTrue(polyLines.contains(polyLine2));
+    }
+
+    @Test
+    public void testDuplicatedPolyLines()
+    {
+        final List<PolyLine> polyLines = new ArrayList<>();
+        final PolyLine polyLine = PolyLine.wkt(
+                "LINESTRING (107.68471354246141 2.2346191319821231, 107.68471354246141 2.2345360028045156)");
+        final PolyLine polyLine2 = PolyLine.wkt(
+                "LINESTRING (107.68454724550249 2.2345601370821555, 107.68453115224835 2.2345601370821555, "
+                        + "107.68449419872607 2.2344243539043736)");
+        polyLines.add(polyLine);
+        polyLines.add(polyLine);
+        polyLines.add(polyLine2);
+        final MultiPolyLine multiPolyLine = new MultiPolyLine(polyLines);
+
+        Assert.assertEquals(3, polyLines.size());
+        Assert.assertEquals(2, multiPolyLine.getPolyLineList().size());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolyLineTest.java
@@ -147,13 +147,20 @@ public class MultiPolyLineTest
         final String wkt3 = "MULTILINESTRING ((107.68471354246141 2.2346191319821231, 107.68471354246141 2.2345360028045156), "
                 + "(107.68454724550249 2.2345601370821555, 107.68453115224835 2.2345601370821555, "
                 + "107.68449419872607 2.2344243539043736))";
+        // wkt4 = wkt3 with duplicated polylines
+        final String wkt4 = "MULTILINESTRING ((107.68471354246141 2.2346191319821231, 107.68471354246141 2.2345360028045156), "
+                + "(107.68454724550249 2.2345601370821555, 107.68453115224835 2.2345601370821555, "
+                + "107.68449419872607 2.2344243539043736), "
+                + "(107.68471354246141 2.2346191319821231, 107.68471354246141 2.2345360028045156))";
         final MultiPolyLine multiPolyLine1 = MultiPolyLine.wkt(wkt1);
         final MultiPolyLine multiPolyLine2 = MultiPolyLine.wkt(wkt1);
         final MultiPolyLine multiPolyLine3 = MultiPolyLine.wkt(wkt3);
+        final MultiPolyLine multiPolyLine4 = MultiPolyLine.wkt(wkt4);
 
         Assert.assertEquals(multiPolyLine1, multiPolyLine2);
         Assert.assertNotSame(multiPolyLine1, multiPolyLine2);
         Assert.assertNotEquals(null, multiPolyLine1);
         Assert.assertNotEquals(multiPolyLine1, multiPolyLine3);
+        Assert.assertEquals(multiPolyLine3, multiPolyLine4);
     }
 }


### PR DESCRIPTION
### Description:

This PR modified the constructor of MultiPolyLine to only add distinct PolyLine to generate a MultiPolyLine. 

### Potential Impact:

This change covers corner cases when there are duplicated polyline in MultiPolyLine and make MultiPolyLine.isEqual cleaner.

### Unit Test Approach:

Added duplicated polyline list case in the test.

### Test Results:

All tests passed. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
