### PR TITLE
Some bug fixes and log changes for relation geometries

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/ChangeDescriptorGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/ChangeDescriptorGenerator.java
@@ -14,6 +14,7 @@ import org.openstreetmap.atlas.geography.atlas.builder.RelationBean;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptorComparator;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptorName;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.GeometricRelationGeometryChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.GeometryChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.LongElementChangeDescriptor;
 import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.RelationMemberChangeDescriptor;
@@ -24,6 +25,7 @@ import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
 
 /**
  * A helper class for generating a list of {@link ChangeDescriptor}s based on some
@@ -139,6 +141,14 @@ public final class ChangeDescriptorGenerator
          */
         if (this.afterView.getType() == ItemType.RELATION)
         {
+            final Relation beforeRelation = (Relation) this.beforeView;
+            final Relation afterRelation = (Relation) this.afterView;
+            final ChangeDescriptor descriptor = GeometricRelationGeometryChangeDescriptor
+                    .getDescriptorsForGeometricRelations(beforeRelation, afterRelation);
+            if (descriptor != null)
+            {
+                descriptors.add(descriptor);
+            }
             return descriptors;
         }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/descriptors/GeometricRelationGeometryChangeDescriptor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/descriptors/GeometricRelationGeometryChangeDescriptor.java
