### PR TITLE
Allow expand indefinitely for relation exploration

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasExpander.java
@@ -386,9 +386,8 @@ class DynamicAtlasExpander
     private void browseForPotentialNewShardsFromAggressiveRelations()
     {
         // In case we want to aggressively explore relations, we constrain it to only when the
-        // policy is to not extend indefinitely, and to defer loading.
-        if (this.policy.isAggressivelyExploreRelations() && !this.policy.isExtendIndefinitely()
-                && this.policy.isDeferLoading())
+        // policy is to defer loading.
+        if (this.policy.isAggressivelyExploreRelations() && this.policy.isDeferLoading())
         {
             // Get all the neighboring shards
             final Set<Shard> onlyNeighboringShards = new HashSet<>();

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAggressiveRelationsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasAggressiveRelationsTest.java
@@ -12,7 +12,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy;
+import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasAggressiveRelationsTestRule;
 import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasTestRule;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
@@ -20,10 +22,13 @@ import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
 /**
  * @author matthieun
  */
-public class DynamicAtlasAgressiveRelationsTest
+public class DynamicAtlasAggressiveRelationsTest
 {
     @Rule
     public DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
+
+    @Rule
+    public DynamicAtlasAggressiveRelationsTestRule rule2 = new DynamicAtlasAggressiveRelationsTestRule();
 
     private Map<Shard, Atlas> store;
     private final Supplier<DynamicAtlasPolicy> policySupplier = () -> new DynamicAtlasPolicy(
@@ -39,6 +44,19 @@ public class DynamicAtlasAgressiveRelationsTest
                 }
             }, new SlippyTileSharding(12), new SlippyTile(1350, 1870, 12), Rectangle.MAXIMUM);
 
+    private final Supplier<DynamicAtlasPolicy> policySupplier2 = () -> new DynamicAtlasPolicy(
+            shard ->
+            {
+                if (this.store.containsKey(shard))
+                {
+                    return Optional.of(this.store.get(shard));
+                }
+                else
+                {
+                    return Optional.empty();
+                }
+            }, new SlippyTileSharding(11), new SlippyTile(998, 708, 11), Rectangle.MAXIMUM);
+
     @Before
     public void prepare()
     {
@@ -47,6 +65,8 @@ public class DynamicAtlasAgressiveRelationsTest
         this.store.put(new SlippyTile(1350, 1869, 12), this.rule.getAtlasz12x1350y1869());
         this.store.put(new SlippyTile(1349, 1869, 12), this.rule.getAtlasz12x1349y1869());
         this.store.put(new SlippyTile(1349, 1870, 12), this.rule.getAtlasz12x1349y1870());
+        this.store.put(new SlippyTile(998, 708, 11), this.rule2.getAtlasZ11X998Y708());
+        this.store.put(new SlippyTile(999, 708, 11), this.rule2.getAtlasZ11X999Y708());
     }
 
     @Test
@@ -62,5 +82,20 @@ public class DynamicAtlasAgressiveRelationsTest
         Assert.assertNotNull(dynamicAtlas.relation(2));
         Assert.assertNotNull(dynamicAtlas.relation(3));
         Assert.assertEquals(9, dynamicAtlas.numberOfEdges());
+    }
+
+    @Test
+    public void testRelationsAggressivelyWithExpantionIndefinite()
+    {
+        final DynamicAtlas dynamicAtlas = new DynamicAtlas(this.policySupplier2.get()
+                .withAggressivelyExploreRelations(true).withExtendIndefinitely(true)
+                .withDeferredLoading(true)
+                .withAtlasEntitiesToConsiderForExpansion(entity -> entity instanceof Relation));
+
+        // Prompts load of 11-999-708
+        dynamicAtlas.preemptiveLoad();
+        final Relation relation = dynamicAtlas.relation(99756000000L);
+        Assert.assertNotNull(relation);
+        Assert.assertEquals(2, relation.members().size());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAggressiveRelationsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAggressiveRelationsTestRule.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.geography.atlas.dynamic.rules;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * @author matthieun
+ */
+public class DynamicAtlasAggressiveRelationsTestRule extends CoreTestRule
+{
+    @TestAtlas(loadFromJosmOsmResource = "DynamicAtlasAgressiveRelationsTest_11-998-708.josm.osm")
+    private Atlas atlasZ11X998Y708;
+
+    @TestAtlas(loadFromJosmOsmResource = "DynamicAtlasAgressiveRelationsTest_11-999-708.josm.osm")
+    private Atlas atlasZ11X999Y708;
+
+    public Atlas getAtlasZ11X998Y708()
+    {
+        return this.atlasZ11X998Y708;
+    }
+
+    public Atlas getAtlasZ11X999Y708()
+    {
+        return this.atlasZ11X999Y708;
+    }
+}

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAgressiveRelationsTest_11-998-708.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAgressiveRelationsTest_11-998-708.josm.osm
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-131089' action='modify' visible='true' lat='48.34193997112' lon='-4.39594840655' />
+  <node id='-131090' action='modify' visible='true' lat='48.34237003312' lon='-4.3950918749' />
+  <way id='-121840' action='modify' visible='true'>
+    <nd ref='-131089' />
+    <nd ref='-131090' />
+    <tag k='highway' v='motorway' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <relation id='-99756' action='modify' visible='true'>
+    <member type='way' ref='-121840' role='member' />
+    <tag k='type' v='test' />
+  </relation>
+</osm>

--- a/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAgressiveRelationsTest_11-999-708.josm.osm
+++ b/src/test/resources/org/openstreetmap/atlas/geography/atlas/dynamic/rules/DynamicAtlasAgressiveRelationsTest_11-999-708.josm.osm
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-131094' action='modify' visible='true' lat='48.34232088336' lon='-4.39405048031' />
+  <node id='-131095' action='modify' visible='true' lat='48.34198912125' lon='-4.39300292363' />
+  <way id='-121885' action='modify' visible='true'>
+    <nd ref='-131094' />
+    <nd ref='-131095' />
+    <tag k='highway' v='primary' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <relation id='-99756' action='modify' visible='true'>
+    <member type='way' ref='-121885' role='member' />
+    <tag k='type' v='test' />
+  </relation>
+</osm>


### PR DESCRIPTION
### Description:

When toggling the aggressive relation expansion (to explore neighboring shards in search for relations with the same id) the dynamic atlas expander was ignoring it when the indefinite expansion is true, thinking it would be redundant. But in some cases, when the `entitiesToConsiderForExpansion` predicate is definded, or when some sparse areas have relations with far flung members (which would not be explored by regular indefinite expansion) this behavior was unexpected. 

### Potential Impact:

In more cases with neighboring shards be explored for relations.

### Unit Test Approach:

Added one unit test

### Test Results:

Relied on unit tests and other simple local testing. 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
