### PR TITLE
Fix for certain tags being dropped during sectioning

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -580,10 +580,12 @@ public class AtlasSectionProcessor
         {
             logger.error("Edge {} hass less than {} nodes, cannot be sectioned!",
                     line.getIdentifier(), MINIMUM_NODES_TO_QUALIFY_AS_A_EDGE);
-            this.changes.add(FeatureChange.add(
-                    CompleteLine.shallowFrom(line).withTags(line.getTags()).withAddedTag(SyntheticInvalidWaySectionTag.KEY,
-                            SyntheticInvalidWaySectionTag.YES.toString()),
-                    this.inputAtlas));
+            this.changes
+                    .add(FeatureChange.add(
+                            CompleteLine.shallowFrom(line).withTags(line.getTags()).withAddedTag(
+                                    SyntheticInvalidWaySectionTag.KEY,
+                                    SyntheticInvalidWaySectionTag.YES.toString()),
+                            this.inputAtlas));
             return;
         }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -580,10 +580,12 @@ public class AtlasSectionProcessor
         {
             logger.error("Edge {} hass less than {} nodes, cannot be sectioned!",
                     line.getIdentifier(), MINIMUM_NODES_TO_QUALIFY_AS_A_EDGE);
-            this.changes.add(FeatureChange.add(
-                    CompleteLine.shallowFrom(line).withAddedTag(SyntheticInvalidWaySectionTag.KEY,
-                            SyntheticInvalidWaySectionTag.YES.toString()),
-                    this.inputAtlas));
+            this.changes
+                    .add(FeatureChange.add(
+                            CompleteLine.shallowFrom(line).withTags(line.getTags()).withAddedTag(
+                                    SyntheticInvalidWaySectionTag.KEY,
+                                    SyntheticInvalidWaySectionTag.YES.toString()),
+                            this.inputAtlas));
             return;
         }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -580,12 +580,10 @@ public class AtlasSectionProcessor
         {
             logger.error("Edge {} hass less than {} nodes, cannot be sectioned!",
                     line.getIdentifier(), MINIMUM_NODES_TO_QUALIFY_AS_A_EDGE);
-            this.changes
-                    .add(FeatureChange.add(
-                            CompleteLine.shallowFrom(line).withTags(line.getTags()).withAddedTag(
-                                    SyntheticInvalidWaySectionTag.KEY,
-                                    SyntheticInvalidWaySectionTag.YES.toString()),
-                            this.inputAtlas));
+            this.changes.add(FeatureChange.add(
+                    CompleteLine.shallowFrom(line).withTags(line.getTags()).withAddedTag(SyntheticInvalidWaySectionTag.KEY,
+                            SyntheticInvalidWaySectionTag.YES.toString()),
+                    this.inputAtlas));
             return;
         }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessorTest.java
@@ -92,6 +92,27 @@ public class AtlasSectionProcessorTest
     }
 
     @Test
+    public void testLineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine()
+    {
+        // Based on a prior version of https://www.openstreetmap.org/way/488453376
+        final Atlas slicedRawAtlas = this.setup
+                .getLineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLineAtlas();
+        final Atlas finalAtlas = new AtlasSectionProcessor(slicedRawAtlas,
+                AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
+
+        Assert.assertNotNull("Line has not been converted to an Edge",
+                finalAtlas.line(488453376000000L));
+        Assert.assertNull("Line has not been converted to an Edge",
+                finalAtlas.edge(488453376000000L));
+        final Map<String, String> originalTags = slicedRawAtlas.line(488453376000000L).getTags();
+        final Map<String, String> finalTags = finalAtlas.line(488453376000000L).getTags();
+        Assert.assertTrue("Line has synthetic invalid way section tag",
+                finalTags.containsKey(SyntheticInvalidWaySectionTag.KEY));
+        finalTags.remove(SyntheticInvalidWaySectionTag.KEY);
+        Assert.assertEquals("Line has no other tag changes", originalTags, finalTags);
+    }
+
+    @Test
     public void testLineWithLoopAtEnd()
     {
         // Based on https://www.openstreetmap.org/way/461101743

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -120,14 +120,14 @@ public class WaySectionProcessorTestRule extends CoreTestRule
         return this.lineWithRepeatedLocation;
     }
 
-    public Atlas getLoopingWayWithIntersectionAtlas()
-    {
-        return this.loopingWayWithIntersection;
-    }
-
     public Atlas getLoopWithRepeatedLocationAtlas()
     {
         return this.loopWithRepeatedLocation;
+    }
+
+    public Atlas getLoopingWayWithIntersectionAtlas()
+    {
+        return this.loopingWayWithIntersection;
     }
 
     public Atlas getMalformedPolyLineAtlas()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/WaySectionProcessorTestRule.java
@@ -56,6 +56,9 @@ public class WaySectionProcessorTestRule extends CoreTestRule
     @TestAtlas(loadFromTextResource = "lineWithRepeatedLocation.atlas.txt")
     private Atlas lineWithRepeatedLocation;
 
+    @TestAtlas(loadFromTextResource = "lineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine.atlas.txt")
+    private Atlas lineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine;
+
     @TestAtlas(loadFromTextResource = "loopWithRepeatedLocation.atlas.txt")
     private Atlas loopWithRepeatedLocation;
 
@@ -92,6 +95,11 @@ public class WaySectionProcessorTestRule extends CoreTestRule
         return this.lineWithInvalidOverlappingGeometry;
     }
 
