### PR TITLE
Change spatial predicates

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/PolyLine.java
@@ -649,11 +649,6 @@ public class PolyLine implements Collection<Location>, Located, Serializable, Ge
         return JTS_POLYLINE_CONVERTER.convert(this).isClosed();
     }
 
-    public boolean isClosed()
-    {
-        return JTS_POLYLINE_CONVERTER.convert(this).isClosed();
-    }
-
     @Override
     public final boolean isEmpty()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/MultiPolygonTest.java
@@ -74,7 +74,7 @@ public class MultiPolygonTest
                 Location.forString("22.648164, 50.364465"));
         logger.info("coveringPolygon: {}", coveringPolygon.toWkt());
         Assert.assertTrue(DEFAULT_MULTIPOLYGON.overlaps(coveringPolygon));
-        Assert.assertFalse(DEFAULT_MULTIPOLYGON.intersects(coveringPolygon));
+        Assert.assertTrue(DEFAULT_MULTIPOLYGON.intersects(coveringPolygon));
 
         final Polygon insideInnerPolygon = new Polygon(Location.forString("20.146558, 23.310950"),
                 Location.forString("19.623812, 24.507328"),

--- a/src/test/java/org/openstreetmap/atlas/geography/PolyLineCoveringPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolyLineCoveringPolygonTest.java
@@ -21,7 +21,7 @@ public class PolyLineCoveringPolygonTest
     {
         final Atlas atlas = this.rule.getPolyLinesAsEntirePolygonBoundaryAtlas();
         verifyOverlapExists(atlas);
-        verifyNoFullContainment(atlas);
+        verifyFullContainment(atlas);
         verifyIntersection(atlas);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonCoveringPolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonCoveringPolygonTest.java
@@ -32,7 +32,7 @@ public class PolygonCoveringPolygonTest
     {
         final Atlas atlas = this.rule.getPolygonsStackedOnEachOtherAtlas();
         verifyOverlapExists(atlas);
-        verifyNoFullContainment(atlas);
+        verifyFullContainment(atlas);
         verifyIntersection(atlas);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/PolygonTest.java
@@ -172,7 +172,7 @@ public class PolygonTest
         Assert.assertTrue(polygon.fullyGeometricallyEncloses(onBoundary1));
         Assert.assertTrue(polygon.fullyGeometricallyEncloses(onBoundary2));
         // see awt definition of contains
-        Assert.assertFalse(polygon.fullyGeometricallyEncloses(onBoundary3));
+        Assert.assertTrue(polygon.fullyGeometricallyEncloses(onBoundary3));
         Assert.assertFalse(polygon.fullyGeometricallyEncloses(outside1));
         Assert.assertFalse(polygon.fullyGeometricallyEncloses(outside2));
     }
@@ -191,8 +191,7 @@ public class PolygonTest
 
         Assert.assertTrue(concave.fullyGeometricallyEncloses(inside1));
         Assert.assertTrue(concave.fullyGeometricallyEncloses(onBoundary1));
-        // see awt definition of contains
-        Assert.assertFalse(concave.fullyGeometricallyEncloses(onBoundary2));
+        Assert.assertTrue(concave.fullyGeometricallyEncloses(onBoundary2));
         Assert.assertFalse(concave.fullyGeometricallyEncloses(outside1));
         Assert.assertFalse(concave.fullyGeometricallyEncloses(outside2));
         Assert.assertTrue(concave.intersects(new Segment(outside1, inside1)));
@@ -716,8 +715,7 @@ public class PolygonTest
         final Location middleThirdSegment = polygon.segmentForIndex(2).middle();
         // Locations on the zero area part are still on the boundary, and therefore contained
         Assert.assertTrue(polygon.fullyGeometricallyEncloses(middleZeroAreaPart));
-        // see awt definition of contains
-        Assert.assertFalse(polygon.fullyGeometricallyEncloses(endpointZeroAreaPart));
+        Assert.assertTrue(polygon.fullyGeometricallyEncloses(endpointZeroAreaPart));
         Assert.assertTrue(polygon.fullyGeometricallyEncloses(middleThirdSegment));
     }
 
@@ -732,7 +730,7 @@ public class PolygonTest
         final Location endpoint = Location.forString("0.0007635,-0.0174722");
         Assert.assertTrue(polygon.fullyGeometricallyEncloses(onZeroAreaPart));
         // see awt definition of contains
-        Assert.assertFalse(polygon.fullyGeometricallyEncloses(endpoint));
+        Assert.assertTrue(polygon.fullyGeometricallyEncloses(endpoint));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/AtlasItemIntersectionTest.java
@@ -95,7 +95,7 @@ public class AtlasItemIntersectionTest
         // awt definition of insideness - which considers Node 4 from edge 0 to be "outside" the
         // polygon, even though it is on the boundary.
         Assert.assertEquals("There are 2 lines, 2 edges, 2 Areas and 2 Nodes within this Polygon",
-                8, Iterables.size(atlas.itemsWithin(polygonBoundary)));
+                9, Iterables.size(atlas.itemsWithin(polygonBoundary)));
 
         // If we represent the Polygon as a Rectangle, then we forego the awt call and the same Node
         // 4 is now considered inside. This is an unfortunate side-affect of the awt dependency.

