### PR TITLE
Added templates to Atlas Shell Tools to facilitate easier option sharing

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -370,14 +370,14 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     public abstract void registerManualPageSections();
 
     /**
-     * Register a {@link AbstractAtlasShellToolsCommandTemplate}'s manual pages for this command.
+     * Register a {@link AtlasShellToolsCommandTemplate}'s manual pages for this command.
      *
      * @param template
-     *            the {@link AbstractAtlasShellToolsCommandTemplate} whose man pages sections you
-     *            want to register
+     *            the {@link AtlasShellToolsCommandTemplate} whose man pages sections you want to
+     *            register
      */
     public void registerManualPageSectionsFromTemplate(
-            final AbstractAtlasShellToolsCommandTemplate template)
+            final AtlasShellToolsCommandTemplate template)
     {
         template.registerManualPageSections(this);
     }
@@ -606,15 +606,14 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     }
 
     /**
-     * Register a {@link AbstractAtlasShellToolsCommandTemplate}'s options and arguments for this
-     * command.
+     * Register a {@link AtlasShellToolsCommandTemplate}'s options and arguments for this command.
      *
      * @param template
-     *            the {@link AbstractAtlasShellToolsCommandTemplate} whose options and arguments you
-     *            want to register
+     *            the {@link AtlasShellToolsCommandTemplate} whose options and arguments you want to
+     *            register
      */
     public void registerOptionsAndArgumentsFromTemplate(
-            final AbstractAtlasShellToolsCommandTemplate template)
+            final AtlasShellToolsCommandTemplate template)
     {
         template.registerOptionsAndArguments(this);
     }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommand.java
@@ -157,6 +157,22 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     private Map<String, String> environment = null;
 
     /**
+     * Add a section to this command's manual page. The section name will be made all capitalized.
+     * Also, use the supplied input stream to read contents into the section.
+     *
+     * @param section
+     *            the name of the section
+     * @param sectionResourceFileStream
+     *            an input stream to the section resource file (easily specified like
+     *            CommandName.class.getResourceAsStream("resourcefile.txt"))
+     */
+    public void addManualPageSection(final String section,
+            final InputStream sectionResourceFileStream)
+    {
+        this.registrar.addManualPageSection(section, sectionResourceFileStream);
+    }
+
+    /**
      * Execute the command logic. Subclasses of {@link AbstractAtlasShellToolsCommand} must
      * implement this method, but in general it should not be called directly. See
      * {@link AbstractAtlasShellToolsCommand#runSubcommandAndExit(String...)}.
@@ -182,6 +198,16 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * @return the simple name of the command
      */
     public abstract String getCommandName();
+
+    /**
+     * Get a {@link CommandOutputDelegate} bound to this {@link AbstractAtlasShellToolsCommand}.
+     *
+     * @return a delegate bound to this command
+     */
+    public CommandOutputDelegate getCommandOutputDelegate()
+    {
+        return new CommandOutputDelegate(this);
+    }
 
     /**
      * Get the value of an environment variable. Command implementations should always defer to this
@@ -244,6 +270,17 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     }
 
     /**
+     * Get an {@link OptionAndArgumentDelegate} bound to this
+     * {@link AbstractAtlasShellToolsCommand}.
+     *
+     * @return a fetcher bound to this command
+     */
+    public OptionAndArgumentDelegate getOptionAndArgumentDelegate()
+    {
+        return new OptionAndArgumentDelegate(this);
+    }
+
+    /**
      * Get the {@link PrintStream} for this command's out stream.
      *
      * @return the {@link PrintStream} for this command's out stream.
@@ -282,6 +319,47 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     }
 
     /**
+     * Register an argument with a given arity. The argument hint is used as a key to retrieve the
+     * argument value(s) later. Additionally, documentation can use the hint to specify what the
+     * argument should be for.
+     *
+     * @param argumentHint
+     *            the hint for the argument
+     * @param arity
+     *            the argument arity
+     * @param optionality
+     *            whether the argument is optional or required
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the argument could not be registered
+     */
+    public void registerArgument(final String argumentHint, final ArgumentArity arity,
+            final ArgumentOptionality optionality, final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerArgument(argumentHint, arity, optionality, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerArgument(argumentHint, arity, optionality, contexts);
+        }
+    }
+
+    /**
+     * Register an empty context. This is useful if you want to have a defined usage case where no
+     * options or arguments are passed.
+     *
+     * @param context
+     *            the context id
+     */
+    public void registerEmptyContext(final int context)
+    {
+        this.parser.registerEmptyContext(context);
+    }
+
+    /**
      * Register any desired manual page sections. An OPTIONS section will be automatically
      * generated, so it is recommended that you register at least a DESCRIPTION and EXAMPLES section
      * with some appropriate documentation. See other {@link AbstractAtlasShellToolsCommand}
@@ -290,6 +368,222 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
      * start).
      */
     public abstract void registerManualPageSections();