@@ -1,0 +1,156 @@
+package org.openstreetmap.atlas.geography.atlas.change.description.descriptors;
+
+import java.util.Optional;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.operation.overlayng.OverlayNG;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.converters.jts.JtsPrecisionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author samg
+ */
+public final class GeometricRelationGeometryChangeDescriptor implements ChangeDescriptor
+{
+
+    private final ChangeDescriptorType changeType;
+    private final String diffWkt;
+    private static final Logger logger = LoggerFactory
+            .getLogger(GeometricRelationGeometryChangeDescriptor.class);
+
+    public static GeometricRelationGeometryChangeDescriptor getDescriptorsForGeometricRelations(
+            final Relation before, final Relation after)
+    {
+        if (before == null)
+        {
+            if (after == null)
+            {
+                return null;
+            }
+            final Optional<MultiPolygon> afterGeometry = after.asMultiPolygon();
+            if (afterGeometry.isPresent())
+            {
+                return new GeometricRelationGeometryChangeDescriptor(afterGeometry.get().toText(),
+                        ChangeDescriptorType.ADD);
+            }
+            return null;
+        }
+        else if (after == null)
+        {
+            final Optional<MultiPolygon> beforeGeometry = before.asMultiPolygon();
+            if (beforeGeometry.isPresent())
+            {
+                return new GeometricRelationGeometryChangeDescriptor(beforeGeometry.get().toText(),
+                        ChangeDescriptorType.REMOVE);
+            }
+            return null;
+        }
+        final Optional<MultiPolygon> beforeGeometry = before.asMultiPolygon();
+        final Optional<MultiPolygon> afterGeometry = after.asMultiPolygon();
+        if (beforeGeometry.isEmpty() && afterGeometry.isEmpty())
+        {
+            return null;
+        }
+        else if (beforeGeometry.isPresent() && afterGeometry.isEmpty())
+        {
+            return new GeometricRelationGeometryChangeDescriptor(beforeGeometry.get().toText(),
+                    ChangeDescriptorType.REMOVE);
+        }
+        else if (beforeGeometry.isEmpty() && afterGeometry.isPresent())
+        {
+            return new GeometricRelationGeometryChangeDescriptor(afterGeometry.get().toText(),
+                    ChangeDescriptorType.ADD);
+        }
+        try
+        {
+            if (beforeGeometry.get().equals(afterGeometry.get()))
+            {
+                return null;
+            }
+        }
+        catch (final Exception exc)
+        {
+            logger.error("Geometry equals failed for relation {}", before.getIdentifier(), exc);
+        }
+
+        try
+        {
+            final Geometry diff = OverlayNG.overlay(beforeGeometry.get(), afterGeometry.get(),
+                    OverlayNG.SYMDIFFERENCE, JtsPrecisionManager.getPrecisionModel());
+            if (diff.isEmpty())
+            {
+                return null;
+            }
+            return new GeometricRelationGeometryChangeDescriptor(diff.toText(),
+                    ChangeDescriptorType.UPDATE);
+        }
+        catch (final Exception exc)
+        {
+            logger.error("Geometry intersection failed for relation {}", before.getIdentifier(),
+                    exc);
+            throw new CoreException("Couldn't calculate diff for relation {}",
+                    before.getIdentifier());
+        }
+    }
+
+    private GeometricRelationGeometryChangeDescriptor(final String diffWkt,
+            final ChangeDescriptorType changeType)
+    {
+        this.changeType = changeType;
+        this.diffWkt = diffWkt;
+    }
+
+    @Override
+    public ChangeDescriptorType getChangeDescriptorType()
+    {
+        return this.changeType;
+    }
+
+    @Override
+    public ChangeDescriptorName getName()
+    {
+        return ChangeDescriptorName.GEOMETRY;
+    }
+
+    @Override
+    public JsonElement toJsonElement()
+    {
+        final JsonObject descriptor = (JsonObject) ChangeDescriptor.super.toJsonElement();
+        descriptor.addProperty("diff", this.diffWkt);
+        return descriptor;
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder diffString = new StringBuilder();
+        diffString.append(this.changeType.toString());
+        diffString.append(", ");
+        switch (this.changeType)
+        {
+            case UPDATE:
+                diffString.append(", ");
+                diffString.append(this.diffWkt);
+                break;
+            case REMOVE:
+                diffString.append(", ");
+                diffString.append(this.diffWkt);
+                break;
+            case ADD:
+                diffString.append(", ");
+                diffString.append(this.diffWkt);
+                break;
+            default:
+                throw new CoreException("Unexpected ChangeType value: " + this.changeType);
+        }
+        return getName().toString() + "(" + diffString.toString() + ")";
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/CompleteRelation.java
@@ -310,8 +310,7 @@ public class CompleteRelation extends Relation implements CompleteEntity<Complet
     {
         return this.bounds != null && this.tags != null && this.members != null
                 && this.allRelationsWithSameOsmIdentifier != null && this.allKnownOsmMembers != null
-                && this.osmRelationIdentifier != null && this.relationIdentifiers != null
-                && (!this.isGeometric() || this.storedGeometry != null);
+                && this.osmRelationIdentifier != null && this.relationIdentifiers != null;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -1332,6 +1332,13 @@ public class RawAtlasSlicer
         for (final Map.Entry<String, Set<org.locationtech.jts.geom.Geometry>> entry : currentResults
                 .entrySet())
         {
+            if (entry.getValue().size() == 1 && entry.getValue().iterator()
+                    .next() instanceof org.locationtech.jts.geom.MultiPolygon)
+            {
+                results.put(entry.getKey(), (org.locationtech.jts.geom.MultiPolygon) entry
+                        .getValue().iterator().next());
+                continue;
+            }
             final Set<org.locationtech.jts.geom.Polygon> polygonClippings = new HashSet<>();
             entry.getValue().stream()
                     .filter(polygon -> polygon instanceof org.locationtech.jts.geom.Polygon)
@@ -1369,7 +1376,8 @@ public class RawAtlasSlicer
     {
         if (point.getOsmTags().isEmpty()
                 && !this.pointsBelongingToEdge.contains(point.getIdentifier()) && this.stagedPoints
-                        .get(point.getIdentifier()).getTag(SyntheticBoundaryNodeTag.KEY).isEmpty())
+                        .get(point.getIdentifier()).getTag(SyntheticBoundaryNodeTag.KEY).isEmpty()
+                && point.relations().isEmpty())
         {
             // we care about a point if and only if it has pre-existing OSM tags OR it belongs
             // to a future edge

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/sub/SubAtlasCreator.java
@@ -52,7 +52,7 @@ public final class SubAtlasCreator
     public static Optional<Atlas> hardCutAllEntities(final Atlas atlas,
             final GeometricSurface boundary)
     {
-        logger.debug(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
+        logger.trace(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
                 atlas.metaData());
         final Time begin = Time.now();
 
@@ -100,7 +100,7 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
                 begin.elapsedSince());
         return Optional.ofNullable(result);
     }
@@ -108,7 +108,7 @@ public final class SubAtlasCreator
     public static Optional<Atlas> hardCutAllEntities(final Atlas atlas,
             final Predicate<AtlasEntity> matcher)
     {
-        logger.debug(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
+        logger.trace(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
                 atlas.metaData());
         final Time begin = Time.now();
 
@@ -149,7 +149,7 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_ALL, atlas.getName(),
                 begin.elapsedSince());
         return Optional.ofNullable(result);
     }
@@ -157,7 +157,7 @@ public final class SubAtlasCreator
     public static Optional<Atlas> hardCutRelationsOnly(final Atlas atlas,
             final Predicate<AtlasEntity> matcher)
     {
-        logger.debug(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_RELATIONS_ONLY, atlas.getName(),
+        logger.trace(CUT_START_MESSAGE, AtlasCutType.HARD_CUT_RELATIONS_ONLY, atlas.getName(),
                 atlas.metaData());
         final Time begin = Time.now();
 
@@ -188,7 +188,7 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_RELATIONS_ONLY, atlas.getName(),
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.HARD_CUT_RELATIONS_ONLY, atlas.getName(),
                 begin.elapsedSince());
         return Optional.ofNullable(result);
     }
@@ -253,7 +253,8 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.SILK_CUT, atlas.getName(), begin.elapsedSince());
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.SILK_CUT, atlas.getName(),
+                begin.elapsedSince());
         return Optional.ofNullable(result);
     }
 
@@ -266,7 +267,7 @@ public final class SubAtlasCreator
      */
     public static Optional<Atlas> silkCut(final Atlas atlas, final Predicate<AtlasEntity> matcher)
     {
-        logger.debug(CUT_START_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), atlas.metaData());
+        logger.trace(CUT_START_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), atlas.metaData());
         final Time begin = Time.now();
 
         // Using a predicate here can create wild changes in entity counts. For example a predicate
@@ -310,14 +311,15 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), begin.elapsedSince());
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(),
+                begin.elapsedSince());
         return Optional.ofNullable(result);
     }
 
     public static Optional<Atlas> softCut(final Atlas atlas, final GeometricSurface boundary,
             final boolean hardCutRelations)
     {
-        logger.debug(CUT_START_MESSAGE,
+        logger.trace(CUT_START_MESSAGE,
                 !hardCutRelations ? AtlasCutType.SOFT_CUT : AtlasCutType.HARD_CUT_RELATIONS_ONLY,
                 atlas.getName(), atlas.metaData());
         final Time begin = Time.now();
@@ -406,7 +408,7 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE,
+        logger.trace(CUT_STOP_MESSAGE,
                 !hardCutRelations ? AtlasCutType.SOFT_CUT : AtlasCutType.HARD_CUT_RELATIONS_ONLY,
                 atlas.getName(), begin.elapsedSince());
         return Optional.ofNullable(result);
@@ -421,7 +423,7 @@ public final class SubAtlasCreator
      */
     public static Optional<Atlas> softCut(final Atlas atlas, final Predicate<AtlasEntity> matcher)
     {
-        logger.debug(CUT_START_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), atlas.metaData());
+        logger.trace(CUT_START_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), atlas.metaData());
         final Time begin = Time.now();
 
         // Using a predicate here can create wild changes in entity counts. For example a predicate
@@ -464,7 +466,8 @@ public final class SubAtlasCreator
             result.trim();
         }
 
