### PR TITLE
Add SnappedLineItem class to support snapsLineItem function in atlas class

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.geography.atlas;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -15,6 +16,7 @@ import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.Snapper;
 import org.openstreetmap.atlas.geography.atlas.builder.AtlasSize;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -28,6 +30,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.SnappedEdge;
+import org.openstreetmap.atlas.geography.atlas.items.SnappedLineItem;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
@@ -949,6 +952,27 @@ public interface Atlas
      *         candidates.
      */
     List<SnappedEdge> snaps(Location point, Distance threshold);
+
+    /**
+     * @param point
+     *            A {@link Location} to snap
+     * @param threshold
+     *            A {@link Distance} threshold to look for edges around the {@link Location}
+     * @return A sorted {@link List} of all the candidate snaps. The list is empty if there are no
+     *         candidates.
+     */
+    default List<SnappedLineItem> snapsLineItem(final Location point, final Distance threshold)
+    {
+        final List<SnappedLineItem> snaps = new ArrayList<>();
+        for (final LineItem lineItem : this.lineItemsIntersecting(point.boxAround(threshold)))
+        {
+            final SnappedLineItem candidate = new SnappedLineItem(
+                    point.snapTo(lineItem.asPolyLine()), lineItem);
+            snaps.add(candidate);
+        }
+        snaps.sort(Snapper.SnappedLocation::compareTo);
+        return snaps;
+    }
 
     /**
      * Return a sub-atlas from this Atlas.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java
@@ -1,7 +1,6 @@
 package org.openstreetmap.atlas.geography.atlas;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -16,7 +15,6 @@ import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Rectangle;
-import org.openstreetmap.atlas.geography.Snapper;
 import org.openstreetmap.atlas.geography.atlas.builder.AtlasSize;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -961,18 +959,7 @@ public interface Atlas
      * @return A sorted {@link List} of all the candidate snaps. The list is empty if there are no
      *         candidates.
      */
