### PR TITLE
atlas/geography/Segment: Initialize list with size 2

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/Segment.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/Segment.java
@@ -46,7 +46,11 @@ public class Segment extends PolyLine
      */
     private static List<Location> asList(final Location start, final Location end)
     {
-        final List<Location> result = new ArrayList<>();
+        // avoid the initial grow calls for ArrayList (there would be at least one grow call,
+        // possibly two here)
+        // The grow calls are ~50% of the cost for this method.
+        // This should decrease the cost for segment creation by ~1/3.
+        final List<Location> result = new ArrayList<>(2);
         result.add(start);
         result.add(end);
         return result;


### PR DESCRIPTION
This significantly decreases the cost for creating segements (a good
    chunk of the cost is from growing the ArrayList)

Signed-off-by: Taylor Smock <tsmock@fb.com>

### Description:

Initialize an arraylist in `atlas/geography/Segment#asList` with the expected number of objects.

### Potential Impact:

Cheaper segment initialization

### Unit Test Approach:

Already covered

### Test Results:
Original:
![image](https://user-images.githubusercontent.com/45215054/113748324-93f59100-96c5-11eb-876c-262c9190dd5e.png)

After patch: (run not yet finished)
