### PR TITLE
Normalize Polygon geometry for consistency

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/ComplexWaterbody.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/water/ComplexWaterbody.java
@@ -22,7 +22,8 @@ public class ComplexWaterbody extends ComplexWaterEntity
 {
     private static final long serialVersionUID = -666543090371777011L;
 
-    private static final RelationOrAreaToMultiPolygonConverter RELATION_OR_AREA_TO_MULTI_POLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
+    private static final RelationOrAreaToMultiPolygonConverter RELATION_OR_AREA_TO_MULTI_POLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter(
+            true);
 
     private static final Logger logger = LoggerFactory.getLogger(ComplexWaterbody.class);
 

--- a/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/converters/MultiplePolyLineToPolygonsConverter.java
@@ -398,8 +398,11 @@ public class MultiplePolyLineToPolygonsConverter
             // Get results
             final List<org.locationtech.jts.geom.Polygon> result = (List<org.locationtech.jts.geom.Polygon>) polygonizer
                     .getPolygons();
-            return result.stream().map(JTS_POLYGON_CONVERTER::backwardConvert)
-                    .collect(Collectors.toList());
+            return result.stream().map(polygon ->
+            {
+                polygon.normalize();
+                return JTS_POLYGON_CONVERTER.backwardConvert(polygon);
+            }).collect(Collectors.toList());
         }
         else
         {


### PR DESCRIPTION
### Description:

```MultiplePolyLineToPolygonsConverter``` uses JTS ```Polygonizer``` to create Polygons from a list of Polylines. Normalize the result Polygon(s) for consistent geometry.

Based on https://github.com/osmlab/atlas/pull/690 Use Polygonizer when creating geometry for a ```ComplexWaterBody``` to include water bodies with outers intersecting at one point as they are valid

### Unit Test Approach:

All existing unit tests should pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