+    public Atlas getLineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLineAtlas()
+    {
+        return this.lineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine;
+    }
+
     public Atlas getLineWithLoopAtEndAtlas()
     {
         return this.lineWithLoopAtEnd;
@@ -112,14 +120,14 @@ public class WaySectionProcessorTestRule extends CoreTestRule
         return this.lineWithRepeatedLocation;
     }
 
-    public Atlas getLoopWithRepeatedLocationAtlas()
-    {
-        return this.loopWithRepeatedLocation;
-    }
-
     public Atlas getLoopingWayWithIntersectionAtlas()
     {
         return this.loopingWayWithIntersection;
+    }
+
+    public Atlas getLoopWithRepeatedLocationAtlas()
+    {
+        return this.loopWithRepeatedLocation;
     }
 
     public Atlas getMalformedPolyLineAtlas()

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine.atlas.txt
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/raw/sectioning/lineWithLessThanTwoNodesDueToRepeatedLocationAtEndOfLine.atlas.txt
@@ -1,0 +1,15 @@
+# Nodes
+# Edges
+# Areas
+# Lines
+488453376000000 && 22.539148,113.9448557:22.539148,113.9448557:22.5392348,113.9448542:22.539495,113.9448495:22.5395425,113.9448487:22.5395455,113.9451532:22.5395009,113.9451538:22.5392333,113.9451574:22.5391521,113.9451585:22.5391521,113.9451585 && last_edit_user_name -> ulrichm || last_edit_changeset -> 58630764 || last_edit_time -> 1525301434000 || last_edit_user_id -> 3331814 || iso_country_code -> CHN || footway -> crossing || highway -> footway || last_edit_version -> 4 || crossing -> zebra
+# Points
+5178935335000000 && 22.539148,113.9448557 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || synthetic_duplicate_osm_node -> YES || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935343000000 && 22.5392348,113.9448542 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503663000000 && 22.539495,113.9448495 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 2
+5178935349000000 && 22.5395425,113.9448487 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+5178935333000000 && 22.5395455,113.9451532 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4808413267000000 && 22.5395009,113.9451538 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533154000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+5178935332000000 && 22.5392333,113.9451574 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533148000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 1
+4807503687000000 && 22.5391521,113.9451585 && last_edit_user_name -> Triomphe346 || last_edit_changeset -> 53112141 || last_edit_time -> 1508533153000 || last_edit_user_id -> 4892967 || iso_country_code -> CHN || last_edit_version -> 3
+# Relations


### PR DESCRIPTION
### Description:

In the rare case of invalid geometry during sectioning, a misunderstanding of the FeatureChange `.withAddedTag()` API led to `synthetic_invalid_way_section` tag being added but all other tags being dropped. This issue has been fixed by properly instantiating the CompleteLine object it intends to add the tag to with the full TagMap before invoking `.withAddedTag()`. 

### Potential Impact:

Limited other than not dropping tags for this object.

### Unit Test Approach:
One added to capture the expected results

### Test Results:
The original tags are no longer dropped

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