-        logger.info(CUT_STOP_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(), begin.elapsedSince());
+        logger.trace(CUT_STOP_MESSAGE, AtlasCutType.SOFT_CUT, atlas.getName(),
+                begin.elapsedSince());
         return Optional.ofNullable(result);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/configuration/StandardConfiguration.java
@@ -259,7 +259,7 @@ public class StandardConfiguration implements Configuration
     @SuppressWarnings("unchecked")
     private Optional<Map<String, Object>> readConfigurationMapFromJSON(final byte[] readBytes)
     {
-        logger.info("Attempting to load configuration as JSON");
+        logger.trace("Attempting to load configuration as JSON");
         try (ByteArrayInputStream read = new ByteArrayInputStream(readBytes))
         {
             final ObjectMapper objectMapper = new ObjectMapper();
@@ -268,12 +268,12 @@ public class StandardConfiguration implements Configuration
             objectMapper.registerModule(simpleModule);
             final JsonParser parser = new JsonFactory().createParser(read);
             final Map<String, Object> readConfig = objectMapper.readValue(parser, Map.class);
-            logger.info("Success! Loaded JSON configuration");
+            logger.trace("Success! Loaded JSON configuration");
             return Optional.of(readConfig);
         }
         catch (final Exception jsonReadException)
         {
-            logger.warn("Unable to parse config file as JSON");
+            logger.error("Unable to parse config file as JSON");
             return Optional.empty();
         }
     }
