### PR TITLE
Generation: Keep tags throughout the generation process

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasMetaData.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/AtlasMetaData.java
@@ -35,6 +35,8 @@ public final class AtlasMetaData
     public static final String OSM_PBF_WAY_CONFIGURATION = "osmPbfWayConfiguration";
     public static final String OSM_PBF_NODE_CONFIGURATION = "osmPbfNodeConfiguration";
     public static final String OSM_PBF_RELATION_CONFIGURATION = "osmPbfRelationConfiguration";
+    /** Set to "true" if -keepAll was passed on the command line */
+    public static final String KEEP_ALL_CONFIGURATION = "keepAll";
     private static final long serialVersionUID = -285346019736489425L;
     private static final String UNKNOWN_VALUE = "unknown";
 
@@ -86,6 +88,19 @@ public final class AtlasMetaData
     {
         return new AtlasMetaData(size, this.original, this.codeVersion, this.dataVersion,
                 this.country, this.shardName, this.tags);
+    }
+
+    /**
+     * Copy this metadata with new tags
+     *
+     * @param tags
+     *            The tags to copy
+     * @return The new AtlasMetaData to use
+     */
+    public AtlasMetaData copyWithNewTags(final Map<String, String> tags)
+    {
+        return new AtlasMetaData(this.size, this.original, this.codeVersion, this.dataVersion,
+                this.country, this.shardName, tags);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/ChangeDescription.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/change/description/ChangeDescription.java
@@ -574,7 +574,7 @@ public class ChangeDescription
         {
             final Optional<String> lastEditVersion = Optional
                     .ofNullable(tagsToUse.get("last_edit_version"));
-            lastEditVersion.ifPresent(s -> information.addProperty(VERSION, Long.parseLong(s) + 1));
+            lastEditVersion.ifPresent(s -> information.addProperty(VERSION, Long.parseLong(s)));
         }
         // Add the tags (OSC files are idempotent, in that they require <i>all</i> information for
         // an object)

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/creation/RawAtlasGenerator.java
@@ -362,15 +362,29 @@ public class RawAtlasGenerator
     /**
      * Populates the {@link AtlasMetaData} used to build the raw {@link Atlas}. Specifically,
      * records any {@link Node}, {@link Way} and {@link Relation} filtering that may have been used.
+     * This may also populate other options that were passed in the {@link AtlasLoadingOption}
+     * parameter at construction.
      */
     private void populateAtlasMetadata()
     {
-        this.metaData.getTags().put(AtlasMetaData.OSM_PBF_NODE_CONFIGURATION,
+        // AtlasMetaData returns a new HashMap with every getTags() call.
+        // We therefore want to operate on a "copy" of the original tags,
+        // and create a new metadata object.
+        final Map<String, String> originalTags = this.metaData.getTags();
+        originalTags.put(AtlasMetaData.OSM_PBF_NODE_CONFIGURATION,
                 this.atlasLoadingOption.getOsmPbfNodeFilter().toString());
-        this.metaData.getTags().put(AtlasMetaData.OSM_PBF_WAY_CONFIGURATION,
+        originalTags.put(AtlasMetaData.OSM_PBF_WAY_CONFIGURATION,
                 this.atlasLoadingOption.getOsmPbfWayFilter().toString());
-        this.metaData.getTags().put(AtlasMetaData.OSM_PBF_RELATION_CONFIGURATION,
+        originalTags.put(AtlasMetaData.OSM_PBF_RELATION_CONFIGURATION,
                 this.atlasLoadingOption.getOsmPbfRelationFilter().toString());
+        originalTags.put(AtlasMetaData.KEEP_ALL_CONFIGURATION,
+                Boolean.toString(this.atlasLoadingOption.isKeepAll()));
+        // While AtlasMetaData returns a new map by default, this accounts for the possibility that
+        // it may change in the future.
+        if (!originalTags.equals(this.metaData.getTags()))
+        {
+            this.metaData = this.metaData.copyWithNewTags(originalTags);
+        }
         this.builder.setMetaData(this.metaData);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/sectioning/AtlasSectionProcessor.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.geography.atlas.raw.sectioning;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -279,10 +278,14 @@ public class AtlasSectionProcessor
             {
                 // Override meta-data here so the country code is properly included.
                 final AtlasMetaData metaData = super.metaData();
+                final var originalTags = metaData.getTags();
+                // Remove country shards to keep old behavior where they were dropped, but keep
+                // other tags.
+                originalTags.remove("countryShards");
                 return new AtlasMetaData(metaData.getSize(), false,
                         metaData.getCodeVersion().orElse(null),
                         metaData.getDataVersion().orElse(null), country, shardOrAtlasName,
-                        new HashMap<>());
+                        originalTags);
             }
         };
         if (this.loadedShards.isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/raw/slicing/RawAtlasSlicer.java
@@ -279,10 +279,14 @@ public class RawAtlasSlicer
             {
                 // Override meta-data here so the country code is properly included.
                 final AtlasMetaData metaData = super.metaData();
+                final var originalTags = metaData.getTags();
+                // Remove the country shards to keep old behavior where they were dropped, but keep
+                // other tags
+                originalTags.remove("countryShards");
                 return new AtlasMetaData(metaData.getSize(), false,
                         metaData.getCodeVersion().orElse(null),
                         metaData.getDataVersion().orElse(null), RawAtlasSlicer.this.country,
-                        RawAtlasSlicer.this.shardOrAtlasName, new HashMap<>());
+                        RawAtlasSlicer.this.shardOrAtlasName, originalTags);
             }
         };
     }


### PR DESCRIPTION
### Description:

Keep atlas tags throughout the generation process.
* Also, added tag ("keepAll") so that end users know if all nodes are
  present in an atlas file.

### Potential Impact:

This will allow downstream users to know how an atlas file was generated, if necessary.
A specific example is the OrphanNodeCheck in atlas-checks, which looks for nodes without tags that are not part of relations. When keeping all nodes in the atlas file, this check breaks due to the following reasons:
1. It was looking for nodes that were not dropped during generation, had no tags, and were not part of a relation.
2. With the -keepAll flag, this check flags most nodes (for example, nodes that are part of ways or may be part of ways but have no tags).

### Unit Test Approach:

Add test that ensures that specific stages of pbf -> atlas generation does not drop tags.

### Test Results:

N/A