-    default List<SnappedLineItem> snapsLineItem(final Location point, final Distance threshold)
-    {
-        final List<SnappedLineItem> snaps = new ArrayList<>();
-        for (final LineItem lineItem : this.lineItemsIntersecting(point.boxAround(threshold)))
-        {
-            final SnappedLineItem candidate = new SnappedLineItem(
-                    point.snapTo(lineItem.asPolyLine()), lineItem);
-            snaps.add(candidate);
-        }
-        snaps.sort(Snapper.SnappedLocation::compareTo);
-        return snaps;
-    }
+    List<SnappedLineItem> snapsLineItem(Location point, Distance threshold);
 
     /**
      * Return a sub-atlas from this Atlas.

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/BareAtlas.java
@@ -20,6 +20,7 @@ import org.openstreetmap.atlas.geography.GeometricSurface;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Snapper;
 import org.openstreetmap.atlas.geography.Snapper.SnappedLocation;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
@@ -36,6 +37,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
 import org.openstreetmap.atlas.geography.atlas.items.SnappedEdge;
+import org.openstreetmap.atlas.geography.atlas.items.SnappedLineItem;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.atlas.sub.SubAtlasCreator;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonFeatureCollection;
@@ -608,6 +610,20 @@ public abstract class BareAtlas implements Atlas
             snaps.add(candidate);
         }
         snaps.sort(SnappedLocation::compareTo);
+        return snaps;
+    }
+
+    @Override
+    public List<SnappedLineItem> snapsLineItem(final Location point, final Distance threshold)
+    {
+        final List<SnappedLineItem> snaps = new ArrayList<>();
+        for (final LineItem lineItem : this.lineItemsIntersecting(point.boxAround(threshold)))
+        {
+            final SnappedLineItem candidate = new SnappedLineItem(
+                    point.snapTo(lineItem.asPolyLine()), lineItem);
+            snaps.add(candidate);
+        }
+        snaps.sort(Snapper.SnappedLocation::compareTo);
         return snaps;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/complete/EmptyAtlas.java
@@ -26,6 +26,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.SnappedEdge;
+import org.openstreetmap.atlas.geography.atlas.items.SnappedLineItem;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
@@ -645,6 +646,12 @@ public class EmptyAtlas implements Atlas
 
     @Override
     public List<SnappedEdge> snaps(final Location point, final Distance threshold)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SnappedLineItem> snapsLineItem(final Location point, final Distance threshold)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItem.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItem.java
@@ -1,0 +1,63 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.openstreetmap.atlas.geography.Snapper;
+
+/**
+ * {@link Snapper.SnappedLocation} on an {@link LineItem}
+ *
+ * @author chunzc
+ */
+public class SnappedLineItem extends Snapper.SnappedLocation
+{
+    private static final long serialVersionUID = 4935931723612324295L;
+    private final LineItem lineItem;
+
+    public SnappedLineItem(final Snapper.SnappedLocation snap, final LineItem lineItem)
+    {
+        super(snap.getOrigin(), snap, lineItem.asPolyLine());
+        this.lineItem = lineItem;
+    }
+
+    @Override
+    public boolean equals(final Object object)
+    {
+        if (object == null || object.getClass() != this.getClass())
+        {
+            return false;
+        }
+        final SnappedLineItem other = (SnappedLineItem) object;
+        return new EqualsBuilder()
+                .append(this.getLineItem().getIdentifier(), other.getLineItem().getIdentifier())
+                .append(this.getLineItem().asPolyLine(), other.getLineItem().asPolyLine())
+                .append(this.getLineItem().getTags(), other.getLineItem().getTags()).isEquals();
+    }
+
+    public LineItem getLineItem()
+    {
+        return this.lineItem;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(this.getLineItem().asPolyLine())
+                .append(this.getLineItem().getIdentifier()).append(this.getLineItem().getTags())
+                .toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[SnappedLineItem: LineItem: ");
+        builder.append(this.lineItem.getIdentifier());
+        builder.append(", Origin: ");
+        builder.append(getOrigin());
+        builder.append(", Snap: ");
+        builder.append(super.toString());
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/dynamic/DynamicAtlasTest.java
@@ -32,6 +32,7 @@ import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * @author matthieun
@@ -367,6 +368,16 @@ public class DynamicAtlasTest
                 atlasz12x1349y1869, atlasz12x1349y1870);
         Assert.assertEquals("Found differences: " + new AtlasDelta(atlas, multiAtlas).toString(),
                 atlas, multiAtlas);
+    }
+
+    @Test
+    public void testSnapsLineItem()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        Assert.assertEquals(5,
+                atlas.snapsLineItem(atlas.node(1L).getLocation(), Distance.meters(100)).size());
+        Assert.assertEquals(3,
+                atlas.snaps(atlas.node(1L).getLocation(), Distance.meters(100)).size());
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTest.java
@@ -8,7 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasTestRule;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
@@ -17,7 +16,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class SnappedLineItemTest
 {
     @Rule
-    public final DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
+    public final SnappedLineItemTestRule rule = new SnappedLineItemTestRule();
 
     @Test
     public void testEquals()

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTest.java
@@ -1,0 +1,57 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.dynamic.rules.DynamicAtlasTestRule;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * @author chunzc
+ */
+public class SnappedLineItemTest
+{
+    @Rule
+    public final DynamicAtlasTestRule rule = new DynamicAtlasTestRule();
+
+    @Test
+    public void testEquals()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final Location point = atlas.point(1L).getLocation();
+        final LineItem targetLineItem = atlas.lineItems(item -> item.getIdentifier() == 8000000L)
+                .iterator().next();
+        final SnappedLineItem candidate = new SnappedLineItem(
+                point.snapTo(targetLineItem.asPolyLine()), targetLineItem);
+        final List<SnappedLineItem> snappedLineItemList = atlas
+                .snapsLineItem(atlas.node(1L).getLocation(), Distance.meters(100));
+        final SnappedLineItem snappedLineItem = snappedLineItemList
+                .stream().filter(lineItem -> lineItem.getLineItem()
+                        .getIdentifier() == targetLineItem.getIdentifier())
+                .collect(Collectors.toList()).get(0);
+        Assert.assertTrue(snappedLineItemList.contains(candidate));
+        Assert.assertEquals(candidate, snappedLineItem);
+        Assert.assertEquals(candidate.hashCode(), snappedLineItem.hashCode());
+        Assert.assertNotEquals(targetLineItem, snappedLineItem);
+        Assert.assertNotEquals(null, snappedLineItem);
+        Assert.assertNotEquals(snappedLineItemList.get(0), snappedLineItemList.get(1));
+    }
+
+    @Test
+    public void testToString()
+    {
+        final String targetString = "[SnappedLineItem: LineItem: 8000000, Origin: POINT (-61.336198 15.420563), Snap: POINT (-61.336198 15.420563)]";
+        final Atlas atlas = this.rule.getAtlas();
+        final Location point = atlas.point(1L).getLocation();
+        final LineItem targetLineItem = atlas.lineItems(item -> item.getIdentifier() == 8000000L)
+                .iterator().next();
+        final SnappedLineItem candidate = new SnappedLineItem(
+                point.snapTo(targetLineItem.asPolyLine()), targetLineItem);
+        Assert.assertEquals(targetString, candidate.toString());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/SnappedLineItemTestRule.java
@@ -1,0 +1,138 @@
+package org.openstreetmap.atlas.geography.atlas.items;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * The Geojson representation of the below test atlas files is saved in the test/resources folder,
+ * same package
+ *
+ * @author matthieun
+ */
+public class SnappedLineItemTestRule extends CoreTestRule
+{
+    // Inside 12-1350-1870
+    private static final String ONE = "15.420563,-61.336198";
+    private static final String TWO = "15.429499,-61.332850";
+    private static final String TWO_BIS = "15.3907,-61.3112";
+
+    // Inside 12-1350-1869
+    private static final String THREE = "15.4855,-61.3041";
+    private static final String FOUR = "15.4809,-61.3366";
+
+    // Inside 12-1349-1869
+    private static final String FIVE = "15.4852,-61.3816";
+    private static final String SIX = "15.4781,-61.3949";
+
+    // Inside 12-1349-1870
+    private static final String SEVEN = "15.4145,-61.3826";
+    private static final String EIGHT = "15.4073,-61.3749";
+
+    @TestAtlas(
+
+            nodes = {
+
+                    @TestAtlas.Node(id = "1", coordinates = @TestAtlas.Loc(value = ONE)),
+                    @TestAtlas.Node(id = "2", coordinates = @TestAtlas.Loc(value = TWO)),
+                    @TestAtlas.Node(id = "3", coordinates = @TestAtlas.Loc(value = THREE)),
+                    @TestAtlas.Node(id = "4", coordinates = @TestAtlas.Loc(value = FOUR)),
+                    @TestAtlas.Node(id = "5", coordinates = @TestAtlas.Loc(value = FIVE)),
+                    @TestAtlas.Node(id = "6", coordinates = @TestAtlas.Loc(value = SIX)),
+                    @TestAtlas.Node(id = "7", coordinates = @TestAtlas.Loc(value = SEVEN)),
+                    @TestAtlas.Node(id = "8", coordinates = @TestAtlas.Loc(value = EIGHT))
+
+            },
+
+            edges = {
+
+                    @TestAtlas.Edge(id = "1000000", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "-1000000", coordinates = { @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = ONE) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "2000000", coordinates = { @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = THREE) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "3000000", coordinates = { @TestAtlas.Loc(value = THREE),
+                            @TestAtlas.Loc(value = FOUR) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "4000000", coordinates = { @TestAtlas.Loc(value = FOUR),
+                            @TestAtlas.Loc(value = FIVE) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "5000000", coordinates = { @TestAtlas.Loc(value = FIVE),
+                            @TestAtlas.Loc(value = SIX) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "6000000", coordinates = { @TestAtlas.Loc(value = SIX),
+                            @TestAtlas.Loc(value = SEVEN) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "7000000", coordinates = { @TestAtlas.Loc(value = SEVEN),
+                            @TestAtlas.Loc(value = EIGHT) }, tags = { "highway=secondary" }),
+                    @TestAtlas.Edge(id = "8000000", coordinates = { @TestAtlas.Loc(value = EIGHT),
+                            @TestAtlas.Loc(value = ONE) }, tags = { "highway=secondary" })
+
+            },
+
+            areas = {
+
+                    @TestAtlas.Area(id = "1", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = TWO_BIS) }, tags = { "landuse=residential" }),
+                    @TestAtlas.Area(id = "2", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = THREE) }, tags = { "landuse=residential" })
+
+            },
+
+            lines = {
+
+                    @TestAtlas.Line(id = "1", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = TWO_BIS) }, tags = { "power=line" }),
+                    @TestAtlas.Line(id = "2", coordinates = { @TestAtlas.Loc(value = ONE),
+                            @TestAtlas.Loc(value = TWO),
+                            @TestAtlas.Loc(value = THREE) }, tags = { "power=line" })
+
+            },
+
+            points = {
+
+                    @TestAtlas.Point(id = "1", coordinates = @TestAtlas.Loc(value = ONE)),
+                    @TestAtlas.Point(id = "2", coordinates = @TestAtlas.Loc(value = TWO)),
+                    @TestAtlas.Point(id = "3", coordinates = @TestAtlas.Loc(value = THREE)),
+                    @TestAtlas.Point(id = "4", coordinates = @TestAtlas.Loc(value = FOUR)),
+                    @TestAtlas.Point(id = "5", coordinates = @TestAtlas.Loc(value = FIVE)),
+                    @TestAtlas.Point(id = "6", coordinates = @TestAtlas.Loc(value = SIX)),
+                    @TestAtlas.Point(id = "7", coordinates = @TestAtlas.Loc(value = SEVEN)),
+                    @TestAtlas.Point(id = "8", coordinates = @TestAtlas.Loc(value = EIGHT))
+
+            },
+
+            relations = {
+
+                    @TestAtlas.Relation(id = "1", tags = { "type=relation" }, members = {
+
+                            @TestAtlas.Relation.Member(id = "1000000", role = "a", type = "edge"),
+                            @TestAtlas.Relation.Member(id = "3000000", role = "b", type = "edge")
+
+                    }),
+
+                    @TestAtlas.Relation(id = "2", tags = { "type=relation" }, members = {
+
+                            @TestAtlas.Relation.Member(id = "8", role = "a", type = "point"),
+                            @TestAtlas.Relation.Member(id = "1", role = "b", type = "area")
+
+                    }),
+
+                    @TestAtlas.Relation(id = "3", tags = { "type=relation" }, members = {
+
+                            @TestAtlas.Relation.Member(id = "5000000", role = "a", type = "edge"),
+                            @TestAtlas.Relation.Member(id = "6000000", role = "b", type = "edge"),
+                            @TestAtlas.Relation.Member(id = "1", role = "c", type = "area")
+
+                    })
+
+            }
+
+    )
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}


### PR DESCRIPTION
### Description:

This PR added SnappedLineItem class and snapsLineItem function in atlas class to snap LineItem.

### Potential Impact:

atlas.snapsLineItem() can return a list of nearby LineItem. This adds the support for LineItem.

### Unit Test Approach:

Added SnappedLineItemTest and testSnapsLineItem in DynamicAtlasTest.

### Test Results:

All tests passed.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