@@ -291,12 +291,12 @@ public class StandardConfiguration implements Configuration
             objectMapper.registerModule(simpleModule);
             final YAMLParser parser = new YAMLFactory().createParser(read);
             final Map<String, Object> readConfig = objectMapper.readValue(parser, Map.class);
-            logger.info("Success! Loaded YAML configuration.");
+            logger.trace("Success! Loaded YAML configuration.");
             return Optional.of(readConfig);
         }
         catch (final Exception yamlReadException)
         {
-            logger.warn("Unable to parse config file as YAML");
+            logger.error("Unable to parse config file as YAML");
             return Optional.empty();
         }
         finally

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicerTest.java
@@ -900,14 +900,14 @@ public class RawAtlasSlicerTest
                 AtlasLoadingOption.createOptionWithAllEnabled(boundary).setCountryCode("LBR"),
                 rawAtlas).slice();
 
-        Assert.assertEquals(0, civSlicedAtlas.numberOfPoints());
+        Assert.assertEquals(1, civSlicedAtlas.numberOfPoints());
         Assert.assertEquals(3, civSlicedAtlas.numberOfAreas());
-        Assert.assertEquals(1, civSlicedAtlas.numberOfRelations());
+        Assert.assertEquals(2, civSlicedAtlas.numberOfRelations());
         final Iterable<ComplexBuilding> civBuildings = new ComplexBuildingFinder()
                 .find(civSlicedAtlas, Finder::ignore);
         Assert.assertEquals(1, Iterables.size(civBuildings));
 
-        Assert.assertEquals(0, lbrSlicedAtlas.numberOfPoints());
+        Assert.assertEquals(1, lbrSlicedAtlas.numberOfPoints());
         Assert.assertEquals(3, lbrSlicedAtlas.numberOfAreas());
         Assert.assertEquals(1, lbrSlicedAtlas.numberOfRelations());
         final Iterable<ComplexBuilding> lbrBuildings = new ComplexBuildingFinder()


### PR DESCRIPTION
### Description:

This PR fixes a few small bugs for relation geometries, namely CompleteRelation.isFull() expecting a geometry to be mandatory, and ChangeExplainer not including a good explanation of geometry updates. Additionally, a few more Points are preserved during slicing, and some logging has been downgraded to trace.

### Potential Impact:

Limited

### Unit Test Approach:

Covered by some existing test updates

### Test Results:


------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
