### PR TITLE
Add tram_level_crossing to RailwayTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/DisusedRailwayTag.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM disused: Railway tag
+ *
+ * @author Vladimir Lemberg
+ */
+@Tag(with = {
+        ShopTag.class }, taginfo = "https://taginfo.openstreetmap.org/keys/disused%3Arailway#values", osm = "https://wiki.openstreetmap.org/wiki/Key:disused:railway")
+public enum DisusedRailwayTag
+{
+    YES,
+    RAIL,
+    LIGHT_RAIL,
+    CROSSING,
+    LEVEL_CROSSING,
+    STATION,
+    HALT,
+    PLATFORM,
+    TRAM;
+
+    @TagKey
+    public static final String KEY = "disused:railway";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/RailwayTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/RailwayTag.java
@@ -34,10 +34,12 @@ public enum RailwayTag
     NARROW_GAUGE,
     MILESTONE,
     SUBWAY_ENTRANCE,
+    TRAM_LEVEL_CROSSING,
     LIGHT_RAIL,
     STOP,
     PRESERVED,
     RAZED,
+    TRAM_CROSSING,
     CONSTRUCTION,
     RAILWAY_CROSSING,
     DISMANTLED,
@@ -52,7 +54,7 @@ public enum RailwayTag
     public static final String KEY = "railway";
 
     private static final EnumSet<RailwayTag> RAILWAY_CROSSINGS = EnumSet.of(CROSSING,
-            LEVEL_CROSSING);
+            LEVEL_CROSSING, TRAM_LEVEL_CROSSING, TRAM_CROSSING);
 
     public static Optional<RailwayTag> get(final Taggable taggable)
     {

--- a/src/test/java/org/openstreetmap/atlas/tags/RailwayTagTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/RailwayTagTestCase.java
@@ -1,0 +1,23 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author vlemberg
+ */
+
+public class RailwayTagTestCase
+{
+    private final Taggable taggable1 = Taggable.with("railway", "level_crossing");
+    private final Taggable taggable2 = Taggable.with("railway", "tram_level_crossing");
+    private final Taggable taggable3 = Taggable.with("disused:railway", "level_crossing");
+
+    @Test
+    public void isRailwayCrossing()
+    {
+        Assert.assertTrue(RailwayTag.isRailwayCrossing(this.taggable1));
+        Assert.assertTrue(RailwayTag.isRailwayCrossing(this.taggable2));
+        Assert.assertFalse(RailwayTag.isRailwayCrossing(this.taggable3));
+    }
+}


### PR DESCRIPTION
### Description:

Add tram_level_crossing to RailwayTag. Please refer to issue: https://github.com/osmlab/atlas-checks/issues/675
OSM Wiki: https://wiki.openstreetmap.org/wiki/Tag:railway%3Dtram_crossing

### Potential Impact:

Proper handling of level crossing 

### Unit Test Approach:

Simulate FP and TP cases for RailwayTag

### Test Results:

passed
