### PR TITLE
Do not remove nodes that are synthetic nodes

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -372,7 +372,8 @@ public class AtlasSectionProcessor
     {
         if (!this.inputAtlas.pointsAt(nodeLocation).iterator().hasNext())
         {
-            throw new CoreException("Couldn't find node at {} while sectioning Line {} for Atlas {}",
+            throw new CoreException(
+                    "Couldn't find node at {} while sectioning Line {} for Atlas {}",
                     nodeLocation.toString(), line.toString(), getShardOrAtlasName());
         }
         final Point pointForNode = this.inputAtlas.pointsAt(nodeLocation).iterator().next();

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -370,12 +370,12 @@ public class AtlasSectionProcessor
     private CompleteNode createNode(final Line line, final Location nodeLocation,
             final SortedSet<Long> inEdges, final SortedSet<Long> outEdges)
     {
-        final Point pointForNode = this.inputAtlas.pointsAt(nodeLocation).iterator().next();
-        if (pointForNode == null)
+        if (!this.inputAtlas.pointsAt(nodeLocation).iterator().hasNext())
         {
-            throw new CoreException("Couldn't find node while sectioning Line {} for Atlas {}",
-                    line, getShardOrAtlasName());
+            throw new CoreException("Couldn't find node at {} while sectioning Line {} for Atlas {}",
+                    nodeLocation.toString(), line.toString(), getShardOrAtlasName());
         }
+        final Point pointForNode = this.inputAtlas.pointsAt(nodeLocation).iterator().next();
         if (pointForNode.getOsmTags().isEmpty())
         {
             this.changes.add(FeatureChange.remove(CompletePoint.shallowFrom(pointForNode)));

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -1680,7 +1680,8 @@ public class RawAtlasSlicer
     {
         if (point.getOsmTags().isEmpty()
                 && !this.pointsBelongingToEdge.contains(point.getIdentifier())
-                && !this.stagedPoints.get(point.getIdentifier()).getTag(SyntheticBoundaryNodeTag.KEY).isPresent())
+                && !this.stagedPoints.get(point.getIdentifier())
+                        .getTag(SyntheticBoundaryNodeTag.KEY).isPresent())
         {
             // we care about a point if and only if it has pre-existing OSM tags OR it belongs
             // to a future edge

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -1679,7 +1679,8 @@ public class RawAtlasSlicer
     private void slicePoint(final Point point)
     {
         if (point.getOsmTags().isEmpty()
-                && !this.pointsBelongingToEdge.contains(point.getIdentifier()))
+                && !this.pointsBelongingToEdge.contains(point.getIdentifier())
+                && !this.stagedPoints.get(point.getIdentifier()).getTag(SyntheticBoundaryNodeTag.KEY).isPresent())
         {
             // we care about a point if and only if it has pre-existing OSM tags OR it belongs
             // to a future edge


### PR DESCRIPTION
### Description:

This is a fix to not remove nodes that are marked as synthetic nodes when slicing

### Potential Impact:

This will remove fewer Atlas nodes from the atlas file generation and allow the generator to complete a full global execution.

### Unit Test Approach:

I was able to reproduce the issue locally and once this change was patched the crash was not seen. 

### Test Results:

Going to perform a full global execution now... but this should have no adverse affect.