### PR TITLE
EstimatedWidthTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/EstimatedWidthTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/EstimatedWidthTag.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.tags;
+
+import java.util.Optional;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.Tag.Range;
+import org.openstreetmap.atlas.tags.annotations.Tag.Validation;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.extraction.LengthExtractor;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * OSM estimated width tag
+ *
+ * @author bbreithaupt
+ */
+@Tag(value = Validation.DOUBLE, range = @Range(min = 0, max = Integer.MAX_VALUE), taginfo = "https://taginfo.openstreetmap.org/keys/est_width", osm = "https://wiki.openstreetmap.org/wiki/Key:est_width")
+public interface EstimatedWidthTag
+{
+    @TagKey
+    String KEY = "est_width";
+
+    static Optional<Distance> get(final Taggable taggable)
+    {
+        final Optional<String> tagValue = taggable.getTag(KEY);
+        if (tagValue.isPresent())
+        {
+            return LengthExtractor.validateAndExtract(tagValue.get());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/tags/EstimatedWidthTagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/EstimatedWidthTagTest.java
@@ -1,0 +1,30 @@
+package org.openstreetmap.atlas.tags;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link EstimatedWidthTag}.
+ *
+ * @author bbreithaupt
+ */
+public class EstimatedWidthTagTest
+{
+    @Test
+    public void testInvalidValue()
+    {
+        Assert.assertFalse(EstimatedWidthTag.get(Taggable.with("est_width", "1;2")).isPresent());
+    }
+
+    @Test
+    public void testMissingValue()
+    {
+        Assert.assertFalse(EstimatedWidthTag.get(Taggable.with("width", "1.2")).isPresent());
+    }
+
+    @Test
+    public void testValidValue()
+    {
+        Assert.assertTrue(EstimatedWidthTag.get(Taggable.with("est_width", "1.2")).isPresent());
+    }
+}


### PR DESCRIPTION
### Description:

Adding the [estimated width tag](https://wiki.openstreetmap.org/wiki/Key:est_width). It is based on the existing width tag class. 

### Potential Impact:

Adding a new tag to use.

### Unit Test Approach:

Added tests for the get method. 

### Test Results:
Unit tests pass.

