### PR TITLE
Prevent 0 thread count in Pool

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/utilities/threads/Pool.java
+++ b/src/main/java/org/openstreetmap/atlas/utilities/threads/Pool.java
@@ -67,7 +67,7 @@ public class Pool implements Closeable
 
     public Pool(final int numberOfThreads, final String name, final Duration endTimeout)
     {
-        this.numberOfThreads = numberOfThreads;
+        this.numberOfThreads = Math.max(numberOfThreads, 1);
         this.name = name;
         this.endTimeout = endTimeout;
         this.errors = Collections.synchronizedList(new ArrayList<>());

--- a/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
@@ -253,10 +253,12 @@ public class PoolTest
     {
         runWithTimer(Duration.seconds(5), () ->
         {
+            final List<Integer> accumulator = new ArrayList<>();
             try (Pool pool = new Pool(0, "testZeroThreads", Duration.seconds(10)))
             {
-                pool.queue(() -> logger.info("Zero threads!"));
+                pool.queue(() -> accumulator.add(1));
             }
+            Assert.assertEquals(1, accumulator.size());
         });
     }
 

--- a/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
+++ b/src/test/java/org/openstreetmap/atlas/utilities/threads/PoolTest.java
@@ -248,6 +248,18 @@ public class PoolTest
         }
     }
 
+    @Test
+    public void testZeroThreads()
+    {
+        runWithTimer(Duration.seconds(5), () ->
+        {
+            try (Pool pool = new Pool(0, "testZeroThreads", Duration.seconds(10)))
+            {
+                pool.queue(() -> logger.info("Zero threads!"));
+            }
+        });
+    }
+
     private void runWithTimer(final Duration maximum, final Runnable test)
     {
         try (Pool pool = new Pool(1, "RunWithTimer", maximum))


### PR DESCRIPTION
### Description:

In `ThreadPoolExecutor`, [the maximum number of threads has to be at least 1](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java#L1204).

This adds a guard in Pool in case the user passes 0 as thread number.

### Potential Impact:

Avert `IllegalArgumentException` in that case

### Unit Test Approach:

Added a unit test: `testZeroThreads`

### Test Results:

Unit test passes

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