+
+    /**
+     * Register a {@link AbstractAtlasShellToolsCommandTemplate}'s manual pages for this command.
+     *
+     * @param template
+     *            the {@link AbstractAtlasShellToolsCommandTemplate} whose man pages sections you
+     *            want to register
+     */
+    public void registerManualPageSectionsFromTemplate(
+            final AbstractAtlasShellToolsCommandTemplate template)
+    {
+        template.registerManualPageSections(this);
+    }
+
+    /**
+     * Register an option with a given long and short form. The option will be a flag option, ie. it
+     * can take no arguments.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param shortForm
+     *            the short form of the option, eg. -o
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOption(final String longForm, final Character shortForm,
+            final String description, final OptionOptionality optionality,
+            final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOption(longForm, shortForm, description, optionality,
+                    DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOption(longForm, shortForm, description, optionality, contexts);
+        }
+    }
+
+    /**
+     * Register an option with a given long form. The option will be a flag option, ie. it can take
+     * no arguments.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOption(final String longForm, final String description,
+            final OptionOptionality optionality, final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOption(longForm, description, optionality, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOption(longForm, description, optionality, contexts);
+        }
+    }
+
+    /**
+     * Register an option with a given long and short form that takes an optional argument. The
+     * provided argument hint can be used for generated documentation, and should be a single word
+     * describing the argument. The parser will throw an exception at parse-time if the argument is
+     * not supplied.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param shortForm
+     *            the short form of the option, eg. -o
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param argumentHint
+     *            the hint for the argument
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOptionWithOptionalArgument(final String longForm, final Character shortForm,
+            final String description, final OptionOptionality optionality,
+            final String argumentHint, final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOptionWithOptionalArgument(longForm, shortForm, description,
+                    optionality, argumentHint, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOptionWithOptionalArgument(longForm, shortForm, description,
+                    optionality, argumentHint, contexts);
+        }
+    }
+
+    /**
+     * Register an option with a given long form that takes an optional argument. The provided
+     * argument hint can be used for generated documentation, and should be a single word describing
+     * the argument.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param argumentHint
+     *            the hint for the argument
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOptionWithOptionalArgument(final String longForm, final String description,
+            final OptionOptionality optionality, final String argumentHint,
+            final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOptionWithOptionalArgument(longForm, description, optionality,
+                    argumentHint, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOptionWithOptionalArgument(longForm, description, optionality,
+                    argumentHint, contexts);
+        }
+    }
+
+    /**
+     * Register an option with a given long form that takes a required argument. The provided
+     * argument hint can be used for generated documentation, and should be a single word describing
+     * the argument. The parser will throw an exception at parse-time if the argument is not
+     * supplied.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param shortForm
+     *            the short form of the option, eg. -o
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param argumentHint
+     *            the hint for the argument
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOptionWithRequiredArgument(final String longForm, final Character shortForm,
+            final String description, final OptionOptionality optionality,
+            final String argumentHint, final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOptionWithRequiredArgument(longForm, shortForm, description,
+                    optionality, argumentHint, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOptionWithRequiredArgument(longForm, shortForm, description,
+                    optionality, argumentHint, contexts);
+        }
+    }
+
+    /**
+     * Register an option with a given long form that takes a required argument. The provided
+     * argument hint can be used for generated documentation, and should be a single word describing
+     * the argument. The parser will throw an exception if a required argument option is not
+     * supplied an argument at parse-time.
+     *
+     * @param longForm
+     *            the long form of the option, eg. --option
+     * @param description
+     *            a simple description
+     * @param optionality
+     *            the optionality
+     * @param argumentHint
+     *            the hint for the argument
+     * @param contexts
+     *            the contexts
+     * @throws CoreException
+     *             if the option could not be registered
+     */
+    public void registerOptionWithRequiredArgument(final String longForm, final String description,
+            final OptionOptionality optionality, final String argumentHint,
+            final Integer... contexts)
+    {
+        if (contexts.length == 0)
+        {
+            this.parser.registerOptionWithRequiredArgument(longForm, description, optionality,
+                    argumentHint, DEFAULT_CONTEXT);
+        }
+        else
+        {
+            this.parser.registerOptionWithRequiredArgument(longForm, description, optionality,
+                    argumentHint, contexts);
+        }
+    }
 
     /**
      * Register any necessary options and arguments for the command. Subclasses should override this
@@ -309,6 +603,20 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
         final Integer[] contexts = this.getFilteredRegisteredContexts().toArray(new Integer[0]);
         registerOption(VERBOSE_OPTION_LONG, VERBOSE_OPTION_SHORT, VERBOSE_OPTION_DESCRIPTION,
                 OptionOptionality.OPTIONAL, contexts);
+    }
+
+    /**
+     * Register a {@link AbstractAtlasShellToolsCommandTemplate}'s options and arguments for this
+     * command.
+     *
+     * @param template
+     *            the {@link AbstractAtlasShellToolsCommandTemplate} whose options and arguments you
+     *            want to register
+     */
+    public void registerOptionsAndArgumentsFromTemplate(
+            final AbstractAtlasShellToolsCommandTemplate template)
+    {
+        template.registerOptionsAndArguments(this);
     }
 
     /**
@@ -531,22 +839,6 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     }
 
     /**
-     * Add a section to this command's manual page. The section name will be made all capitalized.
-     * Also, use the supplied input stream to read contents into the section.
-     *
-     * @param section
-     *            the name of the section
-     * @param sectionResourceFileStream
-     *            an input stream to the section resource file (easily specified like
-     *            CommandName.class.getResourceAsStream("resourcefile.txt"))
-     */
-    protected void addManualPageSection(final String section,
-            final InputStream sectionResourceFileStream)
-    {
-        this.registrar.addManualPageSection(section, sectionResourceFileStream);
-    }
-
-    /**
      * Add a given paragraph to a given manual page section.
      *
      * @param section
@@ -559,273 +851,6 @@ public abstract class AbstractAtlasShellToolsCommand implements AtlasShellToolsM
     protected void addParagraphToSection(final String section, final String paragraph)
     {
         this.registrar.addParagraphToSection(section, paragraph);
-    }
-
-    /**
-     * Get a {@link CommandOutputDelegate} bound to this {@link AbstractAtlasShellToolsCommand}.
-     *
-     * @return a delegate bound to this command
-     */
-    protected CommandOutputDelegate getCommandOutputDelegate()
-    {
-        return new CommandOutputDelegate(this);
-    }
-
-    /**
-     * Get an {@link OptionAndArgumentDelegate} bound to this
-     * {@link AbstractAtlasShellToolsCommand}.
-     *
-     * @return a fetcher bound to this command
-     */
-    protected OptionAndArgumentDelegate getOptionAndArgumentDelegate()
-    {
-        return new OptionAndArgumentDelegate(this);
-    }
-
-    /**
-     * Register an argument with a given arity. The argument hint is used as a key to retrieve the
-     * argument value(s) later. Additionally, documentation can use the hint to specify what the
-     * argument should be for.
-     *
-     * @param argumentHint
-     *            the hint for the argument
-     * @param arity
-     *            the argument arity
-     * @param optionality
-     *            whether the argument is optional or required
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the argument could not be registered
-     */
-    protected void registerArgument(final String argumentHint, final ArgumentArity arity,
-            final ArgumentOptionality optionality, final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerArgument(argumentHint, arity, optionality, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerArgument(argumentHint, arity, optionality, contexts);
-        }
-    }
-
-    /**
-     * Register an empty context. This is useful if you want to have a defined usage case where no
-     * options or arguments are passed.
-     *
-     * @param context
-     *            the context id
-     */
-    protected void registerEmptyContext(final int context)
-    {
-        this.parser.registerEmptyContext(context);
-    }
-
-    /**
-     * Register an option with a given long and short form. The option will be a flag option, ie. it
-     * can take no arguments.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param shortForm
-     *            the short form of the option, eg. -o
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOption(final String longForm, final Character shortForm,
-            final String description, final OptionOptionality optionality,
-            final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOption(longForm, shortForm, description, optionality,
-                    DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOption(longForm, shortForm, description, optionality, contexts);
-        }
-    }
-
-    /**
-     * Register an option with a given long form. The option will be a flag option, ie. it can take
-     * no arguments.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOption(final String longForm, final String description,
-            final OptionOptionality optionality, final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOption(longForm, description, optionality, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOption(longForm, description, optionality, contexts);
-        }
-    }
-
-    /**
-     * Register an option with a given long and short form that takes an optional argument. The
-     * provided argument hint can be used for generated documentation, and should be a single word
-     * describing the argument. The parser will throw an exception at parse-time if the argument is
-     * not supplied.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param shortForm
-     *            the short form of the option, eg. -o
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param argumentHint
-     *            the hint for the argument
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOptionWithOptionalArgument(final String longForm,
-            final Character shortForm, final String description,
-            final OptionOptionality optionality, final String argumentHint,
-            final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOptionWithOptionalArgument(longForm, shortForm, description,
-                    optionality, argumentHint, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOptionWithOptionalArgument(longForm, shortForm, description,
-                    optionality, argumentHint, contexts);
-        }
-    }
-
-    /**
-     * Register an option with a given long form that takes an optional argument. The provided
-     * argument hint can be used for generated documentation, and should be a single word describing
-     * the argument.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param argumentHint
-     *            the hint for the argument
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOptionWithOptionalArgument(final String longForm,
-            final String description, final OptionOptionality optionality,
-            final String argumentHint, final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOptionWithOptionalArgument(longForm, description, optionality,
-                    argumentHint, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOptionWithOptionalArgument(longForm, description, optionality,
-                    argumentHint, contexts);
-        }
-    }
-
-    /**
-     * Register an option with a given long form that takes a required argument. The provided
-     * argument hint can be used for generated documentation, and should be a single word describing
-     * the argument. The parser will throw an exception at parse-time if the argument is not
-     * supplied.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param shortForm
-     *            the short form of the option, eg. -o
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param argumentHint
-     *            the hint for the argument
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOptionWithRequiredArgument(final String longForm,
-            final Character shortForm, final String description,
-            final OptionOptionality optionality, final String argumentHint,
-            final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOptionWithRequiredArgument(longForm, shortForm, description,
-                    optionality, argumentHint, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOptionWithRequiredArgument(longForm, shortForm, description,
-                    optionality, argumentHint, contexts);
-        }
-    }
-
-    /**
-     * Register an option with a given long form that takes a required argument. The provided
-     * argument hint can be used for generated documentation, and should be a single word describing
-     * the argument. The parser will throw an exception if a required argument option is not
-     * supplied an argument at parse-time.
-     *
-     * @param longForm
-     *            the long form of the option, eg. --option
-     * @param description
-     *            a simple description
-     * @param optionality
-     *            the optionality
-     * @param argumentHint
-     *            the hint for the argument
-     * @param contexts
-     *            the contexts
-     * @throws CoreException
-     *             if the option could not be registered
-     */
-    protected void registerOptionWithRequiredArgument(final String longForm,
-            final String description, final OptionOptionality optionality,
-            final String argumentHint, final Integer... contexts)
-    {
-        if (contexts.length == 0)
-        {
-            this.parser.registerOptionWithRequiredArgument(longForm, description, optionality,
-                    argumentHint, DEFAULT_CONTEXT);
-        }
-        else
-        {
-            this.parser.registerOptionWithRequiredArgument(longForm, description, optionality,
-                    argumentHint, contexts);
-        }
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommandTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommandTemplate.java
@@ -1,0 +1,23 @@
+package org.openstreetmap.atlas.utilities.command.abstractcommand;
+
+/**
+ * @author lcram
+ */
+public interface AbstractAtlasShellToolsCommandTemplate
+{
+    /**
+     * Register some manual page sections associated with this template.
+     *
+     * @param parentCommand
+     *            the parent {@link AbstractAtlasShellToolsCommand} for this template
+     */
+    void registerManualPageSections(final AbstractAtlasShellToolsCommand parentCommand);
+
+    /**
+     * Register some options and arguments associated with this template.
+     *
+     * @param parentCommand
+     *            the parent {@link AbstractAtlasShellToolsCommand} for this template
+     */
+    void registerOptionsAndArguments(final AbstractAtlasShellToolsCommand parentCommand);
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommandTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AbstractAtlasShellToolsCommandTemplate.java
@@ -1,6 +1,14 @@
 package org.openstreetmap.atlas.utilities.command.abstractcommand;
 
+import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNumbersTemplate;
+
 /**
+ * An {@link AbstractAtlasShellToolsCommandTemplate} provides an easy way for implementations of
+ * {@link AbstractAtlasShellToolsCommand} to share options, arguments, man page sections, and common
+ * functionality. For example, by using a template implementation, command authors will not need to
+ * re-declare a common option (with the accompanying duplicated option parsing code) across many
+ * different commands. See {@link ListOfNumbersTemplate} for an example implementation.
+ *
  * @author lcram
  */
 public interface AbstractAtlasShellToolsCommandTemplate
@@ -11,7 +19,7 @@ public interface AbstractAtlasShellToolsCommandTemplate
      * @param parentCommand
      *            the parent {@link AbstractAtlasShellToolsCommand} for this template
      */
-    void registerManualPageSections(final AbstractAtlasShellToolsCommand parentCommand);
+    void registerManualPageSections(AbstractAtlasShellToolsCommand parentCommand);
 
     /**
      * Register some options and arguments associated with this template.
@@ -19,5 +27,5 @@ public interface AbstractAtlasShellToolsCommandTemplate
      * @param parentCommand
      *            the parent {@link AbstractAtlasShellToolsCommand} for this template
      */
-    void registerOptionsAndArguments(final AbstractAtlasShellToolsCommand parentCommand);
+    void registerOptionsAndArguments(AbstractAtlasShellToolsCommand parentCommand);
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AtlasShellToolsCommandTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/abstractcommand/AtlasShellToolsCommandTemplate.java
@@ -3,7 +3,7 @@ package org.openstreetmap.atlas.utilities.command.abstractcommand;
 import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNumbersTemplate;
 
 /**
- * An {@link AbstractAtlasShellToolsCommandTemplate} provides an easy way for implementations of
+ * An {@link AtlasShellToolsCommandTemplate} provides an easy way for implementations of
  * {@link AbstractAtlasShellToolsCommand} to share options, arguments, man page sections, and common
  * functionality. For example, by using a template implementation, command authors will not need to
  * re-declare a common option (with the accompanying duplicated option parsing code) across many
@@ -11,7 +11,7 @@ import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNum
  *
  * @author lcram
  */
-public interface AbstractAtlasShellToolsCommandTemplate
+public interface AtlasShellToolsCommandTemplate
 {
     /**
      * Register some manual page sections associated with this template.

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
@@ -3,14 +3,20 @@ package org.openstreetmap.atlas.utilities.command.subcommands;
 import java.util.List;
 
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommandTemplate;
+import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNumbersTemplate;
 import org.openstreetmap.atlas.utilities.command.terminal.TTYAttribute;
 
 /**
+ * A command to test the {@link AbstractAtlasShellToolsCommandTemplate} feature.
+ * 
  * @author lcram
  */
 public class TemplateTestCommand extends AbstractAtlasShellToolsCommand
 {
+    private static final int REVERSE_CONTEXT = 4;
+
     public static void main(final String[] args)
     {
         new TemplateTestCommand().runSubcommandAndExit(args);
@@ -19,13 +25,23 @@ public class TemplateTestCommand extends AbstractAtlasShellToolsCommand
     @Override
     public int execute()
     {
-        final List<Integer> listOfNumbers = ListOfNumbersTemplate.getListOfNumbers(this);
-        if (listOfNumbers.isEmpty())
+        if (this.getOptionAndArgumentDelegate()
+                .getParserContext() == AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT)
         {
-            this.getCommandOutputDelegate().printlnErrorMessage("failed to parse number list!");
-            return 1;
+            final List<Integer> listOfNumbers = ListOfNumbersTemplate.getListOfNumbers(this);
+            if (listOfNumbers.isEmpty())
+            {
+                this.getCommandOutputDelegate().printlnErrorMessage("failed to parse number list!");
+                return 1;
+            }
+            this.getCommandOutputDelegate().printlnStdout(listOfNumbers.toString(),
+                    TTYAttribute.GREEN);
         }
-        this.getCommandOutputDelegate().printlnStdout(listOfNumbers.toString(), TTYAttribute.GREEN);
+        else
+        {
+            this.getCommandOutputDelegate().printlnStdout("Using reverse context!",
+                    TTYAttribute.GREEN);
+        }
         return 0;
     }
 
@@ -50,7 +66,10 @@ public class TemplateTestCommand extends AbstractAtlasShellToolsCommand
     @Override
     public void registerOptionsAndArguments()
     {
-        registerOptionsAndArgumentsFromTemplate(new ListOfNumbersTemplate());
+        registerOptionsAndArgumentsFromTemplate(
+                new ListOfNumbersTemplate(AbstractAtlasShellToolsCommand.DEFAULT_CONTEXT));
+        registerOption("reverse", "Perform this operation in reverse.", OptionOptionality.REQUIRED,
+                REVERSE_CONTEXT);
         super.registerOptionsAndArguments();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
@@ -3,13 +3,13 @@ package org.openstreetmap.atlas.utilities.command.subcommands;
 import java.util.List;
 
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
-import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommandTemplate;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AtlasShellToolsCommandTemplate;
 import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNumbersTemplate;
 import org.openstreetmap.atlas.utilities.command.terminal.TTYAttribute;
 
 /**
- * A command to test the {@link AbstractAtlasShellToolsCommandTemplate} feature.
+ * A command to test the {@link AtlasShellToolsCommandTemplate} feature.
  * 
  * @author lcram
  */

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommand.java
@@ -1,0 +1,56 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.util.List;
+
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
+import org.openstreetmap.atlas.utilities.command.subcommands.templates.ListOfNumbersTemplate;
+import org.openstreetmap.atlas.utilities.command.terminal.TTYAttribute;
+
+/**
+ * @author lcram
+ */
+public class TemplateTestCommand extends AbstractAtlasShellToolsCommand
+{
+    public static void main(final String[] args)
+    {
+        new TemplateTestCommand().runSubcommandAndExit(args);
+    }
+
+    @Override
+    public int execute()
+    {
+        final List<Integer> listOfNumbers = ListOfNumbersTemplate.getListOfNumbers(this);
+        if (listOfNumbers.isEmpty())
+        {
+            this.getCommandOutputDelegate().printlnErrorMessage("failed to parse number list!");
+            return 1;
+        }
+        this.getCommandOutputDelegate().printlnStdout(listOfNumbers.toString(), TTYAttribute.GREEN);
+        return 0;
+    }
+
+    @Override
+    public String getCommandName()
+    {
+        return "template-test";
+    }
+
+    @Override
+    public String getSimpleDescription()
+    {
+        return "test the Atlas Shell Tools template feature";
+    }
+
+    @Override
+    public void registerManualPageSections()
+    {
+        registerManualPageSectionsFromTemplate(new ListOfNumbersTemplate());
+    }
+
+    @Override
+    public void registerOptionsAndArguments()
+    {
+        registerOptionsAndArgumentsFromTemplate(new ListOfNumbersTemplate());
+        super.registerOptionsAndArguments();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
@@ -9,9 +9,13 @@ import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommandTemplate;
 import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
+import org.openstreetmap.atlas.utilities.command.subcommands.TemplateTestCommand;
 
 /**
- * An example of how to implement an {@link AbstractAtlasShellToolsCommandTemplate}.
+ * An example of how to implement an {@link AbstractAtlasShellToolsCommandTemplate}. This template
+ * simply provides an option that accepts a comma separated list of numbers. Note that the code to
+ * parse the option can be contained within the template itself! Check {@link TemplateTestCommand}
+ * to see how to use the template in a command implementation.
  * 
  * @author lcram
  */
@@ -19,6 +23,12 @@ public class ListOfNumbersTemplate implements AbstractAtlasShellToolsCommandTemp
 {
     private static final String LIST_OF_NUMBERS_OPTION_LONG = "list-of-numbers";
     private static final String COULD_NOT_PARSE = "could not parse %s '%s'";
+
+    /**
+     * The parse contexts under which we want the options provided by this template to appear. Leave
+     * empty to use the default context.
+     */
+    private final Integer[] contexts;
 
     public static List<Integer> getListOfNumbers(final AbstractAtlasShellToolsCommand parentCommand)
     {
@@ -51,6 +61,20 @@ public class ListOfNumbersTemplate implements AbstractAtlasShellToolsCommandTemp
         return numberList;
     }
 
+    /**
+     * This constructor allows callers to specify under which contexts they want the options
+     * provided by this template to appear. If left blank, this template will only be applied to the
+     * default context.
+     * 
+     * @param contexts
+     *            the parse contexts under which you want the options provided by this template to
+     *            appear
+     */
+    public ListOfNumbersTemplate(final Integer... contexts)
+    {
+        this.contexts = contexts;
+    }
+
     @Override
     public void registerManualPageSections(final AbstractAtlasShellToolsCommand parentCommand)
     {
@@ -65,7 +89,7 @@ public class ListOfNumbersTemplate implements AbstractAtlasShellToolsCommandTemp
     public void registerOptionsAndArguments(final AbstractAtlasShellToolsCommand parentCommand)
     {
         parentCommand.registerOptionWithRequiredArgument(LIST_OF_NUMBERS_OPTION_LONG,
-                "Specify a comma separated list of numbers.", OptionOptionality.REQUIRED,
-                "numbers");
+                "Specify a comma separated list of numbers.", OptionOptionality.REQUIRED, "numbers",
+                this.contexts);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
@@ -7,19 +7,19 @@ import java.util.List;
 
 import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
 import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
-import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommandTemplate;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AtlasShellToolsCommandTemplate;
 import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
 import org.openstreetmap.atlas.utilities.command.subcommands.TemplateTestCommand;
 
 /**
- * An example of how to implement an {@link AbstractAtlasShellToolsCommandTemplate}. This template
- * simply provides an option that accepts a comma separated list of numbers. Note that the code to
- * parse the option can be contained within the template itself! Check {@link TemplateTestCommand}
- * to see how to use the template in a command implementation.
+ * An example of how to implement an {@link AtlasShellToolsCommandTemplate}. This template simply
+ * provides an option that accepts a comma separated list of numbers. Note that the code to parse
+ * the option can be contained within the template itself! Check {@link TemplateTestCommand} to see
+ * how to use the template in a command implementation.
  * 
  * @author lcram
  */
-public class ListOfNumbersTemplate implements AbstractAtlasShellToolsCommandTemplate
+public class ListOfNumbersTemplate implements AtlasShellToolsCommandTemplate
 {
     private static final String LIST_OF_NUMBERS_OPTION_LONG = "list-of-numbers";
     private static final String COULD_NOT_PARSE = "could not parse %s '%s'";

--- a/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/command/subcommands/templates/ListOfNumbersTemplate.java
@@ -1,0 +1,71 @@
+package org.openstreetmap.atlas.utilities.command.subcommands.templates;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openstreetmap.atlas.utilities.command.AtlasShellToolsException;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommand;
+import org.openstreetmap.atlas.utilities.command.abstractcommand.AbstractAtlasShellToolsCommandTemplate;
+import org.openstreetmap.atlas.utilities.command.parsing.OptionOptionality;
+
+/**
+ * An example of how to implement an {@link AbstractAtlasShellToolsCommandTemplate}.
+ * 
+ * @author lcram
+ */
+public class ListOfNumbersTemplate implements AbstractAtlasShellToolsCommandTemplate
+{
+    private static final String LIST_OF_NUMBERS_OPTION_LONG = "list-of-numbers";
+    private static final String COULD_NOT_PARSE = "could not parse %s '%s'";
+
+    public static List<Integer> getListOfNumbers(final AbstractAtlasShellToolsCommand parentCommand)
+    {
+        final String listString = parentCommand.getOptionAndArgumentDelegate()
+                .getOptionArgument(LIST_OF_NUMBERS_OPTION_LONG)
+                .orElseThrow(AtlasShellToolsException::new);
+
+        if (listString.isEmpty())
+        {
+            return new ArrayList<>();
+        }
+
+        final List<Integer> numberList = new ArrayList<>();
+        final String[] listStringSplit = listString.split(",");
+        for (final String numberElement : listStringSplit)
+        {
+            final int number;
+            try
+            {
+                number = Integer.parseInt(numberElement);
+                numberList.add(number);
+            }
+            catch (final NumberFormatException exception)
+            {
+                parentCommand.getCommandOutputDelegate().printlnErrorMessage(
+                        String.format(COULD_NOT_PARSE, "number", numberElement));
+                return new ArrayList<>();
+            }
+        }
+        return numberList;
+    }
+
+    @Override
+    public void registerManualPageSections(final AbstractAtlasShellToolsCommand parentCommand)
+    {
+        parentCommand.addManualPageSection("LIST OF NUMBERS TEMPLATE",
+                new ByteArrayInputStream(
+                        ("This is an example man page section for the ListOfNumbersTemplate! "
+                                + "This template adds an option that reads a list of numbers.")
+                                        .getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Override
+    public void registerOptionsAndArguments(final AbstractAtlasShellToolsCommand parentCommand)
+    {
+        parentCommand.registerOptionWithRequiredArgument(LIST_OF_NUMBERS_OPTION_LONG,
+                "Specify a comma separated list of numbers.", OptionOptionality.REQUIRED,
+                "numbers");
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommandTest.java
@@ -43,4 +43,19 @@ public class TemplateTestCommandTest
                         + "template-test: error: failed to parse number list!\n",
                 errContent.toString());
     }
+
+    @Test
+    public void testReverseContext()
+    {
+        final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        final TemplateTestCommand command = new TemplateTestCommand();
+
+        command.setNewOutStream(new PrintStream(outContent));
+        command.setNewErrStream(new PrintStream(errContent));
+        command.runSubcommand("--reverse");
+
+        Assert.assertEquals("Using reverse context!\n", outContent.toString());
+        Assert.assertEquals("", errContent.toString());
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/TemplateTestCommandTest.java
@@ -1,0 +1,46 @@
+package org.openstreetmap.atlas.utilities.command.subcommands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author lcram
+ */
+public class TemplateTestCommandTest
+{
+    @Test
+    public void test()
+    {
+        final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        final TemplateTestCommand command = new TemplateTestCommand();
+
+        command.setNewOutStream(new PrintStream(outContent));
+        command.setNewErrStream(new PrintStream(errContent));
+        command.runSubcommand("--list-of-numbers", "1,2,3");
+
+        Assert.assertEquals("[1, 2, 3]\n", outContent.toString());
+        Assert.assertEquals("", errContent.toString());
+    }
+
+    @Test
+    public void testFail()
+    {
+        final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        final TemplateTestCommand command = new TemplateTestCommand();
+
+        command.setNewOutStream(new PrintStream(outContent));
+        command.setNewErrStream(new PrintStream(errContent));
+        command.runSubcommand("--list-of-numbers", "1,foo,3");
+
+        Assert.assertEquals("", outContent.toString());
+        Assert.assertEquals(
+                "template-test: error: could not parse number 'foo'\n"
+                        + "template-test: error: failed to parse number list!\n",
+                errContent.toString());
+    }
+}


### PR DESCRIPTION
### Description:
Added a class `AbstractAtlasShellToolsTemplate` which allows users to create templates to easily share options, arguments, man page sections, and common functionality (e.g. parsing options, connecting to auth servers, etc). Please check the examples (`ListOfNumbersTemplate` and `TemplateTestCommand`) to see how to use the feature!

### Potential Impact:
Potential for major code cleanup and reduced duplication. Also, a few more methods have been added `AbstractAtlasShellToolsCommand`, with some methods also being made public.

### Unit Test Approach:
Added a unit test for templates. 

### Test Results:
👍

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
