### PR TITLE
Added missing cycle tag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/CyclewayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/CyclewayTag.java
@@ -27,7 +27,8 @@ public enum CyclewayTag
     RIGHT,
     OPPOSITE_SHARE_BUSWAY,
     SEGREGATED,
-    NONE;
+    NONE,
+    SEPARATED;
 
     @TagKey
     public static final String KEY = "cycleway";


### PR DESCRIPTION
### Description:

Missed a cycle tag value from https://github.com/osmlab/atlas/pull/732. This adds the SEPARATE value to `CyclewayTag`.

### Potential Impact:

New tag value.

### Unit Test Approach:

Existing tests

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
