### PR TITLE
Add CompleLandcover type

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCover.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCover.java
@@ -1,0 +1,155 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.landcover;
+
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.complex.ComplexEntity;
+import org.openstreetmap.atlas.geography.atlas.items.complex.RelationOrAreaToMultiPolygonConverter;
+import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+/**
+ * @author sbhalekar
+ * @author samg
+ */
+public final class ComplexLandCover extends ComplexEntity
+{
+    private static final Logger logger = LoggerFactory.getLogger(ComplexLandCover.class);
+    private static final long serialVersionUID = 220683230343177634L;
+    private static final RelationOrAreaToMultiPolygonConverter MULTIPOLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
+    private static final String LAND_COVER_RESOURCE = "land-cover-tag-filter.json";
+    // The default LandCover tags
+    private static List<TaggableFilter> defaultTaggableFilter;
+    private final MultiPolygon multiPolygon;
+
+    /**
+     * This method creates a {@link ComplexLandCover} for the specified {@link AtlasEntity} if it
+     * meets the requirements for Complex LandCover relation. The LandCover tags are checked against
+     * the default tags.
+     *
+     * @param source
+     *            The {@link AtlasEntity} for which the ComplexEntity is created
+     * @return {@link ComplexLandCover} if created, else return empty.
+     */
+    public static Optional<ComplexLandCover> getComplexLandCover(final AtlasEntity source)
+    {
+        if (defaultTaggableFilter == null)
+        {
+            computeDefaultFilter();
+        }
+        return getComplexLandCover(source, ComplexLandCover::hasLandCoverTag);
+    }
+
+    /**
+     * This method creates a {@link ComplexLandCover} for the specified {@link AtlasEntity} and
+     * {@link TaggableFilter}. The land cover tags are checked against the landCoverFilter param as
+     * well as the default tags.
+     *
+     * @param source
+     *            The {@link AtlasEntity} for which the ComplexEntity is created
+     * @param landCoverFilter
+     *            The {@link TaggableFilter} of land cover tags against which the relation is
+     *            checked for land cover tags
+     * @return {@link ComplexLandCover} if created, else return empty.
+     */
+    public static Optional<ComplexLandCover> getComplexLandCover(final AtlasEntity source,
+            final Predicate<Taggable> landCoverFilter)
+    {
+        try
+        {
+            return ((source instanceof Relation || source instanceof Area)
+                    && landCoverFilter.test(source)) ? Optional.of(new ComplexLandCover(source))
+                            : Optional.empty();
+        }
+        catch (final Exception exception)
+        {
+            logger.warn("Unable to create complex land cover relations from {}", source, exception);
+            return Optional.empty();
+        }
+    }
+
+    private static void computeDefaultFilter()
+    {
+        try (InputStreamReader reader = new InputStreamReader(
+                ComplexLandCover.class.getResourceAsStream(LAND_COVER_RESOURCE)))
+        {
+            final JsonElement element = new JsonParser().parse(reader);
+            final JsonArray filters = element.getAsJsonObject().get("filters").getAsJsonArray();
+            defaultTaggableFilter = StreamSupport.stream(filters.spliterator(), false)
+                    .map(jsonElement -> TaggableFilter.forDefinition(jsonElement.getAsString()))
+                    .collect(Collectors.toList());
+        }
+        catch (final Exception exception)
+        {
+            throw new CoreException(
+                    "There was a problem parsing aoi-tag-filter.json. Check if the JSON file has valid structure.",
+                    exception);
+        }
+    }
+
+    /**
+     * Checks for land cover tags in the object
+     *
+     * @param source
+     *            {@link AtlasEntity} that needs to be checked for land cover tags
+     * @return {@code true} if the source has land cover tags
+     */
+    private static boolean hasLandCoverTag(final Taggable source)
+    {
+        return defaultTaggableFilter.stream()
+                .anyMatch(taggableFilter -> taggableFilter.test(source));
+    }
+
+    private ComplexLandCover(final AtlasEntity source)
+    {
+        super(source);
+        try
+        {
+            this.multiPolygon = MULTIPOLYGON_CONVERTER.convert(source);
+        }
+        catch (final Exception exception)
+        {
+            setInvalidReason("Unable to convert the AtlasEntity to MultiPolygon", exception);
+            throw new CoreException("Unable to convert the AtlasEntity {} to MultiPolygon",
+                    source.getOsmIdentifier(), exception);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        return other instanceof ComplexLandCover && super.equals(other);
+    }
+
+    public MultiPolygon getGeometry()
+    {
+        return this.multiPolygon;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.getClass().getName() + " " + getSource();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinder.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinder.java
@@ -1,0 +1,66 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.landcover;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.complex.Finder;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.MultiIterable;
+
+/**
+ * {@link ComplexLandCover} finder.
+ *
+ * @author samg
+ */
+public class ComplexLandCoverFinder implements Finder<ComplexLandCover>
+{
+    /**
+     * Finds all relations and areas that are candidates for {@link ComplexLandCover} and converts
+     * them into {@link ComplexLandCover}.
+     *
+     * @param atlas
+     *            The {@link Atlas} to browse.
+     * @return {@link Iterables} of {@link ComplexLandCover}.
+     */
+    @Override
+    public Iterable<ComplexLandCover> find(final Atlas atlas)
+    {
+        final Iterable<ComplexLandCover> iterableOfComplexLandCoverRelations = StreamSupport
+                .stream(atlas.relations().spliterator(), true)
+                .map(ComplexLandCover::getComplexLandCover).filter(Optional::isPresent)
+                .map(Optional::get).collect(Collectors.toList());
+        final Iterable<ComplexLandCover> iterableOfComplexLandCoverAreas = StreamSupport
+                .stream(atlas.areas().spliterator(), true)
+                .map(ComplexLandCover::getComplexLandCover).filter(Optional::isPresent)
+                .map(Optional::get).collect(Collectors.toList());
+        return new MultiIterable<>(iterableOfComplexLandCoverRelations,
+                iterableOfComplexLandCoverAreas);
+    }
+
+    /**
+     * Finds all relations and areas that are candidates for {@link ComplexLandCover} with given
+     * land cover tags and converts them into {@link ComplexLandCover}.
+     *
+     * @param atlas
+     *            Atlas to build the ComplexLandCover
+     * @param landCoverFilter
+     *            {@link TaggableFilter} land cover taggable filter
+     * @return {@link Iterables} of {@link ComplexLandCover}.
+     */
+    public Iterable<ComplexLandCover> find(final Atlas atlas, final TaggableFilter landCoverFilter)
+    {
+        final Iterable<ComplexLandCover> iterableOfComplexLandCoverRelations = StreamSupport
+                .stream(atlas.relations().spliterator(), true)
+                .map(relation -> ComplexLandCover.getComplexLandCover(relation, landCoverFilter))
+                .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+        final Iterable<ComplexLandCover> iterableOfComplexLandCoverAreas = StreamSupport
+                .stream(atlas.areas().spliterator(), true)
+                .map(area -> ComplexLandCover.getComplexLandCover(area, landCoverFilter))
+                .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+        return new MultiIterable<>(iterableOfComplexLandCoverRelations,
+                iterableOfComplexLandCoverAreas);
+    }
+}

--- a/src/main/resources/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/land-cover-tag-filter.json
+++ b/src/main/resources/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/land-cover-tag-filter.json
@@ -1,0 +1,8 @@
+{
+    "filters": [
+      "landuse->*",
+      "natural->*",
+      "surface->*",
+      "landcover->*"
+      ]
+  }

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTest.java
@@ -11,7 +11,7 @@ import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 /**
  * @author samg
  */
-public class ComplexLandCoverFinderTest 
+public class ComplexLandCoverFinderTest
 {
     @Rule
     public ComplexLandCoverFinderTestRule rule = new ComplexLandCoverFinderTestRule();
@@ -23,7 +23,8 @@ public class ComplexLandCoverFinderTest
         final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
         final Iterable<ComplexLandCover> complexLandCovers = landCoverRelationFinder.find(atlas,
                 TaggableFilter.forDefinition("landuse->VINEYARD|surface->paved"));
-        Assert.assertEquals(2, StreamSupport.stream(complexLandCovers.spliterator(), false).count());
+        Assert.assertEquals(2,
+                StreamSupport.stream(complexLandCovers.spliterator(), false).count());
     }
 
     @Test
@@ -31,8 +32,10 @@ public class ComplexLandCoverFinderTest
     {
         final Atlas atlas = this.rule.getLandCoverAreaAtlas();
         final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
-        final Iterable<ComplexLandCover> complexLandCoverAreas = landCoverRelationFinder.find(atlas);
-        Assert.assertEquals(2, StreamSupport.stream(complexLandCoverAreas.spliterator(), false).count());
+        final Iterable<ComplexLandCover> complexLandCoverAreas = landCoverRelationFinder
+                .find(atlas);
+        Assert.assertEquals(2,
+                StreamSupport.stream(complexLandCoverAreas.spliterator(), false).count());
     }
 
     @Test
@@ -40,7 +43,8 @@ public class ComplexLandCoverFinderTest
     {
         final Atlas atlas = this.rule.getMultipolygonLandCoverRelationAtlas();
         final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
-        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder.find(atlas);
+        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder
+                .find(atlas);
         Assert.assertEquals(2,
                 StreamSupport.stream(complexLandCoverRelations.spliterator(), false).count());
     }
@@ -50,7 +54,8 @@ public class ComplexLandCoverFinderTest
     {
         final Atlas atlas = this.rule.getNonMultipolygonLandCoverRelationAtlas();
         final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
-        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder.find(atlas);
+        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder
+                .find(atlas);
         Assert.assertFalse(complexLandCoverRelations.iterator().hasNext());
         Assert.assertEquals(0,
                 StreamSupport.stream(complexLandCoverRelations.spliterator(), false).count());

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTest.java
@@ -1,0 +1,58 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.landcover;
+
+import java.util.stream.StreamSupport;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
+
+/**
+ * @author samg
+ */
+public class ComplexLandCoverFinderTest 
+{
+    @Rule
+    public ComplexLandCoverFinderTestRule rule = new ComplexLandCoverFinderTestRule();
+
+    @Test
+    public void testComplexLandCoverWithCustomFilter()
+    {
+        final Atlas atlas = this.rule.getComplexLandCoverWithRelationsAndAreas();
+        final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
+        final Iterable<ComplexLandCover> complexLandCovers = landCoverRelationFinder.find(atlas,
+                TaggableFilter.forDefinition("landuse->VINEYARD|surface->paved"));
+        Assert.assertEquals(2, StreamSupport.stream(complexLandCovers.spliterator(), false).count());
+    }
+
+    @Test
+    public void testLandCoverArea()
+    {
+        final Atlas atlas = this.rule.getLandCoverAreaAtlas();
+        final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
+        final Iterable<ComplexLandCover> complexLandCoverAreas = landCoverRelationFinder.find(atlas);
+        Assert.assertEquals(2, StreamSupport.stream(complexLandCoverAreas.spliterator(), false).count());
+    }
+
+    @Test
+    public void testMultipolygonLandCoverRelation()
+    {
+        final Atlas atlas = this.rule.getMultipolygonLandCoverRelationAtlas();
+        final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
+        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder.find(atlas);
+        Assert.assertEquals(2,
+                StreamSupport.stream(complexLandCoverRelations.spliterator(), false).count());
+    }
+
+    @Test
+    public void testNonMultipolygonLandCoverRelation()
+    {
+        final Atlas atlas = this.rule.getNonMultipolygonLandCoverRelationAtlas();
+        final ComplexLandCoverFinder landCoverRelationFinder = new ComplexLandCoverFinder();
+        final Iterable<ComplexLandCover> complexLandCoverRelations = landCoverRelationFinder.find(atlas);
+        Assert.assertFalse(complexLandCoverRelations.iterator().hasNext());
+        Assert.assertEquals(0,
+                StreamSupport.stream(complexLandCoverRelations.spliterator(), false).count());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTestRule.java
@@ -185,8 +185,7 @@ public class ComplexLandCoverFinderTestRule extends CoreTestRule
                                             @Relation(id = "39190", members = {
                                                     @Member(id = "39010", type = "area", role = "outer"),
                                                     @Member(id = "38989", type = "area", role = "inner") }, tags = {
-                                                            "type=multipolygon",
-                                                            "surface=paved" }),
+                                                            "type=multipolygon", "surface=paved" }),
                                             @Relation(id = "39990", members = {
                                                     @Member(id = "38987", type = "area", role = "outer") }, tags = {
                                                             "type=boundary",

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/landcover/ComplexLandCoverFinderTestRule.java
@@ -1,0 +1,215 @@
+package org.openstreetmap.atlas.geography.atlas.items.complex.landcover;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * @author samg
+ */
+public class ComplexLandCoverFinderTestRule extends CoreTestRule
+{
+    private static final String LOCATION_ONE = "1.43958970913, 103.91306306772";
+    private static final String LOCATION_TWO = "1.42773565932, 103.90488839864";
+    private static final String LOCATION_THREE = "1.43419031086, 103.89654055711";
+    private static final String LOCATION_FOUR = "1.41407426416, 103.89600156794";
+    private static final String LOCATION_FIVE = "1.40850639889, 103.91621366183";
+    private static final String LOCATION_SIX = "1.39835848123, 103.92322052105";
+    private static final String LOCATION_SEVEN = "1.41146994174, 103.94549874009";
+    private static final String LOCATION_EIGHT = "1.41155974601, 103.96373454036";
+    private static final String LOCATION_NINE = "1.43419031086, 103.97038207346";
+    private static final String LOCATION_TEN = "1.45116308784, 103.96454302412";
+    private static final String LOCATION_ELEVEN = "1.45233052286, 103.93786306018";
+    private static final String LOCATION_TWELVE = "1.45367756252, 103.91845945004";
+    private static final String LOCATION_THIRTEEN = "1.41193016458, 103.91459020371";
+    private static final String LOCATION_FOURTEEN = "1.41624076477, 103.94180915682";
+    private static final String LOCATION_FIFTEEN = "1.42638860433, 103.94621090171";
+    private static final String LOCATION_SIXTEEN = "1.43141760561, 103.96399754433";
+    private static final String LOCATION_SEVENTEEN = "1.44273281808, 103.95447540232";
+    private static final String LOCATION_EIGHTEEN = "1.43842226756, 103.93857522179";
+    private static final String LOCATION_NINETEEN = "1.44839040324, 103.9256394817";
+    private static final String LOCATION_TWENTY = "1.4507140742, 103.9069610144";
+
+    @TestAtlas(points = { @Point(id = "39008", coordinates = @Loc(value = LOCATION_TWENTY)),
+            @Point(id = "39009", coordinates = @Loc(value = LOCATION_THREE)),
+            @Point(id = "39011", coordinates = @Loc(value = LOCATION_FOUR)),
+            @Point(id = "39013", coordinates = @Loc(value = LOCATION_FIVE)),
+            @Point(id = "39015", coordinates = @Loc(value = LOCATION_SIX)),
+            @Point(id = "38985", coordinates = @Loc(value = LOCATION_ONE)),
+            @Point(id = "39019", coordinates = @Loc(value = LOCATION_EIGHT)),
+            @Point(id = "38988", coordinates = @Loc(value = LOCATION_TWO)),
+            @Point(id = "39021", coordinates = @Loc(value = LOCATION_NINE)),
+            @Point(id = "39023", coordinates = @Loc(value = LOCATION_TEN)),
+            @Point(id = "38992", coordinates = @Loc(value = LOCATION_THIRTEEN)),
+            @Point(id = "39025", coordinates = @Loc(value = LOCATION_ELEVEN)),
+            @Point(id = "38994", coordinates = @Loc(value = LOCATION_FOURTEEN)),
+            @Point(id = "39027", coordinates = @Loc(value = LOCATION_TWELVE)),
+            @Point(id = "38996", coordinates = @Loc(value = LOCATION_FIFTEEN)),
+            @Point(id = "38998", coordinates = @Loc(value = LOCATION_SIXTEEN)),
+            @Point(id = "39017", coordinates = @Loc(value = LOCATION_SEVEN)),
+            @Point(id = "39000", coordinates = @Loc(value = LOCATION_SEVENTEEN)),
+            @Point(id = "39002", coordinates = @Loc(value = LOCATION_EIGHTEEN)),
+            @Point(id = "39004", coordinates = @Loc(value = LOCATION_NINETEEN)) }, areas = {
+                    @Area(id = "39010", coordinates = { @Loc(value = LOCATION_TWENTY),
+                            @Loc(value = LOCATION_THREE), @Loc(value = LOCATION_FOUR),
+                            @Loc(value = LOCATION_FIVE), @Loc(value = LOCATION_SIX),
+                            @Loc(value = LOCATION_SEVEN), @Loc(value = LOCATION_EIGHT),
+                            @Loc(value = LOCATION_NINE), @Loc(value = LOCATION_TEN),
+                            @Loc(value = LOCATION_ELEVEN), @Loc(value = LOCATION_TWELVE),
+                            @Loc(value = LOCATION_TWENTY) }),
+                    @Area(id = "38989", coordinates = { @Loc(value = LOCATION_ONE),
+                            @Loc(value = LOCATION_TWO), @Loc(value = LOCATION_THIRTEEN),
+                            @Loc(value = LOCATION_FOURTEEN), @Loc(value = LOCATION_FIFTEEN),
+                            @Loc(value = LOCATION_SIXTEEN), @Loc(value = LOCATION_SEVENTEEN),
+                            @Loc(value = LOCATION_EIGHTEEN), @Loc(value = LOCATION_NINETEEN),
+                            @Loc(value = LOCATION_ONE) }),
+                    @Area(id = "38987", coordinates = { @Loc(value = LOCATION_ELEVEN),
+                            @Loc(value = LOCATION_TEN), @Loc(value = LOCATION_EIGHTEEN),
+                            @Loc(value = LOCATION_SEVENTEEN) }) }, relations = {
+                                    @Relation(id = "39190", members = {
+                                            @Member(id = "39010", type = "area", role = "outer"),
+                                            @Member(id = "38989", type = "area", role = "inner") }, tags = {
+                                                    "type=multipolygon", "surface=paved" }),
+                                    @Relation(id = "39990", members = {
+                                            @Member(id = "38987", type = "area", role = "outer") }, tags = {
+                                                    "type=boundary", "landuse=CEMETERY" }) })
+    private Atlas multipolygonLandCoverRelationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "10020", coordinates = @Loc(value = LOCATION_SEVEN)),
+                    @Node(id = "21001", coordinates = @Loc(value = LOCATION_EIGHT)),
+                    @Node(id = "31233", coordinates = @Loc(value = LOCATION_NINE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12333", coordinates = { @Loc(value = LOCATION_SEVEN),
+                            @Loc(value = LOCATION_EIGHT) }, tags = { "highway=road" }),
+                    @Edge(id = "23332", coordinates = { @Loc(value = LOCATION_EIGHT),
+                            @Loc(value = LOCATION_NINE) }, tags = { "highway=road" }),
+                    @Edge(id = "31223", coordinates = { @Loc(value = LOCATION_NINE),
+                            @Loc(value = LOCATION_SEVEN) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "89765", members = {
+                    @Member(id = "12333", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                    @Member(id = "21001", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                    @Member(id = "31223", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                            "restriction=no_u_turn", "landuse=VILLAGE" }) })
+    private Atlas nonMultipolygonLandCoverRelationAtlas;
+
+    @TestAtlas(points = { @Point(id = "39008", coordinates = @Loc(value = LOCATION_TWENTY)),
+            @Point(id = "39009", coordinates = @Loc(value = LOCATION_THREE)),
+            @Point(id = "39011", coordinates = @Loc(value = LOCATION_FOUR)),
+            @Point(id = "39013", coordinates = @Loc(value = LOCATION_FIVE)),
+            @Point(id = "39015", coordinates = @Loc(value = LOCATION_SIX)),
+            @Point(id = "38985", coordinates = @Loc(value = LOCATION_ONE)),
+            @Point(id = "39019", coordinates = @Loc(value = LOCATION_EIGHT)),
+            @Point(id = "38988", coordinates = @Loc(value = LOCATION_TWO)),
+            @Point(id = "39021", coordinates = @Loc(value = LOCATION_NINE)),
+            @Point(id = "39023", coordinates = @Loc(value = LOCATION_TEN)),
+            @Point(id = "38992", coordinates = @Loc(value = LOCATION_THIRTEEN)),
+            @Point(id = "39025", coordinates = @Loc(value = LOCATION_ELEVEN)),
+            @Point(id = "38994", coordinates = @Loc(value = LOCATION_FOURTEEN)),
+            @Point(id = "39027", coordinates = @Loc(value = LOCATION_TWELVE)),
+            @Point(id = "38996", coordinates = @Loc(value = LOCATION_FIFTEEN)),
+            @Point(id = "38998", coordinates = @Loc(value = LOCATION_SIXTEEN)),
+            @Point(id = "39017", coordinates = @Loc(value = LOCATION_SEVEN)),
+            @Point(id = "39000", coordinates = @Loc(value = LOCATION_SEVENTEEN)),
+            @Point(id = "39002", coordinates = @Loc(value = LOCATION_EIGHTEEN)),
+            @Point(id = "39004", coordinates = @Loc(value = LOCATION_NINETEEN)) }, areas = {
+                    @Area(id = "39010", coordinates = { @Loc(value = LOCATION_TWENTY),
+                            @Loc(value = LOCATION_THREE), @Loc(value = LOCATION_FOUR),
+                            @Loc(value = LOCATION_FIVE), @Loc(value = LOCATION_SIX),
+                            @Loc(value = LOCATION_SEVEN), @Loc(value = LOCATION_EIGHT),
+                            @Loc(value = LOCATION_NINE), @Loc(value = LOCATION_TEN),
+                            @Loc(value = LOCATION_ELEVEN), @Loc(value = LOCATION_TWELVE),
+                            @Loc(value = LOCATION_TWENTY) }),
+                    @Area(id = "38989", coordinates = { @Loc(value = LOCATION_ONE),
+                            @Loc(value = LOCATION_TWO), @Loc(value = LOCATION_THIRTEEN),
+                            @Loc(value = LOCATION_FOURTEEN), @Loc(value = LOCATION_FIFTEEN),
+                            @Loc(value = LOCATION_SIXTEEN), @Loc(value = LOCATION_SEVENTEEN),
+                            @Loc(value = LOCATION_EIGHTEEN), @Loc(value = LOCATION_NINETEEN),
+                            @Loc(value = LOCATION_ONE) }, tags = "natural=water"),
+                    @Area(id = "38987", coordinates = { @Loc(value = LOCATION_ELEVEN),
+                            @Loc(value = LOCATION_TEN), @Loc(value = LOCATION_EIGHTEEN),
+                            @Loc(value = LOCATION_SEVENTEEN) }, tags = "landuse=meadow") })
+    private Atlas landCoverAreaAtlas;
+
+    @TestAtlas(points = { @Point(id = "39008", coordinates = @Loc(value = LOCATION_TWENTY)),
+            @Point(id = "39009", coordinates = @Loc(value = LOCATION_THREE)),
+            @Point(id = "39011", coordinates = @Loc(value = LOCATION_FOUR)),
+            @Point(id = "39013", coordinates = @Loc(value = LOCATION_FIVE)),
+            @Point(id = "39015", coordinates = @Loc(value = LOCATION_SIX)),
+            @Point(id = "38985", coordinates = @Loc(value = LOCATION_ONE)),
+            @Point(id = "39019", coordinates = @Loc(value = LOCATION_EIGHT)),
+            @Point(id = "38988", coordinates = @Loc(value = LOCATION_TWO)),
+            @Point(id = "39021", coordinates = @Loc(value = LOCATION_NINE)),
+            @Point(id = "39023", coordinates = @Loc(value = LOCATION_TEN)),
+            @Point(id = "38992", coordinates = @Loc(value = LOCATION_THIRTEEN)),
+            @Point(id = "39025", coordinates = @Loc(value = LOCATION_ELEVEN)),
+            @Point(id = "38994", coordinates = @Loc(value = LOCATION_FOURTEEN)),
+            @Point(id = "39027", coordinates = @Loc(value = LOCATION_TWELVE)),
+            @Point(id = "38996", coordinates = @Loc(value = LOCATION_FIFTEEN)),
+            @Point(id = "38998", coordinates = @Loc(value = LOCATION_SIXTEEN)),
+            @Point(id = "39017", coordinates = @Loc(value = LOCATION_SEVEN)),
+            @Point(id = "39000", coordinates = @Loc(value = LOCATION_SEVENTEEN)),
+            @Point(id = "39002", coordinates = @Loc(value = LOCATION_EIGHTEEN)),
+            @Point(id = "39004", coordinates = @Loc(value = LOCATION_NINETEEN)) }, areas = {
+                    @Area(id = "39010", coordinates = { @Loc(value = LOCATION_TWENTY),
+                            @Loc(value = LOCATION_THREE), @Loc(value = LOCATION_FOUR),
+                            @Loc(value = LOCATION_FIVE), @Loc(value = LOCATION_SIX),
+                            @Loc(value = LOCATION_SEVEN), @Loc(value = LOCATION_EIGHT),
+                            @Loc(value = LOCATION_NINE), @Loc(value = LOCATION_TEN),
+                            @Loc(value = LOCATION_ELEVEN), @Loc(value = LOCATION_TWELVE),
+                            @Loc(value = LOCATION_TWENTY) }),
+                    @Area(id = "38989", coordinates = { @Loc(value = LOCATION_ONE),
+                            @Loc(value = LOCATION_TWO), @Loc(value = LOCATION_THIRTEEN),
+                            @Loc(value = LOCATION_FOURTEEN), @Loc(value = LOCATION_FIFTEEN),
+                            @Loc(value = LOCATION_SIXTEEN), @Loc(value = LOCATION_SEVENTEEN),
+                            @Loc(value = LOCATION_EIGHTEEN), @Loc(value = LOCATION_NINETEEN),
+                            @Loc(value = LOCATION_ONE) }),
+                    @Area(id = "38987", coordinates = { @Loc(value = LOCATION_ELEVEN),
+                            @Loc(value = LOCATION_TEN), @Loc(value = LOCATION_EIGHTEEN),
+                            @Loc(value = LOCATION_SEVENTEEN) }),
+                    @Area(id = "45677", coordinates = { @Loc(value = LOCATION_EIGHT),
+                            @Loc(value = LOCATION_TEN), @Loc(value = LOCATION_FIVE),
+                            @Loc(value = LOCATION_FOUR) }, tags = {
+                                    "amenity=SCHOOL" }) }, relations = {
+                                            @Relation(id = "39190", members = {
+                                                    @Member(id = "39010", type = "area", role = "outer"),
+                                                    @Member(id = "38989", type = "area", role = "inner") }, tags = {
+                                                            "type=multipolygon",
+                                                            "surface=paved" }),
+                                            @Relation(id = "39990", members = {
+                                                    @Member(id = "38987", type = "area", role = "outer") }, tags = {
+                                                            "type=boundary",
+                                                            "landuse=VINEYARD" }) })
+    private Atlas complexLandCoverWithRelationsAndAreas;
+
+    public Atlas getComplexLandCoverWithRelationsAndAreas()
+    {
+        return this.complexLandCoverWithRelationsAndAreas;
+    }
+
+    public Atlas getLandCoverAreaAtlas()
+    {
+        return this.landCoverAreaAtlas;
+    }
+
+    public Atlas getMultipolygonLandCoverRelationAtlas()
+    {
+        return this.multipolygonLandCoverRelationAtlas;
+    }
+
+    public Atlas getNonMultipolygonLandCoverRelationAtlas()
+    {
+        return this.nonMultipolygonLandCoverRelationAtlas;
+    }
+}


### PR DESCRIPTION
### Description:

This PR adds in a ComplexLandCover type, which is very similar to the ComplexAreaOfInterest type with different default tagging based on the OSM wiki specifications for land cover https://wiki.openstreetmap.org/wiki/Landcover

### Potential Impact:

Very limited, as this is a new complex entity and finder.
### Unit Test Approach:

Tests capturing expected behavior have been added

### Test Results:


------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
