### PR TITLE
remove unused transitive dependency to info.picocli:picocli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,9 @@ configurations
 dependencies
 {
     implementation packages.artifact
-    implementation packages.checkstyle
+    implementation (packages.checkstyle) {
+        exclude group: 'info.picocli', module: 'picocli'
+    }
     api            packages.classgraph
     implementation packages.commons.cli
     implementation packages.commons.compress


### PR DESCRIPTION
### Description:
Currently there is a transitive dependency to picocli (https://picocli.info/) library that is used to handle CLI arguments, which is brought by com.puppycrawl.tools:checkstyle lib. The functionality of CLI handling is not used and I think it's an error that checkstyle exports it in first place, because usually checkstyle is used as a library, not a CLI application. Anyway picocli is not used in atlas, and also shouldn't be exported further to atlas users. So this dependency is excluded from the checkstyle dependency.

### Potential Impact:
In case downstream users are CLI applications and they don't depend explicitly on picocli, they will need to do so after this change (which is actually the correct way). If this situation occurs, the fix is trivial.

### Unit Test Approach:
No unit tests are needed, because there's no logic change.

### Test Results:
N/A
------
