### PR TITLE
Streaming GeoJsonReader Root Element Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/streaming/readers/GeoJsonReader.java
+++ b/src/main/java/org/openstreetmap/atlas/streaming/readers/GeoJsonReader.java
@@ -51,7 +51,7 @@ public class GeoJsonReader implements Iterator<PropertiesLocated>
             while (!"features".equals(features))
             {
                 // Read and skip the object (crs for example)
-                this.gson.fromJson(this.reader, JsonObject.class);
+                this.reader.skipValue();
                 features = this.reader.nextName();
             }
             this.reader.beginArray();

--- a/src/test/resources/org/openstreetmap/atlas/streaming/readers/geojson-polygon.json
+++ b/src/test/resources/org/openstreetmap/atlas/streaming/readers/geojson-polygon.json
@@ -1,5 +1,6 @@
 {
   "type": "FeatureCollection",
+  "generator": "test",
   "features": [
     {
       "type": "Feature",


### PR DESCRIPTION
### Description:

The latest update of the GSON dependency has brought to light a bug in the streaming geojson reader. The bug occurs when there is foreign key in the root of a geojson object whose value is not itself an object. An example is having `"generator": "JOSM"` in the root object. This causes a JsonSyntaxException to be thrown. 

The code that causes the exception is simply intended to skip any unused keys in a feature collection. This update ensures those keys are skipped, regardless of their values type. 

### Potential Impact:

The only impact should be a more forgiving geojson parser. 

### Unit Test Approach:
Updated one existing unit test to cover this case. 

### Test Results:

No non-unit test tests were performed. 
