### PR TITLE
Minor fix to sectioning logic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -527,11 +527,15 @@ public class AtlasSectionProcessor
         for (int i = 0; i < linePolyLine.size(); i++)
         {
             final Location location = linePolyLine.get(i);
-            if (location.equals(previousLocation))
+            if (i == 0 || i == linePolyLine.size() - 1)
+            {
+                nodesForEdge.add(i);
+            }
+            else if (location.equals(previousLocation))
             {
                 // NOOP
             }
-            else if (i == 0 || i == linePolyLine.size() - 1 || selfIntersections.contains(location)
+            else if (selfIntersections.contains(location)
                     || shouldSectionAtLocation(location, line))
             {
                 nodesForEdge.add(i);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessorTest.java
@@ -100,16 +100,13 @@ public class AtlasSectionProcessorTest
         final Atlas finalAtlas = new AtlasSectionProcessor(slicedRawAtlas,
                 AtlasLoadingOption.createOptionWithAllEnabled(COUNTRY_BOUNDARY_MAP)).run();
 
-        Assert.assertNotNull("Line has not been converted to an Edge",
-                finalAtlas.line(488453376000000L));
-        Assert.assertNull("Line has not been converted to an Edge",
+        Assert.assertNotNull("Line has been converted to an Edge",
                 finalAtlas.edge(488453376000000L));
+        Assert.assertNull("Line has not been converted to an Edge",
+                finalAtlas.line(488453376000000L));
         final Map<String, String> originalTags = slicedRawAtlas.line(488453376000000L).getTags();
-        final Map<String, String> finalTags = finalAtlas.line(488453376000000L).getTags();
-        Assert.assertTrue("Line has synthetic invalid way section tag",
-                finalTags.containsKey(SyntheticInvalidWaySectionTag.KEY));
-        finalTags.remove(SyntheticInvalidWaySectionTag.KEY);
-        Assert.assertEquals("Line has no other tag changes", originalTags, finalTags);
+        final Map<String, String> finalTags = finalAtlas.edge(488453376000000L).getTags();
+        Assert.assertEquals("Edge has no other tag changes", originalTags, finalTags);
     }
 
     @Test


### PR DESCRIPTION
### Description:

In certain cases for Edges ending in odd geometry (specifically, repeated points at the end of the line), sectioning was dropping geometry. This fix ensures that is no longer the case.

### Potential Impact:

Extremely limited, these geometries are rare-- but they now section as expected.

### Unit Test Approach:

A previous unit test covered this case, but thought the behavior should be to fail sectioning the line. This unit test has been updated to reflect the now correct behavior.

### Test Results:

Unit test passes.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
