### PR TITLE
Fix issue with snaps

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.SortedSet;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.LongFunction;
@@ -946,7 +945,7 @@ public interface Atlas
      *            A {@link Location} to snap
      * @param threshold
      *            A {@link Distance} threshold to look for edges around the {@link Location}
-     * @return A {@link SortedSet} of all the candidate snaps. The set is empty if there are no
+     * @return A sorted {@link List} of all the candidate snaps. The list is empty if there are no
      *         candidates.
      */
     List<SnappedEdge> snaps(Location point, Distance threshold);

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.geography.atlas;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -65,6 +66,11 @@ public interface Atlas
     Area area(long identifier);
 
     /**
+     * @return All the {@link Area}s in this {@link Atlas}
+     */
+    Iterable<Area> areas();
+
+    /**
      * A wrapper over {@link #area(long)} for multiple ids.
      *
      * @param identifiers
@@ -75,11 +81,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::area);
     }
-
-    /**
-     * @return All the {@link Area}s in this {@link Atlas}
-     */
-    Iterable<Area> areas();
 
     /**
      * Return all the {@link Area}s matching a {@link Predicate}.
@@ -169,6 +170,11 @@ public interface Atlas
     Edge edge(long identifier);
 
     /**
+     * @return All the {@link Edge}s in this {@link Atlas}
+     */
+    Iterable<Edge> edges();
+
+    /**
      * A wrapper over {@link #edge(long)} for multiple ids.
      *
      * @param identifiers
@@ -179,11 +185,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::edge);
     }
-
-    /**
-     * @return All the {@link Edge}s in this {@link Atlas}
-     */
-    Iterable<Edge> edges();
 
     /**
      * Return all the {@link Edge}s matching a {@link Predicate}.
@@ -488,6 +489,11 @@ public interface Atlas
     Iterable<LineItem> lineItemsWithin(GeometricSurface surface);
 
     /**
+     * @return All the {@link Line}s in this {@link Atlas}
+     */
+    Iterable<Line> lines();
+
+    /**
      * A wrapper over {@link #line(long)} for multiple ids.
      *
      * @param identifiers
@@ -498,11 +504,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::line);
     }
-
-    /**
-     * @return All the {@link Line}s in this {@link Atlas}
-     */
-    Iterable<Line> lines();
 
     /**
      * Return all the {@link Line}s matching a {@link Predicate}.
@@ -619,6 +620,11 @@ public interface Atlas
     Node node(long identifier);
 
     /**
+     * @return All the {@link Node}s in this Atlas
+     */
+    Iterable<Node> nodes();
+
+    /**
      * A wrapper over {@link #node(long)} for multiple ids.
      *
      * @param identifiers
@@ -629,11 +635,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::node);
     }
-
-    /**
-     * @return All the {@link Node}s in this Atlas
-     */
-    Iterable<Node> nodes();
 
     /**
      * Return all the {@link Node}s matching a {@link Predicate}.
@@ -716,6 +717,11 @@ public interface Atlas
     Point point(long identifier);
 
     /**
+     * @return All the {@link Point}s in this Atlas
+     */
+    Iterable<Point> points();
+
+    /**
      * A wrapper over {@link #point(long)} for multiple ids.
      *
      * @param identifiers
@@ -726,11 +732,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::point);
     }
-
-    /**
-     * @return All the {@link Point}s in this Atlas
-     */
-    Iterable<Point> points();
 
     /**
      * Return all the {@link Point}s matching a {@link Predicate}.
@@ -783,6 +784,11 @@ public interface Atlas
     Relation relation(long identifier);
 
     /**
+     * @return All the {@link Relation}s in this Atlas
+     */
+    Iterable<Relation> relations();
+
+    /**
      * A wrapper over {@link #relation(long)} for multiple ids.
      *
      * @param identifiers
@@ -793,11 +799,6 @@ public interface Atlas
     {
         return entitiesMatchingId(identifiers, this::relation);
     }
-
-    /**
-     * @return All the {@link Relation}s in this Atlas
-     */
-    Iterable<Relation> relations();
 
     /**
      * Return all the {@link Relation}s matching a {@link Predicate}.
@@ -948,7 +949,7 @@ public interface Atlas
      * @return A {@link SortedSet} of all the candidate snaps. The set is empty if there are no
      *         candidates.
      */