--- a/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/command/subcommands/AtlasSearchCommandTest.java
@@ -41,7 +41,7 @@ public class AtlasSearchCommandTest
             command.setNewErrStream(new PrintStream(errContent));
 
             command.runSubcommand("/Users/foo/test.atlas", "--verbose",
-                    "--bounding-polygon=POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))");
+                    "--bounding-polygon=POLYGON((0 0, 0 2.8, 2.8 2.8, 2.8 0, 0 0))");
 
             Assert.assertEquals("Found entity matching criteria in /Users/foo/test.atlas:\n"
                     + "CompletePoint [\n" + "identifier: 1000000, \n" + "geometry: POINT (1 1), \n"

--- a/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/filters/AtlasEntityPolygonsFilterTest.java
@@ -318,9 +318,9 @@ public class AtlasEntityPolygonsFilterTest
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(dudIntersectionPolicy, Collections.singleton(polygon1)), 0L, 0L, 0L, 0L);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(
-                FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
+                FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 1L, 0L);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE.geometricSurfaces(
-                FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 0L, 0L);
+                FULL_GEOMETRIC_ENCLOSING, Collections.singleton(polygon1)), 2L, 1L, 1L, 0L);
 
         // Test all three decision makers on two polygon filter
         this.assertCounts(testCountsAtlas,
@@ -330,14 +330,14 @@ public class AtlasEntityPolygonsFilterTest
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
                 .polygons(dudIntersectionPolicy, Arrays.asList(polygon1, polygon2)), 0, 0, 0, 0);
         this.assertCounts(testCountsAtlas, AtlasEntityPolygonsFilter.Type.INCLUDE
-                .polygons(FULL_GEOMETRIC_ENCLOSING, Arrays.asList(polygon1, polygon2)), 2, 1, 0, 0);
+                .polygons(FULL_GEOMETRIC_ENCLOSING, Arrays.asList(polygon1, polygon2)), 2, 1, 2, 0);
 
         // Test Serializability
         this.assertCounts(testCountsAtlas,
                 new FreezeDryFunction<AtlasEntityPolygonsFilter>().apply(
                         AtlasEntityPolygonsFilter.Type.INCLUDE.polygons(FULL_GEOMETRIC_ENCLOSING,
                                 Arrays.asList(polygon1, polygon2))),
-                2, 1, 0, 0);
+                2, 1, 2, 0);
     }
 
     /**


### PR DESCRIPTION
### Description:

This PR reworks many spatial predicates in Atlas to use the underlying equivalent version in JTS using PreparedGeometry. This change has two impacts. Firstly, performance for polygonal checks is across the board more performant for a number of operations, leading to certain workflows that use this (like RawAtlasGeneration, which runs a number of checks on entity geometry being within a polygon) to be significantly faster. Secondly, it improves the accuracy, as the previous shortcut AWT method led to incorrect and nonsensical results, like an outer linestring not being contained by its own multipolygon. 

### Potential Impact:

Relatively limited. Performance should be equivalent or better, though there will be some slight variations in memory usage or overall time depending on how the predicates are invoked. So far though, testing doesn't reveal any significant negative impact and *does* show improvements for some workflows as noted above. Data processing may change very slightly, as certain corner cases for spatial predicates are now more accurate.
 
### Unit Test Approach:

Unit tests for relevant predicates were audited and in all cases either remained the same with valid results, or were changed to reflect the more accurate operations.

### Test Results:

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
