### PR TITLE
Add disuse:railway tag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
@@ -1,7 +1,11 @@
 package org.openstreetmap.atlas.tags;
 
+import java.util.EnumSet;
+import java.util.Optional;
+
 import org.openstreetmap.atlas.tags.annotations.Tag;
 import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 
 /**
  * OSM disused: Railway tag
@@ -24,4 +28,19 @@ public enum DisusedRailwayTag
 
     @TagKey
     public static final String KEY = "disused:railway";
+
+    private static final EnumSet<DisusedRailwayTag> DISUSED_RAILWAY_CROSSINGS = EnumSet.of(CROSSING,
+            LEVEL_CROSSING);
+
+    public static Optional<DisusedRailwayTag> get(final Taggable taggable)
+    {
+        return Validators.from(DisusedRailwayTag.class, taggable);
+    }
+
+    public static boolean isDisusedRailwayCrossing(final Taggable taggable)
+    {
+        final Optional<DisusedRailwayTag> disusedRailway = get(taggable);
+        return disusedRailway.isPresent()
+                && DISUSED_RAILWAY_CROSSINGS.contains(disusedRailway.get());
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM disused: Railway tag
+ *
+ * @author Vladimir Lemberg
+ */
+@Tag(with = {
+        ShopTag.class }, taginfo = "https://taginfo.openstreetmap.org/keys/disused%3Arailway#values", osm = "https://wiki.openstreetmap.org/wiki/Key:disused:railway")
+public enum DisusedRailwayTag
+{
+    YES,
+    RAIL,
+    LIGHT_RAIL,
+    CROSSING,
+    LEVEL_CROSSING,
+    STATION,
+    HALT,
+    PLATFORM,
+    TRAM;
+
+    @TagKey
+    public static final String KEY = "disused:railway";
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/DisusedRailwayTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/DisusedRailwayTagTestCase.java
@@ -1,0 +1,23 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author vlemberg
+ */
+
+public class DisusedRailwayTagTestCase
+{
+    private final Taggable taggable1 = Taggable.with("disused:railway", "level_crossing");
+    private final Taggable taggable2 = Taggable.with("disused:railway", "crossing");
+    private final Taggable taggable3 = Taggable.with("railway", "level_crossing");
+
+    @Test
+    public void isDisuseRailwayCrossing()
+    {
+        Assert.assertTrue(DisusedRailwayTag.isDisusedRailwayCrossing(this.taggable1));
+        Assert.assertTrue(DisusedRailwayTag.isDisusedRailwayCrossing(this.taggable2));
+        Assert.assertFalse(DisusedRailwayTag.isDisusedRailwayCrossing(this.taggable3));
+    }
+}


### PR DESCRIPTION
### Description:

Adding `disused:railway` tag for better handling of LevelCrossingOnRailwayCheck. Please refer: https://github.com/osmlab/atlas-checks/issues/672

### Potential Impact:

Process `Nodes` with `disused:railway` properly. 

### Unit Test Approach:

Simulate TP and FP cased utilizing `disused:railway` tag. 

### Test Results:

passed