-    SortedSet<SnappedEdge> snaps(Location point, Distance threshold);
+    List<SnappedEdge> snaps(Location point, Distance threshold);
 
     /**
      * Return a sub-atlas from this Atlas.
@@ -978,7 +979,7 @@ public interface Atlas
     /**
      * Get a summary of this {@link Atlas}. This string should be relatively compact, for e.g. just
      * the entity counts.
-     * 
+     *
      * @return A summary of this {@link Atlas}.
      */
     String summary();
@@ -986,7 +987,7 @@ public interface Atlas
     /**
      * Get a complete string representation of this {@link Atlas}. This string may include details
      * on all contained entities.
-     * 
+     *
      * @return a complete string representation of this {@link Atlas}
      */
     String toStringDetailed();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -11,8 +11,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
@@ -22,6 +20,7 @@ import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Snapper.SnappedLocation;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -600,14 +599,15 @@ public abstract class BareAtlas implements Atlas
     }
 
     @Override
-    public SortedSet<SnappedEdge> snaps(final Location point, final Distance threshold)
+    public List<SnappedEdge> snaps(final Location point, final Distance threshold)
     {
-        final SortedSet<SnappedEdge> snaps = new TreeSet<>();
+        final List<SnappedEdge> snaps = new ArrayList<>();
         for (final Edge edge : this.edgesIntersecting(point.boxAround(threshold)))
         {
             final SnappedEdge candidate = new SnappedEdge(point.snapTo(edge.asPolyLine()), edge);
             snaps.add(candidate);
         }
+        snaps.sort(SnappedLocation::compareTo);
         return snaps;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
@@ -1,8 +1,8 @@
 package org.openstreetmap.atlas.geography.atlas.complete;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
-import java.util.SortedSet;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
@@ -644,7 +644,7 @@ public class EmptyAtlas implements Atlas
     }
 
     @Override
-    public SortedSet<SnappedEdge> snaps(final Location point, final Distance threshold)
+    public List<SnappedEdge> snaps(final Location point, final Distance threshold)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/routing/AbstractRouter.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/routing/AbstractRouter.java
@@ -1,7 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas.routing;
 
 import java.util.Iterator;
-import java.util.SortedSet;
+import java.util.List;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
@@ -75,8 +75,8 @@ public abstract class AbstractRouter implements Router
             throw new CoreException(
                     "Cannot compute route on null arguments: start = {} and end = {}", start, end);
         }
-        final SortedSet<SnappedEdge> startEdges = this.atlas.snaps(start, this.threshold);
-        final SortedSet<SnappedEdge> endEdges = this.atlas.snaps(end, this.threshold);
+        final List<SnappedEdge> startEdges = this.atlas.snaps(start, this.threshold);
+        final List<SnappedEdge> endEdges = this.atlas.snaps(end, this.threshold);
         if (startEdges.isEmpty())
         {
             // logger.warn("Could not find a snap for start location {}", start);

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlasTest.java
@@ -374,6 +374,15 @@ public class PackedAtlasTest
     }
 
     @Test
+    public void testSnaps()
+    {
+        Assert.assertEquals(2, this.atlas
+                .snaps(this.atlas.node(12345L).getLocation(), Distance.meters(100)).size());
+        Assert.assertEquals(4, this.atlas
+                .snaps(this.atlas.node(12345L).getLocation(), Distance.meters(100000)).size());
+    }
+
+    @Test
     public void testValence()
     {
         // Case where valences are equals


### PR DESCRIPTION
### Description:

This PR fixes an unfortunate issue with the `snaps()` method in Atlas. The method is intending to return all Edges within a "snap" distance that can be "snapped" to that location, sorted by the distance from the original point. Unfortunately, there is an unintended consequence to using SortedSet-- while sorting happens easily on insertion using this type of collection, it enforces uniqueness for the Set by the same distance function used to sort. Abstractly, this distance condition could already lead to accidental exclusions, but it's made significantly worse by the implementation of the distance comparator for SnappedLocation: it measures the distance from the initial snapped location to the *starting Node of the Edge*. This means that all Edges from an intersection will have the same Distance, and thus only one Edge from any given intersection will be allowed into the SortedSet.

The fix for this has been to return a List, sorted by the original comparator.  

### Potential Impact:

Not too much, other than expected data now coming through `snaps()` 💀 

### Unit Test Approach:

Added unit test to capture the expected behavior

### Test Results:
💯 

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
