### PR TITLE
Fix PackedAtlas null serializer issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/packed/PackedAtlas.java
@@ -1977,7 +1977,10 @@ public final class PackedAtlas extends AbstractAtlas
 
     private void writeObject(final java.io.ObjectOutputStream out) throws IOException
     {
-        this.serializer.deserializeAllFieldsIfNeeded();
+        if (this.serializer != null)
+        {
+            this.serializer.deserializeAllFieldsIfNeeded();
+        }
         out.defaultWriteObject();
     }
 }


### PR DESCRIPTION
### Description:

This PR is a minor fix for a rare issue in which a PackedAtlas is Java serialized but was loaded without the use of a PackedAtlasSerializer.

### Potential Impact:

Only be a minor fix.

### Unit Test Approach:


### Test Results:


------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
