### PR TITLE
Alter slicing intersection call

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -22,6 +22,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.geom.prep.PreparedPolygon;
@@ -1411,8 +1412,19 @@ public class RawAtlasSlicer
                 {
                     results.put(countryCode, new HashSet<>());
                 }
-                final Geometry clipped = OverlayNG.overlay(geometry, boundaryPolygon.getGeometry(),
-                        OverlayNG.INTERSECTION, JtsPrecisionManager.getPrecisionModel());
+                Geometry clipped;
+                try
+                {
+                    clipped = geometry.intersection(boundaryPolygon.getGeometry());
+                }
+                catch (final TopologyException exc)
+                {
+                    logger.warn(
+                            "Topology exception using regular intersection, falling back to snap overlay");
+                    clipped = OverlayNG.overlay(geometry, boundaryPolygon.getGeometry(),
+                            OverlayNG.INTERSECTION, JtsPrecisionManager.getPrecisionModel());
+                }
+
                 if (clipped instanceof GeometryCollection)
                 {
                     CountryBoundaryMap.geometries((GeometryCollection) clipped)


### PR DESCRIPTION
### Description:

Previously, slicing had been changed to use the OverlayNG intersection logic by default. While this is largely functional, in extremely rare cases there are slightly off results. Consequently, the logic has been updated to preferentially use the default intersection logic, and fall back to the OverlayNG logic if necessary.

### Potential Impact:
This PR does change the intersection call used by all slicing operations, however while there are differences in large numbers of cases, they are cosmetic in the grand majority of cases. 

### Unit Test Approach:

This isn't really a unit testable behavior. 

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
