### PR TITLE
Minor slicing fix for certain areas

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -1319,7 +1319,9 @@ public class RawAtlasSlicer
             final Set<Long> relationIds = new HashSet<>();
             area.relations().forEach(relation -> relationIds.add(relation.getIdentifier()));
             final CompleteLine lineFromArea = new CompleteLine(area.getIdentifier(),
-                    area.asPolygon(), area.getTags(), relationIds);
+                    JTS_POLYLINE_CONVERTER.backwardConvert(
+                            JTS_POLYGON_CONVERTER.convert(area.asPolygon()).getExteriorRing()),
+                    area.getTags(), relationIds);
             area.relations().forEach(relation -> this.stagedRelations.get(relation.getIdentifier())
                     .withAddedMember(lineFromArea, area));
             removeArea(area);


### PR DESCRIPTION
### Description:

In rare cases, an Area can get sliced into resulting multipolygon geometry; this corner case arises when an Area completely contains a boundary, leaving one or more holes after slicing. Since Areas only support simply polygon geometry, the code path rejects this new sliced geometry and attempt to convert the Area to a linear Line geometry and slice that. However, in this case, using `Area.asPolygon()` in the new CompleteLine accidentally preserves the polygonal geometry. So instead, a fix here casts it to a JTS Polygon, then converts the exterior ring to a PolyLine, which guarantees a linear representation when sliced again.
 
### Potential Impact:

Extremely limited, this is an unusual corner case.

### Unit Test Approach:


### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
