### PR TITLE
Fix rare issue with closed OSM ways not being converted to Areas

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfReader.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/OsmPbfReader.java
@@ -562,8 +562,9 @@ public class OsmPbfReader implements Sink
         }
         else
         {
+            final PolyLine wayPolyLine = constructWayPolyline(way);
             final TagMap wayTags = populateEntityTags(way);
-            if (way.isClosed())
+            if (wayPolyLine.first().equals(wayPolyLine.last()))
             {
                 boolean kept = false;
                 if (this.loadingOption.getAreaFilter().test(wayTags))
@@ -575,7 +576,7 @@ public class OsmPbfReader implements Sink
                 }
                 if (this.loadingOption.getEdgeFilter().test(wayTags))
                 {
-                    this.builder.addLine(padIdentifier(way.getId()), constructWayPolyline(way),
+                    this.builder.addLine(padIdentifier(way.getId()), wayPolyLine,
                             wayTags.getTags());
                     this.statistics.recordCreatedLine();
                     kept = true;
@@ -587,8 +588,7 @@ public class OsmPbfReader implements Sink
             }
             else
             {
-                this.builder.addLine(padIdentifier(way.getId()), constructWayPolyline(way),
-                        wayTags.getTags());
+                this.builder.addLine(padIdentifier(way.getId()), wayPolyLine, wayTags.getTags());
                 this.statistics.recordCreatedLine();
             }
         }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGeneratorTest.java
@@ -133,8 +133,8 @@ public class RawAtlasGeneratorTest
         // Verify Atlas Entities
         assertBasicRawAtlasPrinciples(atlas);
         Assert.assertEquals(457863, atlas.numberOfPoints());
-        Assert.assertEquals(13334, atlas.numberOfAreas());
-        Assert.assertEquals(32522, atlas.numberOfLines());
+        Assert.assertEquals(13335, atlas.numberOfAreas());
+        Assert.assertEquals(32521, atlas.numberOfLines());
         Assert.assertEquals(408, atlas.numberOfRelations());
         Assert.assertEquals(49, Iterables.size(atlas.points(
                 point -> Validators.hasValuesFor(point, SyntheticDuplicateOsmNodeTag.class))));


### PR DESCRIPTION
### Description:

This PR fixes a rare issue in which certain OSM ways are geometrically closed, but the Way objects in Osmosis will not report them as such due to the start and end Nodes having different IDs, thus Atlas will bring them in as Lines instead of Areas. The fix for this issue is relatively straightforward-- now, instead of relaying on the `Way.isClosed()` method to determine if an Area should be made, the PBF reader will convert the Line to a PolyLine preemptively, and check the start and and locations directly. 

### Potential Impact:
Relatively limited, other than more correct creation of Areas in the raw Atlas workflow.

### Unit Test Approach:

Updated an existing unit test that has an example of this behavior to properly reflect the counts. This count should have been accurate in the first place, but was mistakenly set.

### Test Results:

Passing.
------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
