### PR TITLE
Fix CyclewayTag typo

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/CyclewayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/CyclewayTag.java
@@ -28,7 +28,7 @@ public enum CyclewayTag
     OPPOSITE_SHARE_BUSWAY,
     SEGREGATED,
     NONE,
-    SEPARATED;
+    SEPARATE;
 
     @TagKey
     public static final String KEY = "cycleway";


### PR DESCRIPTION
### Description:

A "SEPARATED" tag value was added to cycleways instead of "SEPARATE". This fixes the issue.

### Potential Impact:

Typo fix

### Unit Test Approach:

Existing tests.

### Test Results:

All tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
