### PR TITLE
Closeable Resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ configurations
 dependencies
 {
     compile packages.slf4j.api
-    compile packages.junit
     compile packages.opencsv
     compile packages.gson
     compile packages.http
@@ -61,6 +60,8 @@ dependencies
     compile packages.jackson.core
     compile packages.jackson.databind
     compile packages.jackson.dataformat
+    // Support JUnit 3/4 tests
+    compile packages.junit.junit4
     compile packages.protobuf_java
     compile packages.protoc
     compile packages.artifact
@@ -78,9 +79,10 @@ dependencies
     shaded project.configurations.getByName('compile')
     shaded packages.slf4j.log4j12
     shaded packages.log4j
+
 }
 
-task shaded(type: Jar){
+task shaded(type: Jar) {
     baseName = project.name
     classifier = 'shaded'
     from

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    junit: '4.12',
+    junit4: '4.13.1',
+    junit5: '5.7.0',
     jacoco: '0.8.3',
     slf4j: '1.7.12',
     log4j: '1.2.17',
@@ -34,7 +35,12 @@ project.ext.versions = [
 ]
 
 project.ext.packages = [
-    junit: "junit:junit:${versions.junit}",
+    junit: [
+        junit4: "junit:junit:${versions.junit4}",
+        vintage: "org.junit.vintage:junit-vintage-engine:${versions.junit5}",
+        api: "org.junit.jupiter:junit-jupiter-api:${versions.junit5}",
+        engine: "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
+    ],
     slf4j: [
         api: "org.slf4j:slf4j-api:${versions.slf4j}",
         simple: "org.slf4j:slf4j-simple:${versions.slf4j}",

--- a/gradle/protobuf.gradle
+++ b/gradle/protobuf.gradle
@@ -10,7 +10,7 @@ sourceSets
 }
 
 protobuf {
-    generatedFilesBaseDir = 'src/generated/'
+    generatedFilesBaseDir = "${projectDir}/src/generated/"
 
     protoc {
         artifact = "${packages.protoc}"

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -24,6 +24,7 @@ sourceSets
 
 test
 {
+    useJUnitPlatform()
     testLogging
     {
         events "failed"
@@ -68,9 +69,15 @@ dependencies
 {
     testCompile packages.slf4j.log4j12
     testCompile packages.log4j
-    testCompile packages.junit
+    // Support Junit 5 tests
+    testImplementation packages.junit.api
+    testRuntimeOnly packages.junit.engine
+    // Support JUnit 3/4 tests
+    testCompile packages.junit.junit4
+    testRuntimeOnly packages.junit.vintage
 
-    integrationTestCompile packages.junit
+    integrationTestCompile packages.junit.junit4
+    testRuntimeOnly packages.junit.vintage
 }
 
 spotless {

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResourceCloseable.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/InputStreamResourceCloseable.java
@@ -1,0 +1,41 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Create an InputStream resource that depends upon other resources that should not be closed until
+ * the caller is done with the InputStream
+ * 
+ * @author Taylor Smock
+ */
+public class InputStreamResourceCloseable extends InputStreamResource implements ResourceCloseable
+{
+    private final AutoCloseable[] dependencies;
+
+    /**
+     * Create a new InputStreamWritableResource
+     * 
+     * @param inputStreamSupplier
+     *            The InputStream to write to
+     * @param dependencies
+     *            The dependencies that should be closed on finish
+     */
+    @SafeVarargs
+    public InputStreamResourceCloseable(final Supplier<InputStream> inputStreamSupplier,
+            final AutoCloseable... dependencies)
+    {
+        super(inputStreamSupplier);
+        this.dependencies = dependencies != null
+                ? Stream.of(dependencies).filter(Objects::nonNull).toArray(AutoCloseable[]::new)
+                : new AutoCloseable[0];
+    }
+
+    @Override
+    public AutoCloseable[] getDependencies()
+    {
+        return this.dependencies;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/OutputStreamWritableResourceCloseable.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/OutputStreamWritableResourceCloseable.java
@@ -1,0 +1,40 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import java.io.OutputStream;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Create an OutputStream resource that depends upon other resources that should not be closed until
+ * the caller is done with the OutputStream
+ * 
+ * @author Taylor Smock
+ */
+public class OutputStreamWritableResourceCloseable extends OutputStreamWritableResource
+        implements WritableResourceCloseable
+{
+    private final AutoCloseable[] dependencies;
+
+    /**
+     * Create a new OutputStreamWritableResource
+     * 
+     * @param out
+     *            The OutputStream to write to
+     * @param dependencies
+     *            The dependencies that should be closed on finish
+     */
+    public OutputStreamWritableResourceCloseable(final OutputStream out,
+            final AutoCloseable... dependencies)
+    {
+        super(out);
+        this.dependencies = dependencies != null
+                ? Stream.of(dependencies).filter(Objects::nonNull).toArray(AutoCloseable[]::new)
+                : new AutoCloseable[0];
+    }
+
+    @Override
+    public AutoCloseable[] getDependencies()
+    {
+        return this.dependencies;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/ResourceCloseable.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/ResourceCloseable.java
@@ -1,0 +1,52 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * Use when the returned resource has some items that cannot be closed prior to finishing with this
+ * resource.
+ *
+ * @author Taylor Smock
+ */
+public interface ResourceCloseable extends Resource, AutoCloseable
+{
+    @Override
+    default void close() throws Exception
+    {
+        final Collection<Exception> exceptions = new ArrayList<>();
+        for (final AutoCloseable closeable : Stream.of(getDependencies()).filter(Objects::nonNull)
+                .collect(Collectors.toList()))
+        {
+            try
+            {
+                closeable.close();
+            }
+            catch (final Exception exception)
+            {
+                exceptions.add(exception);
+            }
+        }
+        if (!exceptions.isEmpty())
+        {
+            throw new CoreException(
+                    "{} exceptions thrown while closing {}, only showing the first thrown exception",
+                    exceptions.size(), this.getName(), exceptions.iterator().next());
+        }
+    }
+
+    /**
+     * Get the {@link AutoCloseable} resources that this resource depends upon.
+     *
+     * @return An array of {@link AutoCloseable} dependencies
+     */
+    default AutoCloseable[] getDependencies()
+    {
+        return new AutoCloseable[0];
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/WritableResourceCloseable.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/WritableResourceCloseable.java
@@ -1,0 +1,11 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+/**
+ * Use for WritableResources that have dependent AutoCloseable resources
+ * 
+ * @author Taylor Smock
+ */
+public interface WritableResourceCloseable extends WritableResource, ResourceCloseable
+{
+
+}

--- a/src/main/java/org/openstreetmap/atlas/streaming/resource/http/HttpResource.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/resource/http/HttpResource.java
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.streaming.StringInputStream;
 import org.openstreetmap.atlas.streaming.resource.AbstractResource;
+import org.openstreetmap.atlas.streaming.resource.ResourceCloseable;
 
 /**
  * Base Http resource object that will handle most of the http request information. Sub classes
@@ -35,7 +36,7 @@ import org.openstreetmap.atlas.streaming.resource.AbstractResource;
  *
  * @author cuthbertm
  */
-public abstract class HttpResource extends AbstractResource
+public abstract class HttpResource extends AbstractResource implements ResourceCloseable
 {
     private HttpRequestBase request;
     private final URI uri;
@@ -67,6 +68,7 @@ public abstract class HttpResource extends AbstractResource
         this.uri = uri;
     }
 
+    @Override
     public void close()
     {
         HttpClientUtils.closeQuietly(this.response);

--- a/src/test/java/org/openstreetmap/atlas/streaming/resource/ByteArrayOutputStreamExceptional.java
+++ b/src/test/java/org/openstreetmap/atlas/streaming/resource/ByteArrayOutputStreamExceptional.java
@@ -1,0 +1,84 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * The whole purpose of this class is to throw when closed (which ByteArrayOutputStream does not).
+ * This should never be used in production, and should be used only in tests.
+ * 
+ * @author Taylor Smock
+ */
+public class ByteArrayOutputStreamExceptional extends ByteArrayOutputStream
+{
+    private boolean isClosed;
+    private boolean throwOnClose;
+
+    @Override
+    public void close() throws IOException
+    {
+        if (this.throwOnClose)
+        {
+            throw new IOException("This stream is closed");
+        }
+        this.isClosed = true;
+    }
+
+    /**
+     * Check if this resource is closed
+     * 
+     * @return {@code true} if this resource has been closed
+     */
+    public boolean isClosed()
+    {
+        return this.isClosed;
+    }
+
+    /**
+     * Use to force this OutputStream to throw an exception on close
+     * 
+     * @param throwOnClose
+     *            {@code true} to force a throw on close.
+     */
+    public void setThrowOnClose(final boolean throwOnClose)
+    {
+        this.throwOnClose = throwOnClose;
+    }
+
+    @Override
+    public byte[] toByteArray() throws UncheckedIOException
+    {
+        this.checkClosed();
+        return super.toByteArray();
+    }
+
+    @Override
+    public void write(final int byteWrite)
+    {
+        this.checkClosed();
+        super.write(byteWrite);
+    }
+
+    @Override
+    public synchronized void write(final byte[] bytes, final int off, final int len)
+    {
+        this.checkClosed();
+        super.write(bytes, off, len);
+    }
+
+    @Override
+    public void writeBytes(final byte[] bytes) throws UncheckedIOException
+    {
+        this.checkClosed();
+        super.writeBytes(bytes);
+    }
+
+    private void checkClosed()
+    {
+        if (this.isClosed)
+        {
+            throw new UncheckedIOException(new IOException("This stream is closed"));
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/streaming/resource/InputStreamResourceCloseableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/streaming/resource/InputStreamResourceCloseableTest.java
@@ -1,0 +1,92 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.jupiter.api.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * Test class for {@link InputStreamResourceCloseable}
+ * 
+ * @author Taylor Smock
+ */
+class InputStreamResourceCloseableTest
+{
+    /** An arbitrary string to use for input/output streams */
+    private static final String HELLO_WORLD = "Hello World";
+
+    /**
+     * Test that the class properly closes a resource
+     * 
+     * @throws Exception
+     *             If an untested exception is thrown
+     */
+    @Test
+    void testClosingResource() throws Exception
+    {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStreamExceptional();
+        outputStream.writeBytes(HELLO_WORLD.getBytes());
+        try (InputStreamResourceCloseable inputStreamResource = new InputStreamResourceCloseable(
+                () -> new ByteArrayInputStream(outputStream.toByteArray()), outputStream))
+        {
+            // Check twice for open/close of ByteArrayInputStream
+            assertEquals(HELLO_WORLD, assertDoesNotThrow(() -> inputStreamResource.firstLine()));
+            assertEquals(HELLO_WORLD, assertDoesNotThrow(() -> inputStreamResource.firstLine()));
+            outputStream.close();
+            final UncheckedIOException uncheckedIOException = assertThrows(
+                    UncheckedIOException.class, () -> inputStreamResource.firstLine());
+            assertTrue(uncheckedIOException.getCause() instanceof IOException);
+        }
+    }
+
+    /**
+     * Test that a thrown exception is passed back
+     * 
+     * @throws Exception
+     *             If an untested exception is thrown
+     */
+    @Test
+    void testExceptionOnClosing() throws Exception
+    {
+        final ByteArrayOutputStreamExceptional outputStream = new ByteArrayOutputStreamExceptional();
+        outputStream.write(HELLO_WORLD.getBytes());
+        final InputStreamResourceCloseable inputStreamResource = new InputStreamResourceCloseable(
+                () -> new ByteArrayInputStream(outputStream.toByteArray()), outputStream);
+        assertDoesNotThrow(() -> outputStream.close());
+        outputStream.setThrowOnClose(true);
+
+        assertThrows(CoreException.class, () -> inputStreamResource.close());
+    }
+
+    /**
+     * Check that this class fails when improperly used
+     * 
+     * @throws Exception
+     *             If an untested exception is thrown
+     */
+    @Test
+    void testTryWithResources() throws Exception
+    {
+        final InputStreamResourceCloseable inputStreamResource;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStreamExceptional())
+        {
+            outputStream.write(HELLO_WORLD.getBytes());
+            inputStreamResource = new InputStreamResourceCloseable(
+                    () -> new ByteArrayInputStream(outputStream.toByteArray()),
+                    (AutoCloseable[]) null);
+            assertEquals(HELLO_WORLD, assertDoesNotThrow(() -> inputStreamResource.firstLine()));
+        }
+        final UncheckedIOException uncheckedIOException = assertThrows(UncheckedIOException.class,
+                () -> inputStreamResource.firstLine());
+        assertTrue(uncheckedIOException.getCause() instanceof IOException);
+        inputStreamResource.close();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/streaming/resource/OutputStreamWritableResourceCloseableTest.java
+++ b/src/test/java/org/openstreetmap/atlas/streaming/resource/OutputStreamWritableResourceCloseableTest.java
@@ -1,0 +1,72 @@
+package org.openstreetmap.atlas.streaming.resource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+
+import org.junit.jupiter.api.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * Test class for {@link OutputStreamWritableResourceCloseable}
+ * 
+ * @author Taylor Smock
+ */
+class OutputStreamWritableResourceCloseableTest
+{
+    private static final String HELLO_WORLD = "Hello World";
+    private static final byte[] HELLO_WORLD_BYTES = HELLO_WORLD.getBytes();
+
+    @Test
+    void testClosingResource() throws Exception
+    {
+        final ByteArrayOutputStreamExceptional outputStream = new ByteArrayOutputStreamExceptional();
+        final OutputStreamWritableResourceCloseable resource = new OutputStreamWritableResourceCloseable(
+                outputStream, (AutoCloseable[]) null);
+        assertDoesNotThrow(() -> resource.write().write(HELLO_WORLD_BYTES));
+        assertEquals(HELLO_WORLD, new String(outputStream.toByteArray()));
+
+        outputStream.close();
+        assertTrue(outputStream.isClosed());
+        final OutputStream writer = resource.write();
+        assertThrows(UncheckedIOException.class, () -> writer.write(HELLO_WORLD_BYTES));
+        resource.close();
+    }
+
+    @Test
+    void testCorrectImplementation() throws Exception
+    {
+        final ByteArrayOutputStreamExceptional outputStream = new ByteArrayOutputStreamExceptional();
+        final OutputStreamWritableResourceCloseable resource = new OutputStreamWritableResourceCloseable(
+                outputStream, outputStream);
+        assertDoesNotThrow(() -> resource.write().write(HELLO_WORLD_BYTES));
+        assertEquals(HELLO_WORLD, new String(outputStream.toByteArray()));
+
+        resource.close();
+        assertTrue(outputStream.isClosed());
+    }
+
+    @Test
+    void testTryWithResources() throws Exception
+    {
+        final ByteArrayOutputStreamExceptional outputStream = new ByteArrayOutputStreamExceptional();
+        final OutputStreamWritableResourceCloseable resource = new OutputStreamWritableResourceCloseable(
+                outputStream, outputStream);
+
+        try (ByteArrayOutputStreamExceptional temp = outputStream)
+        {
+            assertDoesNotThrow(() -> resource.write().write(HELLO_WORLD_BYTES));
+            assertEquals(HELLO_WORLD, new String(outputStream.toByteArray()));
+        }
+
+        final OutputStream writer = resource.write();
+        assertThrows(UncheckedIOException.class, () -> writer.write(HELLO_WORLD_BYTES));
+        outputStream.setThrowOnClose(true);
+        assertThrows(CoreException.class, () -> resource.close());
+    }
+
+}


### PR DESCRIPTION
### Description:

Add Closeable Resources, for use when a Resource depends upon an AutoCloseable resource that must not be closed prior to the user finishing with the resource.

### Potential Impact:

This largely comes down to memory impact. In https://github.com/osmlab/atlas-generator/pull/167, closing resources significantly freed up space and sped up processing. Unfortunately, during testing, a bug where resources were closed prior to reads was missed. This fixes that issue by creating resources that store the closeable resources internally, which can then be closed automatically when finished.

### Unit Test Approach:

The added unit tests use JUnit5 to check assertions (I find that the `assertThrows`/`assertDoesNotThrow` syntax to be much easier to use for checking for assertions).

The addition of JUnit5 support should not affect any existing tests (there is a vintage runner for JUnit4 and JUnit3 tests).

The unit tests check various conditions where the `ResourceCloseable`s are closed (so, `try-with-resources` or manually), and checks for what happens when a required resource is unexpectedly closed).